### PR TITLE
rename custom header name to avoid header restriction in asp.net framework

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.SignalR
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly string _userId;
         private static readonly string Name = $"ServiceHubDispatcher<{typeof(THub).FullName}>";
-        private static Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { "User-Agent", ProductInfo.GetProductInfo() } };
+        private static Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { "Asrs-UserAgent", ProductInfo.GetProductInfo() } };
 
         public ServiceHubDispatcher(IServiceProtocol serviceProtocol,
             IServiceConnectionManager<THub> serviceConnectionManager,

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.SignalR
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly string _userId;
         private static readonly string Name = $"ServiceHubDispatcher<{typeof(THub).FullName}>";
+        // Fix issue: https://github.com/Azure/azure-signalr/issues/198
+        // .NET Framework has restriction about reserved string as the header name like "User-Agent"
         private static Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { "Asrs-UserAgent", ProductInfo.GetProductInfo() } };
 
         public ServiceHubDispatcher(IServiceProtocol serviceProtocol,

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.SignalR
         private static readonly string Name = $"ServiceHubDispatcher<{typeof(THub).FullName}>";
         // Fix issue: https://github.com/Azure/azure-signalr/issues/198
         // .NET Framework has restriction about reserved string as the header name like "User-Agent"
-        private static Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { "Asrs-UserAgent", ProductInfo.GetProductInfo() } };
+        private static Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { "Asrs-User-Agent", ProductInfo.GetProductInfo() } };
 
         public ServiceHubDispatcher(IServiceProtocol serviceProtocol,
             IServiceConnectionManager<THub> serviceConnectionManager,


### PR DESCRIPTION
fix issue [#198](https://github.com/Azure/azure-signalr/issues/198)