### PR TITLE
Loop over the dictionary itself rather than keys

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceConnection.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Azure.SignalR
                     return;
                 }
                 var tasks = new List<Task>(_connectionIds.Count);
-                foreach (var connectionId in _connectionIds.Keys)
+                foreach (var connection in _connectionIds)
                 {
-                    tasks.Add(PerformDisconnectAsyncCore(connectionId));
+                    tasks.Add(PerformDisconnectAsyncCore(connection.Key));
                 }
                 await Task.WhenAll(tasks);
             }


### PR DESCRIPTION
> Performance tip: It's more efficient to loop over the ConcurrentDictionary itself rather than keys or values. Each of those collections takes a lock on all of the buckets.