### PR TITLE
Add ServerCloseMessage to protocol

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.SignalR
         private bool _isStopped;
         private long _lastReceiveTimestamp;
         protected ConnectionContext _connection;
-        protected string _errorMessage;
+        protected string ErrorMessage;
 
         public Task WaitForConnectionStart => _serviceConnectionStartTcs.Task;
 
@@ -86,10 +86,10 @@ namespace Microsoft.Azure.SignalR
             // The lock is per serviceConnection
             await _serviceConnectionLock.WaitAsync();
 
-            if (!string.IsNullOrEmpty(_errorMessage))
+            if (!string.IsNullOrEmpty(ErrorMessage))
             {
                 _serviceConnectionLock.Release();
-                throw new InvalidOperationException(_errorMessage);
+                throw new InvalidOperationException(ErrorMessage);
             }
 
             if (_connection == null)
@@ -131,10 +131,10 @@ namespace Microsoft.Azure.SignalR
             if (!string.IsNullOrEmpty(serviceErrorMessage.ErrorMessage))
             {
                 // When receives service error message, we suppose server -> service connection doesn't work,
-                // and set _errorMessage to prevent sending message from server to service
+                // and set ErrorMessage to prevent sending message from server to service
                 // But messages in the pipe from service -> server should be processed as usual. Just log without
                 // throw exception here.
-                _errorMessage = serviceErrorMessage.ErrorMessage;
+                ErrorMessage = serviceErrorMessage.ErrorMessage;
                 Log.ReceivedServiceErrorMessage(_logger, serviceErrorMessage.ErrorMessage);
             }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.SignalR
                 try
                 {
                     _connection = await CreateConnection();
-                    _errorMessage = null;
+                    ErrorMessage = null;
 
                     if (await HandshakeAsync())
                     {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
@@ -119,6 +119,16 @@ namespace Microsoft.Azure.SignalR
 
         protected abstract Task OnMessageAsync(ConnectionDataMessage connectionDataMessage);
 
+        protected Task OnServerCloseAsync(ServerCloseMessage serverCloseMessage)
+        {
+            if (!string.IsNullOrEmpty(serverCloseMessage.CloseMessage))
+            {
+                throw new Exception(serverCloseMessage.CloseMessage);
+            }
+
+            return Task.CompletedTask;
+        }
+
         private async Task<bool> StartAsyncCore()
         {
             // Always try until connected
@@ -343,6 +353,8 @@ namespace Microsoft.Azure.SignalR
                     return OnDisconnectedAsync(closeConnectionMessage);
                 case ConnectionDataMessage connectionDataMessage:
                     return OnMessageAsync(connectionDataMessage);
+                case ServerCloseMessage serverCloseMessage:
+                    return OnServerCloseAsync(serverCloseMessage);
                 case PingMessage _:
                     // ignore ping
                     break;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
@@ -126,12 +126,16 @@ namespace Microsoft.Azure.SignalR
 
         protected abstract Task OnMessageAsync(ConnectionDataMessage connectionDataMessage);
 
-        protected Task OnServerCloseAsync(ServerCloseMessage serverCloseMessage)
+        protected Task OnServiceErrorAsync(ServiceErrorMessage serviceErrorMessage)
         {
-            if (!string.IsNullOrEmpty(serverCloseMessage.ErrorMessage))
+            if (!string.IsNullOrEmpty(serviceErrorMessage.ErrorMessage))
             {
-                _errorMessage = serverCloseMessage.ErrorMessage;
-                throw new Exception(serverCloseMessage.ErrorMessage);
+                // When receives service error message, we suppose server -> service connection doesn't work,
+                // and set _errorMessage to prevent sending message from server to service
+                // But messages in the pipe from service -> server should be processed as usual. Just log without
+                // throw exception here.
+                _errorMessage = serviceErrorMessage.ErrorMessage;
+                Log.ReceivedServiceErrorMessage(_logger, serviceErrorMessage.ErrorMessage);
             }
 
             return Task.CompletedTask;
@@ -362,8 +366,8 @@ namespace Microsoft.Azure.SignalR
                     return OnDisconnectedAsync(closeConnectionMessage);
                 case ConnectionDataMessage connectionDataMessage:
                     return OnMessageAsync(connectionDataMessage);
-                case ServerCloseMessage serverCloseMessage:
-                    return OnServerCloseAsync(serverCloseMessage);
+                case ServiceErrorMessage serviceErrorMessage:
+                    return OnServiceErrorAsync(serviceErrorMessage);
                 case PingMessage _:
                     // ignore ping
                     break;
@@ -535,6 +539,9 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, Exception> _failedSendingPing =
                 LoggerMessage.Define(LogLevel.Warning, new EventId(26, "FailedSendingPing"), "Failed sending a ping message to service.");
 
+            private static readonly Action<ILogger, string, Exception> _receivedServiceErrorMessage =
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(27, "ReceivedServiceErrorMessage"), "Received error message from service: {Error}");
+
             public static void FailedToWrite(ILogger logger, Exception exception)
             {
                 _failedToWrite(logger, exception);
@@ -663,6 +670,11 @@ namespace Microsoft.Azure.SignalR
             public static void FailedSendingPing(ILogger logger, Exception exception)
             {
                 _failedSendingPing(logger, exception);
+            }
+
+            public static void ReceivedServiceErrorMessage(ILogger logger, string errorMessage)
+            {
+                _receivedServiceErrorMessage(logger, errorMessage, null);
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
@@ -121,9 +121,9 @@ namespace Microsoft.Azure.SignalR
 
         protected Task OnServerCloseAsync(ServerCloseMessage serverCloseMessage)
         {
-            if (!string.IsNullOrEmpty(serverCloseMessage.CloseMessage))
+            if (!string.IsNullOrEmpty(serverCloseMessage.ErrorMessage))
             {
-                throw new Exception(serverCloseMessage.CloseMessage);
+                throw new Exception(serverCloseMessage.ErrorMessage);
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -74,24 +74,17 @@ namespace Microsoft.Azure.SignalR.Protocol
     public class ServerCloseMessage : ServiceMessage
     {
         /// <summary>
-        /// Gets or sets the optional close message
+        /// Gets or sets the error message
         /// </summary>
-        public string CloseMessage { get; set; }
+        public string ErrorMessage { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerCloseMessage"/> class.
         /// </summary>
-        public ServerCloseMessage() : this(string.Empty)
+        /// <param name="errorMessage">An error message.</param>
+        public ServerCloseMessage(string errorMessage)
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ServerCloseMessage"/> class.
-        /// </summary>
-        /// <param name="closeMessage">An optional close message. A <c>null</c> or empty error message indicates a close without errors.</param>
-        public ServerCloseMessage(string closeMessage)
-        {
-            CloseMessage = closeMessage;
+            ErrorMessage = errorMessage;
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -67,4 +67,31 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         public static PingMessage Instance = new PingMessage();
     }
+
+    /// <summary>
+    /// A server close message
+    /// </summary>
+    public class ServerCloseMessage : ServiceMessage
+    {
+        /// <summary>
+        /// Gets or sets the optional close message
+        /// </summary>
+        public string CloseMessage { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerCloseMessage"/> class.
+        /// </summary>
+        public ServerCloseMessage() : this(string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerCloseMessage"/> class.
+        /// </summary>
+        /// <param name="closeMessage">An optional close message. A <c>null</c> or empty error message indicates a close without errors.</param>
+        public ServerCloseMessage(string closeMessage)
+        {
+            CloseMessage = closeMessage;
+        }
+    }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
-    /// A server close message
+    /// A service error message
     /// </summary>
-    public class ServerCloseMessage : ServiceMessage
+    public class ServiceErrorMessage : ServiceMessage
     {
         /// <summary>
         /// Gets or sets the error message
@@ -79,10 +79,10 @@ namespace Microsoft.Azure.SignalR.Protocol
         public string ErrorMessage { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ServerCloseMessage"/> class.
+        /// Initializes a new instance of the <see cref="ServiceErrorMessage"/> class.
         /// </summary>
         /// <param name="errorMessage">An error message.</param>
-        public ServerCloseMessage(string errorMessage)
+        public ServiceErrorMessage(string errorMessage)
         {
             ErrorMessage = errorMessage;
         }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         {
             MessagePackBinary.WriteArrayHeader(packer,2);
             MessagePackBinary.WriteInt32(packer, ServiceProtocolConstants.ServerCloseMessageType);
-            MessagePackBinary.WriteString(packer, message.CloseMessage);
+            MessagePackBinary.WriteString(packer, message.ErrorMessage);
         }
 
         private static void WriteStringArray(IReadOnlyList<string> array, Stream packer)

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Azure.SignalR.Protocol
                     return CreateGroupBroadcastDataMessage(input, ref startOffset);
                 case ServiceProtocolConstants.MultiGroupBroadcastDataMessageType:
                     return CreateMultiGroupBroadcastDataMessage(input, ref startOffset);
-                case ServiceProtocolConstants.ServerCloseMessageType:
-                    return CreateServerCloseMessage(input, ref startOffset);
+                case ServiceProtocolConstants.ServiceErrorMessageType:
+                    return CreateServiceErrorMessage(input, ref startOffset);
                 default:
                     // Future protocol changes can add message types, old clients can ignore them
                     return null;
@@ -192,8 +192,8 @@ namespace Microsoft.Azure.SignalR.Protocol
                 case MultiGroupBroadcastDataMessage multiGroupBroadcastDataMessage:
                     WriteMultiGroupBroadcastDataMessage(multiGroupBroadcastDataMessage, packer);
                     break;
-                case ServerCloseMessage serverCloseMessage:
-                    WriteServerCloseMessage(serverCloseMessage, packer);
+                case ServiceErrorMessage serviceErrorMessage:
+                    WriteServiceErrorMessage(serviceErrorMessage, packer);
                     break;
                 default:
                     throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
@@ -362,10 +362,10 @@ namespace Microsoft.Azure.SignalR.Protocol
             WritePayloads(message.Payloads, packer);
         }
 
-        private static void WriteServerCloseMessage(ServerCloseMessage message, Stream packer)
+        private static void WriteServiceErrorMessage(ServiceErrorMessage message, Stream packer)
         {
             MessagePackBinary.WriteArrayHeader(packer,2);
-            MessagePackBinary.WriteInt32(packer, ServiceProtocolConstants.ServerCloseMessageType);
+            MessagePackBinary.WriteInt32(packer, ServiceProtocolConstants.ServiceErrorMessageType);
             MessagePackBinary.WriteString(packer, message.ErrorMessage);
         }
 
@@ -539,11 +539,11 @@ namespace Microsoft.Azure.SignalR.Protocol
             return new MultiGroupBroadcastDataMessage(groupList, payloads);
         }
 
-        private static ServerCloseMessage CreateServerCloseMessage(byte[] input, ref int offset)
+        private static ServiceErrorMessage CreateServiceErrorMessage(byte[] input, ref int offset)
         {
-            var closeMessage = ReadString(input, ref offset, "closeMessage");
+            var errorMessage = ReadString(input, ref offset, "errorMessage");
 
-            return new ServerCloseMessage(closeMessage);
+            return new ServiceErrorMessage(errorMessage);
         }
 
         private static Claim[] ReadClaims(byte[] input, ref int offset)

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.SignalR.Protocol
                 case ServiceProtocolConstants.MultiGroupBroadcastDataMessageType:
                     return CreateMultiGroupBroadcastDataMessage(input, ref startOffset);
                 case ServiceProtocolConstants.ServerCloseMessageType:
-                    return createServerCloseMessage(input, ref startOffset);
+                    return CreateServerCloseMessage(input, ref startOffset);
                 default:
                     // Future protocol changes can add message types, old clients can ignore them
                     return null;
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.SignalR.Protocol
             return new MultiGroupBroadcastDataMessage(groupList, payloads);
         }
 
-        private static ServerCloseMessage createServerCloseMessage(byte[] input, ref int offset)
+        private static ServerCloseMessage CreateServerCloseMessage(byte[] input, ref int offset)
         {
             var closeMessage = ReadString(input, ref offset, "closeMessage");
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int LeaveGroupMessageType = 12;
         public const int GroupBroadcastDataMessageType = 13;
         public const int MultiGroupBroadcastDataMessageType = 14;
-        public const int ServerCloseMessageType = 15;
+        public const int ServiceErrorMessageType = 15;
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int LeaveGroupMessageType = 12;
         public const int GroupBroadcastDataMessageType = 13;
         public const int MultiGroupBroadcastDataMessageType = 14;
+        public const int ServerCloseMessageType = 15;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 case MultiGroupBroadcastDataMessage multiGroupBroadcastDataMessage:
                     return MultiGroupBroadcastDataMessagesEqual(multiGroupBroadcastDataMessage,
                         (MultiGroupBroadcastDataMessage)y);
-                case ServerCloseMessage serverCloseMessage:
-                    return ServerCloseMessageEqual(serverCloseMessage, (ServerCloseMessage)y);
+                case ServiceErrorMessage serviceErrorMessage:
+                    return ServiceErrorMessageEqual(serviceErrorMessage, (ServiceErrorMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             return SequenceEqual(x.GroupList, y.GroupList) && PayloadsEqual(x.Payloads, y.Payloads);
         }
 
-        private bool ServerCloseMessageEqual(ServerCloseMessage x, ServerCloseMessage y)
+        private bool ServiceErrorMessageEqual(ServiceErrorMessage x, ServiceErrorMessage y)
         {
             return StringEqual(x.ErrorMessage, y.ErrorMessage);
         }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return MultiGroupBroadcastDataMessagesEqual(multiGroupBroadcastDataMessage,
                         (MultiGroupBroadcastDataMessage)y);
                 case ServerCloseMessage serverCloseMessage:
-                    return ServerCloseMessageEqual(serverCloseMessage, (ServerCloseMessage) y);
+                    return ServerCloseMessageEqual(serverCloseMessage, (ServerCloseMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 case MultiGroupBroadcastDataMessage multiGroupBroadcastDataMessage:
                     return MultiGroupBroadcastDataMessagesEqual(multiGroupBroadcastDataMessage,
                         (MultiGroupBroadcastDataMessage)y);
+                case ServerCloseMessage serverCloseMessage:
+                    return ServerCloseMessageEqual(serverCloseMessage, (ServerCloseMessage) y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -133,6 +135,11 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             MultiGroupBroadcastDataMessage y)
         {
             return SequenceEqual(x.GroupList, y.GroupList) && PayloadsEqual(x.Payloads, y.Payloads);
+        }
+
+        private bool ServerCloseMessageEqual(ServerCloseMessage x, ServerCloseMessage y)
+        {
+            return StringEqual(x.ErrorMessage, y.ErrorMessage);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -159,6 +159,10 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["messagepack"] = new byte[] {7, 8, 1, 2, 3, 4, 5, 6}
                     }),
                 binary: "kw6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBg=="),
+            new ProtocolTestData(
+                name: "ServerClose",
+                message: new ServerCloseMessage("Message count reach limit: 100000"),
+                binary: "kg/ZIU1lc3NhZ2UgY291bnQgcmVhY2ggbGltaXQ6IDEwMDAwMA=="),
         }.ToDictionary(t => t.Name);
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -161,8 +161,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 binary: "kw6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBg=="),
             new ProtocolTestData(
                 name: "ServerClose",
-                message: new ServerCloseMessage("Message count reach limit: 100000"),
-                binary: "kg/ZIU1lc3NhZ2UgY291bnQgcmVhY2ggbGltaXQ6IDEwMDAwMA=="),
+                message: new ServerCloseMessage("Maximum message count limit reached: 100000"),
+                binary: "kg/ZK01heGltdW0gbWVzc2FnZSBjb3VudCBsaW1pdCByZWFjaGVkOiAxMDAwMDA="),
         }.ToDictionary(t => t.Name);
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -160,8 +160,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     }),
                 binary: "kw6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBg=="),
             new ProtocolTestData(
-                name: "ServerClose",
-                message: new ServerCloseMessage("Maximum message count limit reached: 100000"),
+                name: "ServiceError",
+                message: new ServiceErrorMessage("Maximum message count limit reached: 100000"),
                 binary: "kg/ZK01heGltdW0gbWVzc2FnZSBjb3VudCBsaW1pdCByZWFjaGVkOiAxMDAwMDA="),
         }.ToDictionary(t => t.Name);
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -141,6 +141,26 @@ namespace Microsoft.Azure.SignalR.Tests
         }
 
         [Fact]
+        public async Task ThrowingExceptionAfterServerCloseMessage()
+        {
+            var proxy = new ServiceConnectionProxy();
+
+            var serverTask = proxy.WaitForServerConnectionAsync(1);
+            _ = proxy.StartAsync();
+            await serverTask.OrTimeout();
+
+            string errorMessage = "Maximum message count limit reached: 100000";
+
+            await proxy.WriteMessageAsync(new ServerCloseMessage(errorMessage));
+            await Task.Delay(200);
+
+            var serviceConnection = proxy.ServiceConnection;
+            var excption = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                serviceConnection.WriteAsync(new ConnectionDataMessage("1", null)));
+            Assert.Equal(errorMessage, excption.Message);
+        }
+
+        [Fact]
         public async Task WritingMessagesFromConnectionGetsSentAsConnectionData()
         {
             var proxy = new ServiceConnectionProxy();

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.SignalR.Tests
         }
 
         [Fact]
-        public async Task ThrowingExceptionAfterServerCloseMessage()
+        public async Task ThrowingExceptionAfterServiceErrorMessage()
         {
             var proxy = new ServiceConnectionProxy();
 
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
             string errorMessage = "Maximum message count limit reached: 100000";
 
-            await proxy.WriteMessageAsync(new ServerCloseMessage(errorMessage));
+            await proxy.WriteMessageAsync(new ServiceErrorMessage(errorMessage));
             await Task.Delay(200);
 
             var serviceConnection = proxy.ServiceConnection;


### PR DESCRIPTION
* As customer can't get any error messages when service terminate the server connections now, it will be very confusing when service reach message limit. Under that circumstance, server will keep reconnecting without any useful reasons.
* ServerCloseMessage is used to send back error messages from service before service abort the connection. There are some changes in service to enable the workflow and in SDK, we just log these error messages.
* This is not a breaking change, old sdk can work with new service and vice versa.