### PR TITLE
Support multiple hubs

### DIFF
--- a/samples/ChatSample/ChatSample.csproj
+++ b/samples/ChatSample/ChatSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>chatsample</UserSecretsId>
   </PropertyGroup>
 
@@ -13,9 +13,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.SignalR\Microsoft.Azure.SignalR.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
-  </ItemGroup>
-  
 </Project>

--- a/samples/ChatSample/Hub/NotificationHub.cs
+++ b/samples/ChatSample/Hub/NotificationHub.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace ChatSample
+{
+    public class NotificationHub : Hub
+    {
+        
+    }
+}

--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -4,6 +4,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,7 +33,10 @@ namespace ChatSample
             app.UseAzureSignalR(routes =>
             {
                 routes.MapHub<Chat>("/chat");
+                routes.MapHub<Foo>("/foo");
             });
         }
+
+        public class Foo : Hub {}
     }
 }

--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -33,10 +33,7 @@ namespace ChatSample
             app.UseAzureSignalR(routes =>
             {
                 routes.MapHub<Chat>("/chat");
-                routes.MapHub<Foo>("/foo");
             });
         }
-
-        public class Foo : Hub {}
     }
 }

--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -33,6 +33,7 @@ namespace ChatSample
             app.UseAzureSignalR(routes =>
             {
                 routes.MapHub<Chat>("/chat");
+                routes.MapHub<NotificationHub>("/notifications");
             });
         }
     }

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton(typeof(HubLifetimeManager<>), typeof(ServiceLifetimeManager<>))
                 .AddSingleton(typeof(IServiceProtocol), typeof(ServiceProtocol))
                 .AddSingleton(typeof(IClientConnectionManager), typeof(ClientConnectionManager))
-                .AddSingleton(typeof(IServiceConnectionManager), typeof(ServiceConnectionManager))
+                .AddSingleton(typeof(IServiceConnectionManager<>), typeof(ServiceConnectionManager<>))
                 .AddSingleton(typeof(IServiceEndpointUtility), typeof(ServiceEndpointUtility))
                 .AddSingleton(typeof(ServiceHubDispatcher<>))
                 .AddSingleton<IHostedService, HeartBeat>();

--- a/src/Microsoft.Azure.SignalR/HubHost/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/IServiceConnectionManager.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR
 {
-    internal interface IServiceConnectionManager
+    internal interface IServiceConnectionManager<THub> where THub : Hub
     {
         void AddServiceConnection(ServiceConnection serviceConnection);
 

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionManager.cs
@@ -4,11 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR
 {
-    internal class ServiceConnectionManager : IServiceConnectionManager
+    internal class ServiceConnectionManager<THub> : IServiceConnectionManager<THub> where THub : Hub
     {
         private readonly List<ServiceConnection> _serviceConnections = new List<ServiceConnection>();
 

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Azure.SignalR
         private readonly ILogger<ServiceHubDispatcher<THub>> _logger;
         private readonly ServiceOptions _options;
         private readonly IServiceEndpointUtility _serviceEndpointUtility;
-        private readonly IServiceConnectionManager _serviceConnectionManager;
+        private readonly IServiceConnectionManager<THub> _serviceConnectionManager;
         private readonly IClientConnectionManager _clientConnectionManager;
         private readonly IServiceProtocol _serviceProtocol;
         private readonly string _userId;
         private static readonly string Name = $"ServiceHubDispatcher<{typeof(THub).FullName}>";
 
         public ServiceHubDispatcher(IServiceProtocol serviceProtocol,
-            IServiceConnectionManager serviceConnectionManager,
+            IServiceConnectionManager<THub> serviceConnectionManager,
             IClientConnectionManager clientConnectionManager,
             IServiceEndpointUtility serviceEndpointUtility,
             IOptions<ServiceOptions> options,

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Azure.SignalR
         private readonly ILogger<ServiceLifetimeManager<THub>> _logger;
         private readonly IReadOnlyList<IHubProtocol> _allProtocols;
 
-        private readonly IServiceConnectionManager _serviceConnectionManager;
+        private readonly IServiceConnectionManager<THub> _serviceConnectionManager;
         private readonly IClientConnectionManager _clientConnectionManager;
 
-        public ServiceLifetimeManager(IServiceConnectionManager serviceConnectionManager,
+        public ServiceLifetimeManager(IServiceConnectionManager<THub> serviceConnectionManager,
             IClientConnectionManager clientConnectionManager,
             IHubProtocolResolver protocolResolver, ILogger<ServiceLifetimeManager<THub>> logger)
         {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-signalr/issues/97

We were starting multiple instances of the same ServiceConnection per hub since IServiceConnectionManager was a singleton. The fix is to make the `IServiceConnectionManager` specific to a hub so that the ServiceHubDispatcher gets a different instance per hub.

I couldn't think of a good way to test this but the sample has 2 hubs now 😄 