### PR TITLE
fix issue #99

### DIFF
--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-rc1-15775
-commithash:f967cebaec4c8f46d7cb3434bc9bc1a4a59b4095
+version:2.1.0-rtm-15783
+commithash:5fc2b2f607f542a2ffde11c19825e786fc1a3774

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/Microsoft.Azure.SignalR.Protocols.Tests.csproj
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/Microsoft.Azure.SignalR.Protocols.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
+++ b/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Korebuild's config for dotnet SDK needs to be updated. Otherwise, it reports exception:
"Could not load file or assembly 'System.Memory, Version=4.1.0.0, Culture=neutral,
PublicKeyToken=cc7b13ffcd2ddd51'"

dotnet 2.1.300-rc1-008673 works fine. But lower version has this issue.