### PR TITLE
Dispose the HttpConnection if StartAsync fails

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/HubHost.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/HubHost.cs
@@ -76,8 +76,17 @@ namespace Microsoft.Azure.SignalR
         public async Task<ConnectionContext> ConnectAsync(TransferFormat transferFormat, CancellationToken cancellationToken = default)
         {
             var httpConnection = new HttpConnection(_httpConnectionOptions, _loggerFactory);
-            await httpConnection.StartAsync(transferFormat);
-            return httpConnection;
+            
+            try
+            {
+                await httpConnection.StartAsync(transferFormat);
+                return httpConnection;
+            }
+            catch
+            {
+                await httpConnection.DisposeAsync();
+                throw;
+            }
         }
 
         public Task DisposeAsync(ConnectionContext connection)


### PR DESCRIPTION
- This shouldn't matter as much but it's more correct to dispose the httpConnection if StartAsync fails. See https://github.com/aspnet/SignalR/issues/2134.
- The reason it shouldn't matter is because we both skip negotiation and are using websockets which means we shouldn't ever allocate an HttpClient.