### PR TITLE
fix claim in negotiate handler.

### DIFF
--- a/src/Microsoft.Azure.SignalR/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/NegotiateHandler.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Azure.SignalR
         private IEnumerable<Claim> BuildClaims(HttpContext context)
         {
             var userId = _userIdProvider.GetUserId(new ServiceHubConnectionContext(context));
-            yield return new Claim(Constants.ClaimType.UserId, userId ?? string.Empty);
+            if (userId != null)
+            {
+                yield return new Claim(Constants.ClaimType.UserId, userId);
+            }
 
             var claims = _claimsProvider == null ? context.User.Claims : _claimsProvider.Invoke(context);
             if (claims == null) yield break;

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [InlineData(typeof(CustomUserIdProvider), CustomUserId)]
-        [InlineData(typeof(NullUserIdProvider), "")]
+        [InlineData(typeof(NullUserIdProvider), null)]
         [InlineData(typeof(DefaultUserIdProvider), DefaultUserId)]
         public void GenerateNegotiateResponseWithUserId(Type type, string expectedUserId)
         {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.Empty(negotiateResponse.AvailableTransports);
 
             var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Equal(expectedUserId, token.Claims.First(x => x.Type == Constants.ClaimType.UserId).Value);
+            Assert.Equal(expectedUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
         }
 
         [Theory]


### PR DESCRIPTION
Bug: add our custom user id in the claim when the user id is null, this will prevent using the standard name identify.