### PR TITLE
Made some perf changes and sample changes

### DIFF
--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -24,32 +24,21 @@ namespace ChatSample
 
         public IConfiguration Configuration { get; }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
             services.AddSignalR()
-                    .AddAzureSignalR(options =>
-                    {
-                        Configuration.GetSection("AzureSignalRConfiguration").Bind(options);
-                        options.Claims = (httpContext) =>
-                        {
-                            return new[]
-                            {
-                                new Claim(ClaimTypes.Name, "username"),
-                                new Claim(ClaimTypes.NameIdentifier, "userId")
-                            };
-                        };
-                    });
+                    .AddAzureSignalR();
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseMvc();
             app.UseFileServer();
-            app.UseAzureSignalR(
-                builder => { builder.MapHub<Chat>("/chat"); });
+            app.UseAzureSignalR(routes =>
+            {
+                routes.MapHub<Chat>("/chat");
+            });
         }
     }
 }

--- a/samples/ChatSample/appsettings.json
+++ b/samples/ChatSample/appsettings.json
@@ -1,7 +1,8 @@
 ﻿{
-  "AzureSignalRConfiguration": {
-    "ConnectionString": "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;",
-    "ConnectionNumber": 2
+  "Azure": {
+    "SignalR": {
+      "ConnectionString": "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;"
+    }
   },
   "Logging": {
     "IncludeScopes": false,

--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Security.Claims;
 
 namespace Microsoft.Azure.SignalR.Protocol
@@ -37,11 +38,11 @@ namespace Microsoft.Azure.SignalR.Protocol
 
     public class ConnectionDataMessage : ConnectionMessage
     {
-        public ConnectionDataMessage(string connectionId, byte[] payload) : base(connectionId)
+        public ConnectionDataMessage(string connectionId, ReadOnlyMemory<byte> payload) : base(connectionId)
         {
             Payload = payload;
         }
 
-        public byte[] Payload { get; set; }
+        public ReadOnlyMemory<byte> Payload { get; set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Azure.SignalR.Protocol
 
     public class MultiConnectionDataMessage : MulticastDataMessage
     {
-        public MultiConnectionDataMessage(string[] connectionList, IDictionary<string, byte[]> payloads) :
+        public MultiConnectionDataMessage(IReadOnlyList<string> connectionList, IDictionary<string, byte[]> payloads) :
             base(payloads)
         {
             ConnectionList = connectionList;
         }
 
-        public string[] ConnectionList { get; set; }
+        public IReadOnlyList<string> ConnectionList { get; set; }
     }
 
     // It is possible that the same user has multiple connections. So it is a multi-cast message.
@@ -39,19 +39,19 @@ namespace Microsoft.Azure.SignalR.Protocol
 
     public class MultiUserDataMessage : MulticastDataMessage
     {
-        public MultiUserDataMessage(string[] userList, IDictionary<string, byte[]> payloads) : base(payloads)
+        public MultiUserDataMessage(IReadOnlyList<string> userList, IDictionary<string, byte[]> payloads) : base(payloads)
         {
             UserList = userList;
         }
 
-        public string[] UserList { get; set; }
+        public IReadOnlyList<string> UserList { get; set; }
     }
 
     public class BroadcastDataMessage : MulticastDataMessage
     {
-        public string[] ExcludedList { get; set; }
+        public IReadOnlyList<string> ExcludedList { get; set; }
 
-        public BroadcastDataMessage(string[] excludedList, IDictionary<string, byte[]> payloads) : base(payloads)
+        public BroadcastDataMessage(IReadOnlyList<string> excludedList, IDictionary<string, byte[]> payloads) : base(payloads)
         {
             ExcludedList = excludedList;
         }
@@ -60,9 +60,9 @@ namespace Microsoft.Azure.SignalR.Protocol
     public class GroupBroadcastDataMessage : MulticastDataMessage
     {
         public string GroupName { get; set; }
-        public string[] ExcludedList { get; set; }
+        public IReadOnlyList<string> ExcludedList { get; set; }
 
-        public GroupBroadcastDataMessage(string groupName, string[] excludedList, IDictionary<string, byte[]> payloads)
+        public GroupBroadcastDataMessage(string groupName, IReadOnlyList<string> excludedList, IDictionary<string, byte[]> payloads)
             : base(payloads)
         {
             GroupName = groupName;
@@ -72,9 +72,9 @@ namespace Microsoft.Azure.SignalR.Protocol
 
     public class MultiGroupBroadcastDataMessage : MulticastDataMessage
     {
-        public string[] GroupList { get; set; }
+        public IReadOnlyList<string> GroupList { get; set; }
 
-        public MultiGroupBroadcastDataMessage(string[] groupList, IDictionary<string, byte[]> payloads) : base(payloads)
+        public MultiGroupBroadcastDataMessage(IReadOnlyList<string> groupList, IDictionary<string, byte[]> payloads) : base(payloads)
         {
             GroupList = groupList;
         }

--- a/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
@@ -11,17 +11,8 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseAzureSignalR(this IApplicationBuilder app, Action<HubHostBuilder> configure)
         {
-            app.UseRoute(routes =>
-            {
-                configure(new HubHostBuilder(routes));
-            });
-            return app;
-        }
-
-        private static IApplicationBuilder UseRoute(this IApplicationBuilder app, Action<RouteBuilder> callback)
-        {
             var routes = new RouteBuilder(app);
-            callback(routes);
+            configure(new HubHostBuilder(routes));
             app.UseRouter(routes.Build());
             return app;
         }

--- a/src/Microsoft.Azure.SignalR/HubHost/HubHostLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/HubHostLifetimeManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.SignalR
         {
             if (IsInvalidStringArgument(nameof(methodName), methodName)) return Task.CompletedTask;
             return _serviceConnectionManager.SendServiceMessage(
-                new BroadcastDataMessage(excludedIds.ToArray(), SerializeAllProtocols(methodName, args)));
+                new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args)));
         }
 
         public override Task SendConnectionAsync(string connectionId, string methodName, object[] args)
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.SignalR
             if (IsInvalidStringArgument(nameof(methodName), methodName)) return Task.CompletedTask;
 
             return _serviceConnectionManager.SendServiceMessage(
-                new MultiConnectionDataMessage(connectionIds.ToArray(), SerializeAllProtocols(methodName, args)));
+                new MultiConnectionDataMessage(connectionIds, SerializeAllProtocols(methodName, args)));
         }
 
         public override Task SendGroupAsync(string groupName, string methodName, object[] args)
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.SignalR
             if (IsInvalidListArgument(nameof(groupNames), groupNames)) return Task.CompletedTask;
 
             return _serviceConnectionManager.SendServiceMessage(
-                new MultiGroupBroadcastDataMessage(groupNames.ToArray(), SerializeAllProtocols(methodName, args)));
+                new MultiGroupBroadcastDataMessage(groupNames, SerializeAllProtocols(methodName, args)));
         }
 
         public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.SignalR
             if (IsInvalidStringArgument(nameof(methodName), methodName)) return Task.CompletedTask;
 
             return _serviceConnectionManager.SendServiceMessage(
-                new GroupBroadcastDataMessage(groupName, excludedIds.ToArray(), SerializeAllProtocols(methodName, args)));
+                new GroupBroadcastDataMessage(groupName, excludedIds, SerializeAllProtocols(methodName, args)));
         }
 
         public override Task SendUserAsync(string userId, string methodName, object[] args)
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.SignalR
             if (IsInvalidStringArgument(nameof(methodName), methodName)) return Task.CompletedTask;
 
             return _serviceConnectionManager.SendServiceMessage(
-                new MultiUserDataMessage(userIds.ToArray(), SerializeAllProtocols(methodName, args)));
+                new MultiUserDataMessage(userIds, SerializeAllProtocols(methodName, args)));
         }
 
         public override Task AddGroupAsync(string connectionId, string groupName)


### PR DESCRIPTION
- Use ReadOnlyMemory in ConnectionDataMessage
- Use IReadOnlyList<string> instead of string[] in protocol messages. This lets us remove ToArray() everywhere.
- Don't copy the buffer twice when writing it from the application pipe to the service connection. Just write the memory as is.
- Updated the sample to use the default connection string config key.

Fixes #29 

PS: We need some tests ASAP