### PR TITLE
Add fallback to GetPrimaryEndpoints when all primary endpoints are offline

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/NegotiateHandler.cs
@@ -58,7 +58,17 @@ namespace Microsoft.Azure.SignalR.AspNet
             var owinContext = new OwinContext(context.Environment);
             var claims = BuildClaims(owinContext, context.Request);
 
-            var provider = _endpointManager.GetEndpointProvider(_router.GetNegotiateEndpoint(_endpointManager.GetPrimaryEndpoints()));
+            IServiceEndpointProvider provider;
+            try
+            {
+                provider = _endpointManager.GetEndpointProvider(_router.GetNegotiateEndpoint(_endpointManager.GetPrimaryEndpoints()));
+            }
+            catch (AzureSignalRNotConnectedException e)
+            {
+                Log.NegotiateFailed(_logger, e.Message);
+                context.Response.StatusCode = 500;
+                return context.Response.End(e.Message);
+            }
 
             // Redirect to Service
             // TODO: add OriginalPaht and QueryString when the clients support it

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/DefaultRouter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/DefaultRouter.cs
@@ -2,44 +2,46 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Azure.SignalR
 {
     internal class DefaultRouter : IEndpointRouter
     {
-        public ServiceEndpoint GetNegotiateEndpoint(IReadOnlyList<ServiceEndpoint> primaryEndpoints)
+        public ServiceEndpoint GetNegotiateEndpoint(IEnumerable<ServiceEndpoint> primaryEndpoints)
         {
             // get primary endpoints snapshot
-            return primaryEndpoints[StaticRandom.Next(primaryEndpoints.Count)];
+            var endpoints = primaryEndpoints.ToArray();
+            return endpoints[StaticRandom.Next(endpoints.Length)];
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForBroadcast(IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForBroadcast(IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             // broadcast to all the endpoints
             return availableEnpoints;
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForUser(string userId, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForUser(string userId, IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             return availableEnpoints;
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             return availableEnpoints;
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForGroup(string groupName, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForGroup(string groupName, IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             return availableEnpoints;
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             return availableEnpoints;
         }
 
-        public IReadOnlyList<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+        public IEnumerable<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IEnumerable<ServiceEndpoint> availableEnpoints)
         {
             // broadcast to all the endpoints and service side to do the filter
             return availableEnpoints;

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -24,6 +24,15 @@ namespace Microsoft.Azure.SignalR
 
         internal int? Port { get; }
 
+        internal IServiceConnectionContainer Connection { get; set; }
+
+        /// <summary>
+        /// Connection == null means no service connection to this endpoint is yet initialized
+        /// When no connection is yet initialized, we consider the endpoint as Online for now, for compatable with current /negotiate behavior
+        /// TODO: improve /negotiate behavior when the server-connection is being established
+        /// </summary>
+        internal bool Online => Connection == null || Connection.Status == ServiceConnectionStatus.Connected;
+
         public ServiceEndpoint(string key, string connectionString) : this(connectionString)
         {
             if (!string.IsNullOrEmpty(key))

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -12,10 +12,9 @@ namespace Microsoft.Azure.SignalR
 {
     internal abstract class ServiceEndpointManagerBase : IServiceEndpointManager
     {
-        private readonly ServiceEndpoint[] _primaryEndpoints;
         private readonly ILogger _logger;
 
-        protected ServiceEndpoint[] Endpoints { get; }
+        public ServiceEndpoint[] Endpoints { get; }
 
         public ServiceEndpointManagerBase(IServiceEndpointOptions options, ILogger logger) 
             : this(GetEndpoints(options).ToArray(), logger)
@@ -47,9 +46,7 @@ namespace Microsoft.Azure.SignalR
 
                 Endpoints = groupedEndpoints.ToArray();
 
-                _primaryEndpoints = Endpoints.Where(s => s.EndpointType == EndpointType.Primary).ToArray();
-
-                if (_primaryEndpoints.Length == 0)
+                if (!Endpoints.Any(s => s.EndpointType == EndpointType.Primary))
                 {
                     throw new AzureSignalRNoPrimaryEndpointException();
                 }
@@ -58,18 +55,36 @@ namespace Microsoft.Azure.SignalR
 
         public abstract IServiceEndpointProvider GetEndpointProvider(ServiceEndpoint endpoint);
 
-        public IReadOnlyList<ServiceEndpoint> GetAvailableEndpoints()
+        public virtual IReadOnlyList<ServiceEndpoint> GetAvailableEndpoints()
         {
-            return Endpoints;
+            return Endpoints.Where(s => s.Online).ToArray();
         }
 
         /// <summary>
         /// Only primary endpoints will be returned by client /negotiate
+        /// If no primary endpoint is available, promote one secondary endpoint
         /// </summary>
-        /// <returns></returns>
-        public IReadOnlyList<ServiceEndpoint> GetPrimaryEndpoints()
+        /// <returns>The availbale endpoints</returns>
+        public virtual IReadOnlyList<ServiceEndpoint> GetPrimaryEndpoints()
         {
-            return _primaryEndpoints;
+            var endpoints = GetAvailableEndpoints().Where(s => s.EndpointType == EndpointType.Primary).ToArray();
+            if (endpoints.Length == 0)
+            {
+                var endpoint = GetAvailableEndpoints().FirstOrDefault(s => s.EndpointType == EndpointType.Secondary);
+                if (endpoint != null)
+                {
+                    // Return this secondary endpoint for negotiate, so that negotiate returns this endpoint to the client
+                    // Client will then connect to that secondary endpoint, and if that secondary endpoint has primary connections connected to it, it succeeds
+                    Log.SecondaryEndpointPromoted(_logger, endpoint.Endpoint);
+                    return new ServiceEndpoint[] { endpoint };
+                }
+                else
+                {
+                    throw new AzureSignalRNotConnectedException();
+                }
+            }
+
+            return endpoints;
         }
 
         private static IEnumerable<ServiceEndpoint> GetEndpoints(IServiceEndpointOptions options)
@@ -104,9 +119,17 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, int, string, string, Exception> _duplicateEndpointFound =
                 LoggerMessage.Define<int, string, string>(LogLevel.Warning, new EventId(1, "DuplicateEndpointFound"), "{count} endpoint to {endpoint} found, use the one {name}");
 
+            private static readonly Action<ILogger, string, Exception> _secondaryEndpointPromoted =
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(2, "SecondaryEndpointPromoted"), "All primary endpoints are offline. Promote secondary endpoint: {endpoint}");
+
             public static void DuplicateEndpointFound(ILogger logger, int count, string endpoint, string name)
             {
                 _duplicateEndpointFound(logger, count, endpoint, name, null);
+            }
+
+            public static void SecondaryEndpointPromoted(ILogger logger, string endpoint)
+            {
+                _secondaryEndpointPromoted(logger, endpoint, null);
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/Exceptions/ServiceConnectionNotActiveException.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Exceptions/ServiceConnectionNotActiveException.cs
@@ -9,11 +9,18 @@ namespace Microsoft.Azure.SignalR.Common
     [Serializable]
     public class ServiceConnectionNotActiveException : AzureSignalRException
     {
+        public string Endpoint { get; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceConnectionNotActiveException"/> class.
         /// </summary>
         public ServiceConnectionNotActiveException() : base("The connection is not active, data cannot be sent to the service.")
         {
+        }
+
+        public ServiceConnectionNotActiveException(string endpoint) : base($"The connection is not active, data cannot be sent to the service: {endpoint}.")
+        {
+            Endpoint = endpoint;
         }
 
         /// <summary>
@@ -26,6 +33,13 @@ namespace Microsoft.Azure.SignalR.Common
         protected ServiceConnectionNotActiveException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            Endpoint = info.GetString("Endpoint");
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("Endpoint", Endpoint);
+            base.GetObjectData(info, context);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IEndpointRouter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IEndpointRouter.cs
@@ -15,18 +15,18 @@ namespace Microsoft.Azure.SignalR
         /// </summary>
         /// <param name="primaryEndpoints"></param>
         /// <returns></returns>
-        ServiceEndpoint GetNegotiateEndpoint(IReadOnlyList<ServiceEndpoint> primaryEndpoints);
+        ServiceEndpoint GetNegotiateEndpoint(IEnumerable<ServiceEndpoint> primaryEndpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForBroadcast(IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForBroadcast(IEnumerable<ServiceEndpoint> availableEnpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForUser(string userId, IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForUser(string userId, IEnumerable<ServiceEndpoint> availableEnpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IEnumerable<ServiceEndpoint> availableEnpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForGroup(string groupName, IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForGroup(string groupName, IEnumerable<ServiceEndpoint> availableEnpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IEnumerable<ServiceEndpoint> availableEnpoints);
 
-        IReadOnlyList<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IReadOnlyList<ServiceEndpoint> availableEnpoints);
+        IEnumerable<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IEnumerable<ServiceEndpoint> availableEnpoints);
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Azure.SignalR
         Task StopAsync();
 
         ServiceConnectionStatus Status { get; }
+
+        Task ConnectionInitializedTask { get; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointManager.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Azure.SignalR
         IReadOnlyList<ServiceEndpoint> GetAvailableEndpoints();
 
         IReadOnlyList<ServiceEndpoint> GetPrimaryEndpoints();
+
+        ServiceEndpoint[] Endpoints { get; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointManager.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.SignalR
     {
         IServiceEndpointProvider GetEndpointProvider(ServiceEndpoint endpoint);
 
-        IReadOnlyList<ServiceEndpoint> GetAvailableEndpoints();
+        IEnumerable<ServiceEndpoint> GetAvailableEndpoints();
 
-        IReadOnlyList<ServiceEndpoint> GetPrimaryEndpoints();
+        IEnumerable<ServiceEndpoint> GetPrimaryEndpoints();
 
         ServiceEndpoint[] Endpoints { get; }
     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Azure.SignalR
             _endpointManager = endpointManager ?? throw new ArgumentNullException(nameof(endpointManager));
             _logger = loggerFactory?.CreateLogger<MultiEndpointServiceConnectionContainer>() ?? NullLogger<MultiEndpointServiceConnectionContainer>.Instance;
 
-            var endpoints = endpointManager.GetAvailableEndpoints();
+            var endpoints = endpointManager.Endpoints;
 
-            if (endpoints.Count == 1)
+            if (endpoints.Length == 1)
             {
                 _inner = generator(endpoints[0]);
             }
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.SignalR
             var connectionFactory = new ConnectionFactory(hub, provider, loggerFactory);
             if (endpoint.EndpointType == EndpointType.Primary)
             {
-                return new StrongServiceConnectionContainer(serviceConnectionFactory, connectionFactory, count);
+                return new StrongServiceConnectionContainer(serviceConnectionFactory, connectionFactory, count, endpoint);
             }
             else
             {
-                return new WeakServiceConnectionContainer(serviceConnectionFactory, connectionFactory, count);
+                return new WeakServiceConnectionContainer(serviceConnectionFactory, connectionFactory, count, endpoint);
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -91,9 +91,9 @@ namespace Microsoft.Azure.SignalR
             }
 
             // re-evaluate availbale endpoints as they might be offline, however it can not guarantee that all endpoints are online
-            var routed = GetRoutedEndpoints(serviceMessage, _endpointManager.GetAvailableEndpoints());
+            var routed = GetRoutedEndpoints(serviceMessage, _endpointManager.GetAvailableEndpoints()).ToArray();
 
-            if (routed.Count == 0)
+            if (routed.Length == 0)
             {
                 throw new AzureSignalRNotConnectedException();
             }
@@ -108,9 +108,9 @@ namespace Microsoft.Azure.SignalR
                 return _inner.WriteAsync(serviceMessage);
             }
 
-            var routed = GetRoutedEndpoints(serviceMessage, _endpointManager.GetAvailableEndpoints());
+            var routed = GetRoutedEndpoints(serviceMessage, _endpointManager.GetAvailableEndpoints()).ToArray();
 
-            if (routed.Count == 0)
+            if (routed.Length == 0)
             {
                 throw new AzureSignalRNotConnectedException();
             }
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.SignalR
             return Task.WhenAll(routed.Select(s => Connections[s]).Select(s => s.WriteAsync(serviceMessage)));
         }
 
-        private IReadOnlyList<ServiceEndpoint> GetRoutedEndpoints(ServiceMessage message, IReadOnlyList<ServiceEndpoint> availableEndpoints)
+        private IEnumerable<ServiceEndpoint> GetRoutedEndpoints(ServiceMessage message, IEnumerable<ServiceEndpoint> availableEndpoints)
         {
             switch (message)
             {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.SignalR
 
         public ServiceConnectionStatus Status { get; private set; }
 
-        public Task WaitForConnectionStart => _serviceConnectionStartTcs.Task;
+        public Task ConnectionInitializedTask => _serviceConnectionStartTcs.Task;
 
         public ServiceConnectionBase(IServiceProtocol serviceProtocol, ILogger logger, string connectionId, IServiceConnectionManager serviceConnectionManager, ServerConnectionType connectionType)
         {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.SignalR
 {
     abstract class ServiceConnectionContainerBase : IServiceConnectionContainer, IServiceConnectionManager
     {
+        private readonly ServiceEndpoint _endpoint;
+
         protected readonly IServiceConnectionFactory ServiceConnectionFactory;
         protected readonly IConnectionFactory ConnectionFactory;
         protected readonly List<IServiceConnection> FixedServiceConnections;
@@ -18,26 +20,37 @@ namespace Microsoft.Azure.SignalR
 
         protected ServiceConnectionContainerBase(IServiceConnectionFactory serviceConnectionFactory,
             IConnectionFactory connectionFactory,
-            int fixedConnectionCount)
+            int fixedConnectionCount, ServiceEndpoint endpoint)
         {
             ServiceConnectionFactory = serviceConnectionFactory;
             ConnectionFactory = connectionFactory;
             FixedServiceConnections = CreateFixedServiceConnection(fixedConnectionCount);
             FixedConnectionCount = fixedConnectionCount;
+            _endpoint = endpoint;
         }
 
         protected ServiceConnectionContainerBase(IServiceConnectionFactory serviceConnectionFactory,
-            IConnectionFactory connectionFactory, List<IServiceConnection> initialConnections)
+            IConnectionFactory connectionFactory, List<IServiceConnection> initialConnections, ServiceEndpoint endpoint)
         {
             ServiceConnectionFactory = serviceConnectionFactory;
             ConnectionFactory = connectionFactory;
             FixedServiceConnections = initialConnections;
             FixedConnectionCount = initialConnections.Count;
+            _endpoint = endpoint;
         }
 
-        public virtual Task StartAsync()
+        public async Task StartAsync()
         {
-            return Task.WhenAll(FixedServiceConnections.Select(c => c.StartAsync()));
+            var tasks = FixedServiceConnections.Select(c => c.StartAsync());
+            await Task.WhenAny(FixedServiceConnections.Select(s => s.ConnectionInitializedTask));
+
+            // Set the endpoint connection after one connection is initialized
+            if (_endpoint != null)
+            {
+                _endpoint.Connection = this;
+            }
+
+            await Task.WhenAll(tasks);
         }
 
         /// <summary>
@@ -57,7 +70,7 @@ namespace Microsoft.Azure.SignalR
 
         public abstract void DisposeServiceConnection(IServiceConnection connection);
 
-        public virtual ServiceConnectionStatus Status => throw new NotSupportedException();
+        public ServiceConnectionStatus Status => GetStatus();
 
         public Task WriteAsync(ServiceMessage serviceMessage)
         {
@@ -73,6 +86,13 @@ namespace Microsoft.Azure.SignalR
             }
 
             return WriteToPartitionedConnection(partitionKey, serviceMessage);
+        }
+
+        protected virtual ServiceConnectionStatus GetStatus()
+        {
+            return FixedServiceConnections.Any(s => s.Status == ServiceConnectionStatus.Connected)
+                ? ServiceConnectionStatus.Connected
+                : ServiceConnectionStatus.Disconnected;
         }
 
         private Task WriteToPartitionedConnection(string partitionKey, ServiceMessage serviceMessage)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -1,23 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR.Common.ServiceConnections
 {
-    class WeakServiceConnectionContainer : ServiceConnectionContainerBase
+    internal class WeakServiceConnectionContainer : ServiceConnectionContainerBase
     {
-        public WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory, 
-            IConnectionFactory connectionFactory, 
-            int fixedConnectionCount) : base(serviceConnectionFactory, connectionFactory, fixedConnectionCount)
+        public WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory,
+            IConnectionFactory connectionFactory, int fixedConnectionCount, ServiceEndpoint endpoint)
+            : base(serviceConnectionFactory, connectionFactory, fixedConnectionCount, endpoint)
         {
         }
 
         // For test purpose only
         internal WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory,
-            IConnectionFactory connectionFactory, List<IServiceConnection> initialConnections) : base(
-            serviceConnectionFactory, connectionFactory, initialConnections)
+            IConnectionFactory connectionFactory, List<IServiceConnection> initialConnections, ServiceEndpoint endpoint)
+            : base(serviceConnectionFactory, connectionFactory, initialConnections, endpoint)
         {
         }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         {
             _ = StartAsync();
 
-            await WaitForConnectionStart;
+            await ConnectionInitializedTask;
         }
 
         protected override async Task<ConnectionContext> CreateConnection(string target = null)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -135,11 +135,11 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     Assert.Equal(4, options.Value.Endpoints.Length);
 
                     var manager = hubConfig.Resolver.Resolve<IServiceEndpointManager>();
-                    var endpoints = manager.GetAvailableEndpoints();
-                    Assert.Equal(4, endpoints.Count);
+                    var endpoints = manager.GetAvailableEndpoints().ToArray();
+                    Assert.Equal(4, endpoints.Length);
 
-                    endpoints = manager.GetPrimaryEndpoints();
-                    Assert.Equal(4, endpoints.Count);
+                    endpoints = manager.GetPrimaryEndpoints().ToArray();
+                    Assert.Equal(4, endpoints.Length);
                 }
             }
         }
@@ -168,11 +168,11 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     Assert.Equal(3, options.Value.Endpoints.Length);
 
                     var manager = hubConfig.Resolver.Resolve<IServiceEndpointManager>();
-                    var endpoints = manager.GetAvailableEndpoints();
-                    Assert.Equal(4, endpoints.Count);
+                    var endpoints = manager.GetAvailableEndpoints().ToArray();
+                    Assert.Equal(4, endpoints.Length);
 
-                    endpoints = manager.GetPrimaryEndpoints();
-                    Assert.Equal(3, endpoints.Count);
+                    endpoints = manager.GetPrimaryEndpoints().ToArray();
+                    Assert.Equal(3, endpoints.Length);
                 }
             }
         }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
@@ -302,6 +302,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
             public ServiceConnectionStatus Status => ServiceConnectionStatus.Connected;
 
+            public Task ConnectionInitializedTask => Task.CompletedTask;
+
             public TestServiceConnection(string name, Action<(ServiceMessage, IServiceConnectionContainer)> validator)
             {
                 _validator = validator;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Azure.SignalR.Tests
                 new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "11"),
                 new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "12")
                 );
-            var endpoints = sem.GetAvailableEndpoints();
-            Assert.Equal(2, endpoints.Count);
+            var endpoints = sem.GetAvailableEndpoints().ToArray();
+            Assert.Equal(2, endpoints.Length);
             Assert.Equal("1", endpoints[0].Name);
             Assert.Equal("11", endpoints[1].Name);
 
-            var primaryEndpoints = sem.GetPrimaryEndpoints();
-            Assert.Equal(1, primaryEndpoints.Count);
+            var primaryEndpoints = sem.GetPrimaryEndpoints().ToArray();
+            Assert.Single(primaryEndpoints);
             Assert.Equal("1", primaryEndpoints[0].Name);
 
             var router = new TestEndpointRouter(false);
@@ -63,13 +63,13 @@ namespace Microsoft.Azure.SignalR.Tests
                 new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "11"),
                 new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "12")
                 );
-            var endpoints = sem.GetAvailableEndpoints();
-            Assert.Equal(2, endpoints.Count);
+            var endpoints = sem.GetAvailableEndpoints().ToArray();
+            Assert.Equal(2, endpoints.Length);
             Assert.Equal("1", endpoints[0].Name);
             Assert.Equal("11", endpoints[1].Name);
 
-            var primaryEndpoints = sem.GetPrimaryEndpoints();
-            Assert.Equal(1, primaryEndpoints.Count);
+            var primaryEndpoints = sem.GetPrimaryEndpoints().ToArray();
+            Assert.Single(primaryEndpoints);
             Assert.Equal("1", primaryEndpoints[0].Name);
 
             var router = new TestEndpointRouter(false);
@@ -82,13 +82,13 @@ namespace Microsoft.Azure.SignalR.Tests
             // All the connections started
             _ = container.StartAsync();
 
-            endpoints = sem.GetAvailableEndpoints();
-            Assert.Equal(2, endpoints.Count);
+            endpoints = sem.GetAvailableEndpoints().ToArray();
+            Assert.Equal(2, endpoints.Length);
             Assert.Equal("1", endpoints[0].Name);
             Assert.Equal("11", endpoints[1].Name);
 
-            primaryEndpoints = sem.GetPrimaryEndpoints();
-            Assert.Equal(1, primaryEndpoints.Count);
+            primaryEndpoints = sem.GetPrimaryEndpoints().ToArray();
+            Assert.Single(primaryEndpoints);
             Assert.Equal("1", primaryEndpoints[0].Name);
             Assert.Equal(2, container.Connections.Count);
         }
@@ -392,7 +392,7 @@ namespace Microsoft.Azure.SignalR.Tests
             endpoints = sem.GetPrimaryEndpoints();
             Assert.Single(endpoints);
 
-            Assert.Equal("online", endpoints[0].Name);
+            Assert.Equal("online", endpoints.First().Name);
         }
 
         private IServiceConnection CreateServiceConnection(ServerConnectionType type, IConnectionFactory factory)
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 _broken = broken;
             }
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForBroadcast(IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForBroadcast(IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -434,7 +434,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForBroadcast(availableEnpoints);
             }
 
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -444,7 +444,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForConnection(connectionId, availableEnpoints);
             }
 
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForGroup(string groupName, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForGroup(string groupName, IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -454,7 +454,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForGroup(groupName, availableEnpoints);
             }
 
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForGroups(IReadOnlyList<string> groupList, IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -464,7 +464,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForGroups(groupList, availableEnpoints);
             }
 
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForUser(string userId, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForUser(string userId, IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForUser(userId, availableEnpoints);
             }
 
-            public IReadOnlyList<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IReadOnlyList<ServiceEndpoint> availableEnpoints)
+            public IEnumerable<ServiceEndpoint> GetEndpointsForUsers(IReadOnlyList<string> userList, IEnumerable<ServiceEndpoint> availableEnpoints)
             {
                 if (_broken)
                 {
@@ -484,7 +484,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 return _inner.GetEndpointsForUsers(userList, availableEnpoints);
             }
 
-            public ServiceEndpoint GetNegotiateEndpoint(IReadOnlyList<ServiceEndpoint> primaryEndpoints)
+            public ServiceEndpoint GetNegotiateEndpoint(IEnumerable<ServiceEndpoint> primaryEndpoints)
             {
                 if (_broken)
                 {

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerFacts.cs
@@ -2,28 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.IO.Pipelines;
-using System.Net;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
-using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests
 {
-    public class ServiceConnectionContainerFacts
+    public partial class ServiceConnectionContainerFacts
     {
         private static readonly ServiceProtocol Protocol = new ServiceProtocol();
 
         [Fact]
         public async Task TestServiceConnectionContainerWithAllConnectedSucceeeds()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(),
                 new TestServiceConnection(),
                 new TestServiceConnection(),
@@ -41,7 +35,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task TestServiceConnectionContainerWithAllDisconnectedThrows()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -63,7 +57,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task TestServiceConnectionContainerWithAllThrowsThrows()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
@@ -85,7 +79,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task TestServiceConnectionContainerWithSomeThrows1WriteWithPartitionCanPass()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
@@ -102,7 +96,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task TestServiceConnectionContainerWithSomeThrows2WriteWithPartitionCanPass()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(),
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
@@ -119,7 +113,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Fact]
         public async Task TestServiceConnectionContainerWithSomeThrows3WriteWithPartitionCanPass()
         {
-            var container = new StrongServiceConnectionContainer(null, null, new List<IServiceConnection> {
+            var container = new TestServiceConnectionContainer(new List<IServiceConnection> {
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(throws: true),
                 new TestServiceConnection(),
@@ -136,6 +130,8 @@ namespace Microsoft.Azure.SignalR.Tests
         private sealed class TestServiceConnection : IServiceConnection
         {
             public ServiceConnectionStatus Status { get; }
+
+            public Task ConnectionInitializedTask => Task.CompletedTask;
 
             private readonly bool _throws;
             public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected, bool throws = false)

--- a/test/Microsoft.Azure.SignalR.Common.Tests/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/TestServiceConnectionContainer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    internal sealed class TestServiceConnectionContainer : ServiceConnectionContainerBase
+    {
+        public TestServiceConnectionContainer(List<IServiceConnection> serviceConnections, ServiceEndpoint endpoint = null) : base(null, null, serviceConnections, endpoint)
+        {
+        }
+
+        public override IServiceConnection CreateServiceConnection()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DisposeServiceConnection(IServiceConnection connection)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override IServiceConnection CreateServiceConnectionCore()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -189,8 +190,8 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.Equal(SecondaryValue, options.Endpoints[2].ConnectionString);
 
             var endpointManager = serviceProvider.GetRequiredService<IServiceEndpointManager>();
-            var endpoints = endpointManager.GetAvailableEndpoints();
-            Assert.Equal(3, options.Endpoints.Length);
+            var endpoints = endpointManager.GetAvailableEndpoints().ToArray();
+            Assert.Equal(3, endpoints.Length);
             Assert.Equal(EndpointType.Primary, endpoints[0].EndpointType);
             Assert.Equal(DefaultValue, endpoints[0].ConnectionString);
             Assert.Equal(EndpointType.Primary, endpoints[1].EndpointType);

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.SignalR.Tests
             ServiceConnectionContainer = new StrongServiceConnectionContainer(null, connectionFactory, new List<IServiceConnection>()
             {
                 ServiceConnection
-            });
+            }, new ServiceEndpoint("", ""));
         }
 
         public Task StartAsync()


### PR DESCRIPTION
When `connection` is null, consider it as `online` to be compatible with current behavior. 

TODO:
- [ ] 1. Add a mechanism for `/negotiate` to wait or throw when the connection is initializing
- [ ] 2. Add UT to cover `/negotiate`