### PR TITLE
Simplify channel logic and fix bug

### DIFF
--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/Infrastructure/TestTransport.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/Infrastructure/TestTransport.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 {
     public class TestTransport : IServiceTransport
     {
+        private readonly TaskCompletionSource<object> _lifetimeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public long MessageCount = 0;
         public Func<string, Task> Received { get; set; }
         public Func<Task> Connected { get; set; }
@@ -21,9 +23,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             return Task.FromResult<string>(null);
         }
 
-        public void OnDisconnected()
-        {
-        }
+        public void OnDisconnected() => _lifetimeTcs.TrySetResult(null);
 
         public void OnReceived(string value)
         {
@@ -39,6 +39,11 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         public Task Send(object value)
         {
             return Task.CompletedTask;
+        }
+
+        public Task WaitOnDisconnected()
+        {
+            return _lifetimeTcs.Task;
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     // Validate in transport for 1000 data messages.
                     _clientConnectionManager.CurrentTransports.TryGetValue(clientConnection, out var transport);
                     Assert.NotNull(transport);
+                    await transport.WaitOnDisconnected();
                     Assert.Equal(transport.MessageCount, count);
                 }
             }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     // Validate in transport for 1000 data messages.
                     _clientConnectionManager.CurrentTransports.TryGetValue(clientConnection, out var transport);
                     Assert.NotNull(transport);
-                    await transport.WaitOnDisconnected();
+                    await transport.WaitOnDisconnected().OrTimeout();
                     Assert.Equal(transport.MessageCount, count);
                 }
             }


### PR DESCRIPTION
In normal case, close connection message is the last message in channel to process and no need to wait application task anymore.
In abnormal case, loop break for channel exception/cleanup connections, no need to wait for application task as well.