### PR TITLE
Avoid connection timeout when debugger is attached

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
@@ -170,8 +170,13 @@ namespace Microsoft.Azure.SignalR
 
             try
             {
-                using (var cts = new CancellationTokenSource(DefaultHandshakeTimeout))
+                using (var cts = new CancellationTokenSource())
                 {
+                    if (!Debugger.IsAttached)
+                    {
+                        cts.CancelAfter(DefaultHandshakeTimeout);
+                    }
+                    
                     if (await ReceiveHandshakeResponseAsync(_connection.Transport.Input, cts.Token))
                     {
                         Log.HandshakeComplete(_logger);


### PR DESCRIPTION
For ServiceConnection Handshake, for better debugging experience