### PR TITLE
Improve keep alive ping reliability

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnectionBase.cs
@@ -16,11 +16,12 @@ namespace Microsoft.Azure.SignalR
     internal abstract class ServiceConnectionBase : IServiceConnection
     {
         private static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(15);
-        // Service ping rate is 15 sec; this is 2 times that.
+        // Service ping rate is 5 sec. Set timeout for 30 sec for some space.
         private static readonly TimeSpan DefaultServiceTimeout = TimeSpan.FromSeconds(30);
         private static readonly long DefaultServiceTimeoutTicks = DefaultServiceTimeout.Seconds * Stopwatch.Frequency;
-        // App server ping rate is 5 sec. So service can detect an irresponsive server connection in 10 seconds at most.
+        // App server ping rate is 5 sec. Tigger by incoming requests and send by checking last send timestamp.
         private static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(5);
+        private static readonly long DefaultKeepAliveTicks = DefaultKeepAliveInterval.Seconds * Stopwatch.Frequency;
         private static readonly int MaxReconnectBackoffInternalInMilliseconds = 1000;
 
         // Start reconnect after a random interval less than 1 second
@@ -39,7 +40,10 @@ namespace Microsoft.Azure.SignalR
         protected readonly string _connectionId;
 
         private bool _isStopped;
+        // Check service timeout
         private long _lastReceiveTimestamp;
+        // Keep-alive tick
+        private long _lastSendTimestamp;
         private volatile bool _isConnected;
         protected ConnectionContext _connection;
         protected string ErrorMessage;
@@ -322,6 +326,9 @@ namespace Microsoft.Azure.SignalR
 
                             UpdateReceiveTimestamp();
 
+                            // No matter what kind of message come in, trigger send ping check
+                            await TrySendPingAsync();
+
                             while (_serviceProtocol.TryParseMessage(ref buffer, out var message))
                             {
                                 _ = DispatchMessageAsync(message);
@@ -399,6 +406,7 @@ namespace Microsoft.Azure.SignalR
             Log.StartingKeepAliveTimer(_logger, DefaultKeepAliveInterval);
 
             _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+            _lastSendTimestamp = Stopwatch.GetTimestamp();
             var timer = new TimerAwaitable(DefaultKeepAliveInterval, DefaultKeepAliveInterval);
             _ = KeepAliveAsync(timer);
 
@@ -424,9 +432,6 @@ namespace Microsoft.Azure.SignalR
                         // We shouldn't get here twice.
                         continue;
                     }
-
-                    // Send PingMessage to Service
-                    await TrySendPingAsync();
                 }
             }
         }
@@ -441,8 +446,13 @@ namespace Microsoft.Azure.SignalR
 
             try
             {
-                await _connection.Transport.Output.WriteAsync(_cachedPingBytes);
-                Log.SentPing(_logger);
+                // Check if last send time is longer than default keep-alive ticks and then send ping
+                if (Stopwatch.GetTimestamp() - Interlocked.Read(ref _lastSendTimestamp) > DefaultKeepAliveTicks)
+                {
+                    await _connection.Transport.Output.WriteAsync(_cachedPingBytes);
+                    Interlocked.Exchange(ref _lastSendTimestamp, Stopwatch.GetTimestamp());
+                    Log.SentPing(_logger);
+                }
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -220,12 +220,20 @@ namespace Microsoft.Azure.SignalR.Tests
             _ = proxy.StartAsync();
             await serverTask.OrTimeout();
 
-            // Check more than once since it happens periodically
-            for (int i = 0; i < 2; i++)
-            {
-                await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 6000);
-            }
+            // Wait 5 sec and receive ping
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            await proxy.WriteMessageAsync(new PingMessage());
 
+            // Check server PingMessage will send after reveive service PingMessage
+            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 500);
+
+            // Wait another 5 sec and recived connection message will also trigger ping
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            await proxy.WriteMessageAsync(new OpenConnectionMessage("1", null));
+
+            // Check server PingMessage will send after reveive service PingMessage
+            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 500);
+            
             proxy.Stop();
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -225,14 +225,14 @@ namespace Microsoft.Azure.SignalR.Tests
             await proxy.WriteMessageAsync(new PingMessage());
 
             // Check server PingMessage will send after reveive service PingMessage
-            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 500);
+            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input);
 
             // Wait another 5 sec and recived connection message will also trigger ping
             await Task.Delay(TimeSpan.FromSeconds(5));
             await proxy.WriteMessageAsync(new OpenConnectionMessage("1", null));
 
             // Check server PingMessage will send after reveive service PingMessage
-            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input, 500);
+            await ReadServiceMessageAsync<PingMessage>(proxy.ConnectionContext.Application.Input);
             
             proxy.Stop();
         }


### PR DESCRIPTION
Change ping trigger way by any incoming requests and send ping if it's longer than 5 seconds since last.
Service ping interval is updating to 5 seconds already.