### PR TITLE
send PingMessage to service to keep alive

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
@@ -59,14 +59,14 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, long, string, Exception> _receivedMessage =
                 LoggerMessage.Define<long, string>(LogLevel.Debug, new EventId(16, "ReceivedMessage"), "Received {ReceivedBytes} bytes from service {ServiceConnectionId}.");
 
-            private static readonly Action<ILogger, double, Exception> _startingServerTimeoutTimer =
-                LoggerMessage.Define<double>(LogLevel.Trace, new EventId(17, "StartingServerTimeoutTimer"), "Starting server timeout timer. Duration: {ServerTimeout:0.00}ms");
+            private static readonly Action<ILogger, double, Exception> _startingKeepAliveTimer =
+                LoggerMessage.Define<double>(LogLevel.Trace, new EventId(17, "StartingKeepAliveTimer"), "Starting keep-alive timer. Duration: {KeepAliveInterval:0.00}ms");
 
-            private static readonly Action<ILogger, double, Exception> _serverTimeout =
-                LoggerMessage.Define<double>(LogLevel.Error, new EventId(18, "ServerTimeout"), "Server timeout ({ServerTimeout:0.00}ms) elapsed without receiving a message from the server.");
+            private static readonly Action<ILogger, double, Exception> _serviceTimeout =
+                LoggerMessage.Define<double>(LogLevel.Error, new EventId(18, "ServiceTimeout"), "Service timeout. {ServiceTimeout:0.00}ms elapsed without receiving a message from service.");
 
             private static readonly Action<ILogger, Exception> _resettingKeepAliveTimer =
-                LoggerMessage.Define(LogLevel.Trace, new EventId(19, "ResettingKeepAliveTimer"), "Resetting keep-alive timer, received a message from the server.");
+                LoggerMessage.Define(LogLevel.Trace, new EventId(19, "ResettingKeepAliveTimer"), "Resetting keep-alive timer.");
 
             private static readonly Action<ILogger, int, string, Exception> _writeMessageToApplication =
                 LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(20, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
@@ -85,6 +85,12 @@ namespace Microsoft.Azure.SignalR
 
             private static readonly Action<ILogger, string, Exception> _handshakeError =
                 LoggerMessage.Define<string>(LogLevel.Critical, new EventId(25, "HandshakeError"), "Service returned handshake error: {Error}");
+
+            private static readonly Action<ILogger, Exception> _sentPing =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(26, "SentPing"), "Sent a ping message to service.");
+
+            private static readonly Action<ILogger, Exception> _failedSendingPing =
+                LoggerMessage.Define(LogLevel.Warning, new EventId(27, "FailedSendingPing"), "Failed sending a ping message to service.");
 
             public static void FailedToWrite(ILogger logger, Exception exception)
             {
@@ -171,14 +177,14 @@ namespace Microsoft.Azure.SignalR
                 _receivedMessage(logger, bytes, serviceConnectionId, null);
             }
 
-            public static void StartingServerTimeoutTimer(ILogger logger, TimeSpan serverTimeout)
+            public static void StartingKeepAliveTimer(ILogger logger, TimeSpan keepAliveInterval)
             {
-                _startingServerTimeoutTimer(logger, serverTimeout.TotalMilliseconds, null);
+                _startingKeepAliveTimer(logger, keepAliveInterval.TotalMilliseconds, null);
             }
 
-            public static void ServerTimeout(ILogger logger, TimeSpan serverTimeout)
+            public static void ServiceTimeout(ILogger logger, TimeSpan serviceTimeout)
             {
-                _serverTimeout(logger, serverTimeout.TotalMilliseconds, null);
+                _serviceTimeout(logger, serviceTimeout.TotalMilliseconds, null);
             }
 
             public static void ResettingKeepAliveTimer(ILogger logger)
@@ -209,6 +215,16 @@ namespace Microsoft.Azure.SignalR
             public static void HandshakeError(ILogger logger, string error)
             {
                 _handshakeError(logger, error, null);
+            }
+
+            public static void SentPing(ILogger logger)
+            {
+                _sentPing(logger, null);
+            }
+
+            public static void FailedSendingPing(ILogger logger, Exception exception)
+            {
+                _failedSendingPing(logger, exception);
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
@@ -65,32 +65,29 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, double, Exception> _serviceTimeout =
                 LoggerMessage.Define<double>(LogLevel.Error, new EventId(18, "ServiceTimeout"), "Service timeout. {ServiceTimeout:0.00}ms elapsed without receiving a message from service.");
 
-            private static readonly Action<ILogger, Exception> _resettingKeepAliveTimer =
-                LoggerMessage.Define(LogLevel.Trace, new EventId(19, "ResettingKeepAliveTimer"), "Resetting keep-alive timer.");
-
             private static readonly Action<ILogger, int, string, Exception> _writeMessageToApplication =
-                LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(20, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
+                LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(19, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
 
             private static readonly Action<ILogger, string, Exception> _serviceConnectionConnected =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(21, "ServiceConnectionConnected"), "Service connection {ServiceConnectionId} connected.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(20, "ServiceConnectionConnected"), "Service connection {ServiceConnectionId} connected.");
 
             private static readonly Action<ILogger, Exception> _sendingHandshakeRequest =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(22, "SendingHandshakeRequest"), "Sending Handshake request to service.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(21, "SendingHandshakeRequest"), "Sending Handshake request to service.");
 
             private static readonly Action<ILogger, Exception> _handshakeComplete =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(23, "HandshakeComplete"), "Handshake with service completes.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(22, "HandshakeComplete"), "Handshake with service completes.");
 
             private static readonly Action<ILogger, Exception> _errorReceivingHandshakeResponse =
-                LoggerMessage.Define(LogLevel.Error, new EventId(24, "ErrorReceivingHandshakeResponse"), "Error receiving handshake response.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(23, "ErrorReceivingHandshakeResponse"), "Error receiving handshake response.");
 
             private static readonly Action<ILogger, string, Exception> _handshakeError =
-                LoggerMessage.Define<string>(LogLevel.Critical, new EventId(25, "HandshakeError"), "Service returned handshake error: {Error}");
+                LoggerMessage.Define<string>(LogLevel.Critical, new EventId(24, "HandshakeError"), "Service returned handshake error: {Error}");
 
             private static readonly Action<ILogger, Exception> _sentPing =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(26, "SentPing"), "Sent a ping message to service.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(25, "SentPing"), "Sent a ping message to service.");
 
             private static readonly Action<ILogger, Exception> _failedSendingPing =
-                LoggerMessage.Define(LogLevel.Warning, new EventId(27, "FailedSendingPing"), "Failed sending a ping message to service.");
+                LoggerMessage.Define(LogLevel.Warning, new EventId(26, "FailedSendingPing"), "Failed sending a ping message to service.");
 
             public static void FailedToWrite(ILogger logger, Exception exception)
             {
@@ -185,11 +182,6 @@ namespace Microsoft.Azure.SignalR
             public static void ServiceTimeout(ILogger logger, TimeSpan serviceTimeout)
             {
                 _serviceTimeout(logger, serviceTimeout.TotalMilliseconds, null);
-            }
-
-            public static void ResettingKeepAliveTimer(ILogger logger)
-            {
-                _resettingKeepAliveTimer(logger, null);
             }
 
             public static void WriteMessageToApplication(ILogger logger, int count, string connectionId)

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
@@ -17,9 +18,12 @@ namespace Microsoft.Azure.SignalR
     internal partial class ServiceConnection
     {
         private static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(15);
-        // Server ping rate is 15 sec, this is 2 times that.
-        private static readonly TimeSpan DefaultServerTimeout = TimeSpan.FromSeconds(30);
-        private static readonly int MaximumReconnectBackoffInternalInMilliseconds = 1000;
+        // Service ping rate is 15 sec; this is 2 times that.
+        private static readonly TimeSpan DefaultServiceTimeout = TimeSpan.FromSeconds(30);
+        private static readonly long DefaultServiceTimeoutTicks = DefaultServiceTimeout.Seconds * Stopwatch.Frequency;
+        // App server ping rate is 5 sec. So service can detect an irresponsive server connection in 10 seconds at most.
+        private static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(5);
+        private static readonly int MaxReconnectBackoffInternalInMilliseconds = 1000;
 
         private readonly IConnectionFactory _connectionFactory;
         private readonly IServiceProtocol _serviceProtocol;
@@ -27,6 +31,7 @@ namespace Microsoft.Azure.SignalR
         private readonly SemaphoreSlim _serviceConnectionLock = new SemaphoreSlim(1, 1);
         private readonly ILogger<ServiceConnection> _logger;
         private readonly HandshakeRequestMessage _handshakeRequest;
+        private readonly ReadOnlyMemory<byte> _cachedPingBytes;
 
         private readonly ConcurrentDictionary<string, string> _connectionIds =
             new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
@@ -35,10 +40,11 @@ namespace Microsoft.Azure.SignalR
         private readonly ConnectionDelegate _connectionDelegate;
         private ConnectionContext _connection;
         private bool _isStopped;
+        private long _lastReceiveTimestamp;
 
         // Start reconnect after a random interval less than 1 second
         private static TimeSpan ReconnectInterval =>
-            TimeSpan.FromMilliseconds(StaticRandom.Next(MaximumReconnectBackoffInternalInMilliseconds));
+            TimeSpan.FromMilliseconds(StaticRandom.Next(MaxReconnectBackoffInternalInMilliseconds));
 
         public ServiceConnection(IServiceProtocol serviceProtocol,
             IClientConnectionManager clientConnectionManager,
@@ -52,6 +58,8 @@ namespace Microsoft.Azure.SignalR
             _connectionDelegate = connectionDelegate;
             _connectionId = connectionId;
             _logger = loggerFactory.CreateLogger<ServiceConnection>();
+
+            _cachedPingBytes = _serviceProtocol.GetMessageBytes(PingMessage.Instance);
         }
 
         public async Task StartAsync()
@@ -241,20 +249,39 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
-        private Timer StartTimeoutTimer()
+        private Timer StartKeepAliveTimer()
         {
-            Log.StartingServerTimeoutTimer(_logger, DefaultServerTimeout);
-            return new Timer(state => ((ServiceConnection)state).TimeoutElapsed(),
-                    this, Timeout.Infinite, Timeout.Infinite);
+            Log.StartingKeepAliveTimer(_logger, DefaultKeepAliveInterval);
+
+            _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+
+            var timer = new Timer(TimeoutElapsed);
+            timer.Change(DefaultKeepAliveInterval, Timeout.InfiniteTimeSpan);
+            return timer;
         }
 
-        private void ResetTimeoutTimer(Timer timeoutTimer)
+        private void UpdateReceiveTimestamp()
         {
+            Interlocked.Exchange(ref _lastReceiveTimestamp, Stopwatch.GetTimestamp());
+        }
+
+        private void TimeoutElapsed(object state)
+        {
+            if (Stopwatch.GetTimestamp() - Interlocked.Read(ref _lastReceiveTimestamp) > DefaultServiceTimeoutTicks)
+            {
+                AbortConnection();
+                return;
+            }
+
+            // Send PingMessage to Service
+            _ = TrySendPingAsync();
+
             Log.ResettingKeepAliveTimer(_logger);
-            timeoutTimer.Change(DefaultServerTimeout, Timeout.InfiniteTimeSpan);
+            var timer = (Timer) state;
+            timer.Change(DefaultKeepAliveInterval, Timeout.InfiniteTimeSpan);
         }
 
-        private void TimeoutElapsed()
+        private void AbortConnection()
         {
             if (!_serviceConnectionLock.Wait(0))
             {
@@ -268,8 +295,31 @@ namespace Microsoft.Azure.SignalR
                 if (_connection != null)
                 {
                     _connection.Transport.Input.CancelPendingRead();
-                    Log.ServerTimeout(_logger, DefaultServerTimeout);
+                    Log.ServiceTimeout(_logger, DefaultServiceTimeout);
                 }
+            }
+            finally
+            {
+                _serviceConnectionLock.Release();
+            }
+        }
+
+        private async ValueTask TrySendPingAsync()
+        {
+            if (!_serviceConnectionLock.Wait(0))
+            {
+                // Skip sending PingMessage when failed getting lock
+                return;
+            }
+
+            try
+            {
+                await _connection.Transport.Output.WriteAsync(_cachedPingBytes);
+                Log.SentPing(_logger);
+            }
+            catch (Exception ex)
+            {
+                Log.FailedSendingPing(_logger, ex);
             }
             finally
             {
@@ -279,7 +329,7 @@ namespace Microsoft.Azure.SignalR
 
         private async Task ProcessIncomingAsync()
         {
-            var timeoutTimer = StartTimeoutTimer();
+            var keepAliveTimer = StartKeepAliveTimer();
             try
             {
                 while (true)
@@ -297,8 +347,10 @@ namespace Microsoft.Azure.SignalR
 
                         if (!buffer.IsEmpty)
                         {
-                            ResetTimeoutTimer(timeoutTimer);
                             Log.ReceivedMessage(_logger, buffer.Length, _connectionId);
+
+                            UpdateReceiveTimestamp();
+
                             while (_serviceProtocol.TryParseMessage(ref buffer, out var message))
                             {
                                 _ = DispatchMessageAsync(message);
@@ -333,7 +385,7 @@ namespace Microsoft.Azure.SignalR
             }
             finally
             {
-                timeoutTimer.Dispose();
+                keepAliveTimer.Dispose();
                 await _connectionFactory.DisposeAsync(_connection);
             }
 

--- a/src/Microsoft.Azure.SignalR/HubHost/TimerAwaitable.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/TimerAwaitable.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging.Abstractions;
 using HandshakeRequestMessage = Microsoft.Azure.SignalR.Protocol.HandshakeRequestMessage;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -3,22 +3,18 @@
 
 using System;
 using System.Buffers;
-using System.IO;
 using System.IO.Pipelines;
-using System.Security.Claims;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Azure.SignalR.Protocol;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests
 {
     public class ServiceConnectionFacts
     {
+        private static readonly ServiceProtocol Protocol = new ServiceProtocol();
+
         [Fact]
         public async Task ServiceConnectionStartsConnection()
         {
@@ -83,7 +79,6 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task ClosingConnectionSendsCloseMessage()
         {
-            var protocol = new ServiceProtocol();
             var proxy = new ServiceConnectionProxy(context =>
             {
                 // Just let the connection end immediately
@@ -98,11 +93,8 @@ namespace Microsoft.Azure.SignalR.Tests
 
             var connection = await task.OrTimeout();
 
-            var data = await proxy.ConnectionContext.Application.Input.ReadSingleAsync().OrTimeout();
-            var buffer = new ReadOnlySequence<byte>(data);
-            Assert.True(protocol.TryParseMessage(ref buffer, out var message));
-            var closeMessage = Assert.IsType<CloseConnectionMessage>(message);
-            Assert.Equal(closeMessage.ConnectionId, connection.ConnectionId);
+            var message = await ReadServiceMessageAsync<CloseConnectionMessage>(proxy.ConnectionContext.Application.Input);
+            Assert.Equal(message.ConnectionId, connection.ConnectionId);
 
             proxy.Stop();
         }
@@ -110,7 +102,6 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task WritingMessagesFromConnectionGetsSentAsConnectionData()
         {
-            var protocol = new ServiceProtocol();
             var proxy = new ServiceConnectionProxy();
 
             await proxy.StartAsync();
@@ -123,14 +114,35 @@ namespace Microsoft.Azure.SignalR.Tests
 
             await connection.Transport.Output.WriteAsync(Encoding.ASCII.GetBytes("Hello World"));
 
-            var data = await proxy.ConnectionContext.Application.Input.ReadSingleAsync().OrTimeout();
-            var buffer = new ReadOnlySequence<byte>(data);
-            Assert.True(protocol.TryParseMessage(ref buffer, out var message));
-            var connectionDataMessage = Assert.IsType<ConnectionDataMessage>(message);
-            Assert.Equal(connectionDataMessage.ConnectionId, connection.ConnectionId);
-            Assert.Equal("Hello World", Encoding.ASCII.GetString(connectionDataMessage.Payload.ToArray()));
+            var message = await ReadServiceMessageAsync<ConnectionDataMessage>(proxy.ConnectionContext.Application.Input);
+            Assert.Equal(message.ConnectionId, connection.ConnectionId);
+            Assert.Equal("Hello World", Encoding.ASCII.GetString(message.Payload.ToArray()));
 
             proxy.Stop();
+        }
+
+        [Fact]
+        public async Task ServiceConnectionSendsPingMessage()
+        {
+            var proxy = new ServiceConnectionProxy();
+
+            await proxy.StartAsync();
+
+            // Check more than once since it happens periodically
+            for (int i = 0; i < 2; i++)
+            {
+                await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 6000);
+            }
+
+            proxy.Stop();
+        }
+
+        private async Task<T> ReadServiceMessageAsync<T>(PipeReader input, int timeout = 5000) where T : ServiceMessage
+        {
+            var data = await input.ReadSingleAsync().OrTimeout(timeout);
+            var buffer = new ReadOnlySequence<byte>(data);
+            Assert.True(Protocol.TryParseMessage(ref buffer, out var message));
+            return Assert.IsType<T>(message);
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
@@ -1,18 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.IO.Pipelines;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Azure.SignalR.Protocol;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests


### PR DESCRIPTION
Send `PingMessage` from server to service every 5 seconds, so that service can quickly detect an unresponsive service connection.