### PR TITLE
Write the ReadOnlySequence as a single ConnectionDataMessage

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -88,6 +88,11 @@ namespace Microsoft.Azure.SignalR.Protocol
             Payload = new ReadOnlySequence<byte>(payload);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionDataMessage"/> class.
+        /// </summary>
+        /// <param name="connectionId">The connection Id.</param>
+        /// <param name="payload">Binary data to be delivered.</param>
         public ConnectionDataMessage(string connectionId, ReadOnlySequence<byte> payload) : base(connectionId)
         {
             Payload = payload;

--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Security.Claims;
 
 namespace Microsoft.Azure.SignalR.Protocol
@@ -84,12 +85,17 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="payload">Binary data to be delivered.</param>
         public ConnectionDataMessage(string connectionId, ReadOnlyMemory<byte> payload) : base(connectionId)
         {
+            Payload = new ReadOnlySequence<byte>(payload);
+        }
+
+        public ConnectionDataMessage(string connectionId, ReadOnlySequence<byte> payload) : base(connectionId)
+        {
             Payload = payload;
         }
 
         /// <summary>
         /// Gets or sets the binary payload.
         /// </summary>
-        public ReadOnlyMemory<byte> Payload { get; set; }
+        public ReadOnlySequence<byte> Payload { get; set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton(typeof(IServiceConnectionManager<>), typeof(ServiceConnectionManager<>))
                 .AddSingleton(typeof(IServiceEndpointUtility), typeof(ServiceEndpointUtility))
                 .AddSingleton(typeof(ServiceHubDispatcher<>))
+                .AddSingleton<IClientConnectionFactory, ClientConnectionFactory>()
                 .AddSingleton<IHostedService, HeartBeat>();
             return builder;
         }

--- a/src/Microsoft.Azure.SignalR/HubHost/ClientConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ClientConnectionFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.Azure.SignalR
+{
+    internal class ClientConnectionFactory : IClientConnectionFactory
+    {
+        public ServiceConnectionContext CreateConnection(OpenConnectionMessage message)
+        {
+            return new ServiceConnectionContext(message);
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR/HubHost/IClientConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/IClientConnectionFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.Azure.SignalR
+{
+    internal interface IClientConnectionFactory
+    {
+        ServiceConnectionContext CreateConnection(OpenConnectionMessage message);
+    }
+}

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.Log.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, double, Exception> _serviceTimeout =
                 LoggerMessage.Define<double>(LogLevel.Error, new EventId(18, "ServiceTimeout"), "Service timeout. {ServiceTimeout:0.00}ms elapsed without receiving a message from service.");
 
-            private static readonly Action<ILogger, int, string, Exception> _writeMessageToApplication =
-                LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(19, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
+            private static readonly Action<ILogger, long, string, Exception> _writeMessageToApplication =
+                LoggerMessage.Define<long, string>(LogLevel.Trace, new EventId(19, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
 
             private static readonly Action<ILogger, string, Exception> _serviceConnectionConnected =
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(20, "ServiceConnectionConnected"), "Service connection {ServiceConnectionId} connected.");
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.SignalR
                 _serviceTimeout(logger, serviceTimeout.TotalMilliseconds, null);
             }
 
-            public static void WriteMessageToApplication(ILogger logger, int count, string connectionId)
+            public static void WriteMessageToApplication(ILogger logger, long count, string connectionId)
             {
                 _writeMessageToApplication(logger, count, connectionId, null);
             }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnectionContext.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Azure.SignalR
             "exp", // Expiration time claims. A token is valid only before its expiration time.
             "iat", // Issued At claim. Added by default. It is not validated by service.
             "nbf"  // Not Before claim. Added by default. It is not validated by service.
-        }; 
+        };
 
         private readonly object _heartbeatLock = new object();
         private List<(Action<object> handler, object state)> _heartbeatHandlers;
 
-        public ServiceConnectionContext(OpenConnectionMessage serviceMessage)
+        public ServiceConnectionContext(OpenConnectionMessage serviceMessage, PipeOptions transportPipeOptions = null, PipeOptions appPipeOptions = null)
         {
             ConnectionId = serviceMessage.ConnectionId;
             User = new ClaimsPrincipal();
@@ -43,11 +43,12 @@ namespace Microsoft.Azure.SignalR
                 : new ClaimsIdentity());
 
             // Create the Duplix Pipeline for the virtual connection
-            var transportPipeOptions = new PipeOptions(pauseWriterThreshold: 0,
+            transportPipeOptions = transportPipeOptions ?? new PipeOptions(pauseWriterThreshold: 0,
                 resumeWriterThreshold: 0,
                 readerScheduler: PipeScheduler.ThreadPool,
                 useSynchronizationContext: false);
-            var appPipeOptions = new PipeOptions(pauseWriterThreshold: 0,
+
+            appPipeOptions = appPipeOptions ?? new PipeOptions(pauseWriterThreshold: 0,
                 resumeWriterThreshold: 0,
                 readerScheduler: PipeScheduler.ThreadPool,
                 useSynchronizationContext: false);

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.SignalR
         private readonly IServiceConnectionManager<THub> _serviceConnectionManager;
         private readonly IClientConnectionManager _clientConnectionManager;
         private readonly IServiceProtocol _serviceProtocol;
+        private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly string _userId;
         private static readonly string Name = $"ServiceHubDispatcher<{typeof(THub).FullName}>";
 
@@ -31,7 +32,8 @@ namespace Microsoft.Azure.SignalR
             IClientConnectionManager clientConnectionManager,
             IServiceEndpointUtility serviceEndpointUtility,
             IOptions<ServiceOptions> options,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IClientConnectionFactory clientConnectionFactory)
         {
             _serviceProtocol = serviceProtocol;
             _serviceConnectionManager = serviceConnectionManager;
@@ -41,6 +43,7 @@ namespace Microsoft.Azure.SignalR
 
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = loggerFactory.CreateLogger<ServiceHubDispatcher<THub>>();
+            _clientConnectionFactory = clientConnectionFactory;
             _userId = GenerateServerName();
         }
 
@@ -56,7 +59,7 @@ namespace Microsoft.Azure.SignalR
             // Simply create a couple of connections which connect to Azure SignalR
             for (var i = 0; i < _options.ConnectionCount; i++)
             {
-                var serviceConnection = new ServiceConnection(_serviceProtocol, _clientConnectionManager, this, _loggerFactory, connectionDelegate, Guid.NewGuid().ToString());
+                var serviceConnection = new ServiceConnection(_serviceProtocol, _clientConnectionManager, this, _loggerFactory, connectionDelegate, _clientConnectionFactory, Guid.NewGuid().ToString());
                 _serviceConnectionManager.AddServiceConnection(serviceConnection);
             }
             Log.StartingConnection(_logger, Name, _options.ConnectionCount);

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -135,12 +135,13 @@ namespace Microsoft.Azure.SignalR.Tests
             await proxy.WriteMessageAsync(new OpenConnectionMessage("1", null));
 
             var connection = await task.OrTimeout();
+            var outputMessage = "This message should be more than 10 bytes";
 
-            await connection.Transport.Output.WriteAsync(Encoding.ASCII.GetBytes("This message should be more than 10 bytes"));
+            await connection.Transport.Output.WriteAsync(Encoding.ASCII.GetBytes(outputMessage));
 
             var message = await ReadServiceMessageAsync<ConnectionDataMessage>(proxy.ConnectionContext.Application.Input);
             Assert.Equal(message.ConnectionId, connection.ConnectionId);
-            Assert.Equal("This message should be more than 10 bytes", Encoding.ASCII.GetString(message.Payload.ToArray()));
+            Assert.Equal(outputMessage, Encoding.ASCII.GetString(message.Payload.ToArray()));
 
             proxy.Stop();
         }


### PR DESCRIPTION
- Manually write the message pack header and ReadOnlySequence to the Stream directly.

Fixes #124 

PS: I need to write tests. We also need to update the logic in the service that writes to the transport.