### PR TITLE
Remove CloseTimeout

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Azure.SignalR
             {
                 Url = GetServiceUrl(),
                 AccessTokenProvider = () => Task.FromResult(_serviceEndpointUtility.GenerateServerAccessToken<THub>(_userId)),
-                CloseTimeout = TimeSpan.FromSeconds(300),
                 Transports = HttpTransportType.WebSockets,
                 SkipNegotiation = true
             };


### PR DESCRIPTION
- We don't want to wait 300 seconds for the other side to close the websocket.