### PR TITLE
Fix the false warning for connectionstring

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -70,20 +70,26 @@ namespace Microsoft.Azure.SignalR
             var endpoints = options.Endpoints;
             var connectionString = options.ConnectionString;
 
-            // ConnectionString can be set by custom Csonfigure
+            // ConnectionString can be set by custom Configure
             // Return both the one from ConnectionString and from Endpoints
-            // TODO: Better way if Endpoints already contains ConnectionString one?
-            if (!string.IsNullOrEmpty(connectionString))
-            {
-                yield return new ServiceEndpoint(options.ConnectionString);
-            }
-
+            // when the one from connectionString is not included in Endpoints
+            var connectionStringIncluded = false;
             if (endpoints != null)
             {
                 foreach (var endpoint in endpoints)
                 {
+                    if (endpoint.ConnectionString == connectionString)
+                    {
+                        connectionStringIncluded = true;
+                    }
+
                     yield return endpoint;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(connectionString) && !connectionStringIncluded)
+            {
+                yield return new ServiceEndpoint(options.ConnectionString);
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -4,88 +4,114 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.Tests
 {
-    public class AddAzureSignalRFacts
+    public class AddAzureSignalRFacts : VerifiableLoggedTest
     {
         private const string CustomValue = "Endpoint=https://customconnectionstring;AccessKey=1";
         private const string DefaultValue = "Endpoint=https://defaultconnectionstring;AccessKey=1";
         private const string SecondaryValue = "Endpoint=https://secondaryconnectionstring;AccessKey=1";
 
+        public AddAzureSignalRFacts(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void AddAzureSignalRReadsDefaultConfigurationKeyForConnectionString()
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", DefaultValue}
-                })
-                .Build();
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR()
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+                    })
+                    .Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR()
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(DefaultValue, options.ConnectionString);
-            Assert.Equal(5, options.ConnectionCount);
-            Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
-            Assert.Null(options.ClaimsProvider);
+                Assert.Equal(DefaultValue, options.ConnectionString);
+                Assert.Equal(5, options.ConnectionCount);
+                Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
+                Assert.Null(options.ClaimsProvider);
+            }
         }
 
         [Fact]
         public void AddAzureUsesDefaultConnectionStringIfSpecifiedAndOptionsOverridden()
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", DefaultValue}
-                })
-                .Build();
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o => { o.ConnectionCount = 1; })
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+                    })
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                    {"Azure:SignalR:ConnectionString", CustomValue}
+                    })
+                    .Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o =>
+                    {
+                        o.ConnectionCount = 1;
+                    })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(DefaultValue, options.ConnectionString);
-            Assert.Equal(1, options.ConnectionCount);
-            Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
-            Assert.Null(options.ClaimsProvider);
+                Assert.Equal(CustomValue, options.ConnectionString);
+                Assert.Equal(1, options.ConnectionCount);
+                Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
+                Assert.Null(options.ClaimsProvider);
+            }
         }
 
         [Fact]
         public void AddAzureReadsConnectionStringFirst()
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", DefaultValue}
-                })
-                .Build();
-            string capturedConnectionString = null;
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o => { capturedConnectionString = o.ConnectionString; })
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+                    })
+                    .Build();
+                string capturedConnectionString = null;
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o => { capturedConnectionString = o.ConnectionString; })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(DefaultValue, options.ConnectionString);
-            Assert.Equal(DefaultValue, capturedConnectionString);
+                Assert.Equal(DefaultValue, options.ConnectionString);
+                Assert.Equal(DefaultValue, capturedConnectionString);
+            }
         }
 
         [Theory]
@@ -96,29 +122,33 @@ namespace Microsoft.Azure.SignalR.Tests
         public void AddAzureSignalRLoadConnectionStringOrder(string customValue, string defaultValue,
             string secondaryValue, string expected)
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", defaultValue},
                     {"ConnectionStrings:Azure:SignalR:ConnectionString", secondaryValue}
-                })
-                .Build();
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    if (customValue != null)
+                    })
+                    .Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o =>
                     {
-                        o.ConnectionString = customValue;
-                    }
-                })
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+                        if (customValue != null)
+                        {
+                            o.ConnectionString = customValue;
+                        }
+                    })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(expected, options.ConnectionString);
+                Assert.Equal(expected, options.ConnectionString);
+            }
         }
 
         [Theory]
@@ -129,75 +159,82 @@ namespace Microsoft.Azure.SignalR.Tests
         public void AddAzureSignalRReadServiceEndpointsFromConfig(string customValue, string defaultValue,
             string secondaryValue, string expected, int expectedCount)
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", defaultValue},
                     {"Azure:SignalR:ConnectionString:1:secondary", secondaryValue},
-                })
-                .Build();
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    if (customValue != null)
+                    })
+                    .Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o =>
                     {
-                        o.ConnectionString = customValue;
-                    }
-                })
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+                        if (customValue != null)
+                        {
+                            o.ConnectionString = customValue;
+                        }
+                    })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(expected, options.ConnectionString);
-            Assert.Equal(expectedCount, options.Endpoints.Length);
+                Assert.Equal(expected, options.ConnectionString);
+                Assert.Equal(expectedCount, options.Endpoints.Length);
+            }
         }
 
         [Fact]
         public void AddAzureSignalRCustomizeEndpointsOverridesConfigValue()
         {
-            var services = new ServiceCollection();
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
                     {"Azure:SignalR:ConnectionString", DefaultValue},
                     {"Azure:SignalR:ConnectionString:1:secondary", SecondaryValue},
-                })
-                .Build();
-            var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.Endpoints = new ServiceEndpoint[]
+                    })
+                    .Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o =>
                     {
+                        o.Endpoints = new ServiceEndpoint[]
+                        {
                         new ServiceEndpoint(CustomValue, EndpointType.Primary),
                         new ServiceEndpoint(CustomValue, EndpointType.Secondary),
                         new ServiceEndpoint(SecondaryValue, EndpointType.Secondary),
-                    };
-                })
-                .Services
-                .AddSingleton<IConfiguration>(config)
-                .AddLogging()
-                .BuildServiceProvider();
+                        };
+                    })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
 
-            var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-            Assert.Equal(DefaultValue, options.ConnectionString);
-            Assert.Equal(3, options.Endpoints.Length);
-            Assert.Equal(EndpointType.Primary, options.Endpoints[0].EndpointType);
-            Assert.Equal(CustomValue, options.Endpoints[0].ConnectionString);
-            Assert.Equal(SecondaryValue, options.Endpoints[2].ConnectionString);
+                Assert.Equal(DefaultValue, options.ConnectionString);
+                Assert.Equal(3, options.Endpoints.Length);
+                Assert.Equal(EndpointType.Primary, options.Endpoints[0].EndpointType);
+                Assert.Equal(CustomValue, options.Endpoints[0].ConnectionString);
+                Assert.Equal(SecondaryValue, options.Endpoints[2].ConnectionString);
 
-            var endpointManager = serviceProvider.GetRequiredService<IServiceEndpointManager>();
-            var endpoints = endpointManager.GetAvailableEndpoints().ToArray();
-            Assert.Equal(3, endpoints.Length);
-            Assert.Equal(EndpointType.Primary, endpoints[0].EndpointType);
-            Assert.Equal(DefaultValue, endpoints[0].ConnectionString);
-            Assert.Equal(EndpointType.Primary, endpoints[1].EndpointType);
-            Assert.Equal(CustomValue, endpoints[1].ConnectionString);
-            Assert.Equal(EndpointType.Secondary, endpoints[2].EndpointType);
-            Assert.Equal(SecondaryValue, endpoints[2].ConnectionString);
+                var endpointManager = serviceProvider.GetRequiredService<IServiceEndpointManager>();
+                var endpoints = endpointManager.GetAvailableEndpoints().ToArray();
+                Assert.Equal(3, endpoints.Length);
+                Assert.Equal(EndpointType.Primary, endpoints[0].EndpointType);
+                Assert.Equal(CustomValue, endpoints[0].ConnectionString);
+                Assert.Equal(EndpointType.Secondary, endpoints[1].EndpointType);
+                Assert.Equal(SecondaryValue, endpoints[1].ConnectionString);
+                Assert.Equal(EndpointType.Primary, endpoints[2].EndpointType);
+                Assert.Equal(DefaultValue, endpoints[2].ConnectionString);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
+++ b/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.SignalR\Microsoft.Azure.SignalR.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.SignalR.Common\Microsoft.Azure.SignalR.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.SignalR.Tests.Common\Microsoft.Azure.SignalR.Tests.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #439 

Fix false warning message
`2 endpoints to https://northstardevsignalr.service.signalr.net found, use the one https://northstardevsignalr.service.signalr.net`

This is caused when connection string is configured in Configuration, it is counted twice, both into `ConnectionString` and `Endpoints`