### PR TITLE
Send directly to the connection if we have a mapping

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ClientConnectionManager.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Azure.SignalR
             ClientConnections = new ConcurrentDictionary<string, ServiceConnectionContext>();
         }
 
-        public string ClientProtocol(string connectionId)
-        {
-            return ClientConnections[connectionId].ProtocolName;
-        }
-
         public void AddClientConnection(ServiceConnectionContext clientConnection)
         {
             ClientConnections[clientConnection.ConnectionId] = clientConnection;

--- a/src/Microsoft.Azure.SignalR/HubHost/IClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/IClientConnectionManager.cs
@@ -10,7 +10,5 @@ namespace Microsoft.Azure.SignalR
         void AddClientConnection(ServiceConnectionContext clientConnection);
 
         ConcurrentDictionary<string, ServiceConnectionContext> ClientConnections { get; }
-
-        string ClientProtocol(string connectionId);
     }
 }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionContext.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR
@@ -66,12 +67,13 @@ namespace Microsoft.Azure.SignalR
 
         public IDuplexPipe Application { get; set; }
 
-        public string ProtocolName { get; set; }
-
         public ClaimsPrincipal User { get; set; }
 
         public Task ApplicationTask { get; set; }
 
         public bool HasInherentKeepAlive => true;
+
+        // The associated HubConnectionContext
+        public HubConnectionContext HubConnectionContext { get; set; }
     }
 }


### PR DESCRIPTION
- Sending directly to a connection shorts writes to the hub connection context if it can.

