### PR TITLE
Add dependencies from Common project to here

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
+++ b/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="$(MicrosoftExtensionsLoggingTraceSourcePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="$(MicrosoftAspNetCoreHttpConnectionsClientPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Although `PrivateAssets` and set workarounds as https://github.com/nuget/home/issues/3891#issuecomment-397481361 shows, it is unable to detect what Common project references and build process is unable to add it to the references of current project automatically.
So for now, we still need to make sure the references of Common project is added to this project's references, until https://github.com/nuget/home/issues/3891 is resolved.