### PR TITLE
Consolidate the trace source for ASP.NET SignalR

### DIFF
--- a/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/Startup.cs
+++ b/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/Startup.cs
@@ -18,7 +18,6 @@ namespace AspNet.ChatSample.SelfHostServer
             // app.MapSignalR();
             app.UseCors(CorsOptions.AllowAll);
             app.MapAzureSignalR(GetType().FullName);
-            GlobalHost.TraceManager.Switch.Level = SourceLevels.Information;
         }
     }
 }

--- a/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/app.config
+++ b/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/app.config
@@ -4,6 +4,25 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
   <connectionStrings>
+    <!-- Add your connection string here -->
     <add name="Azure:SignalR:ConnectionString" connectionString=""/>
   </connectionStrings>
+  <system.diagnostics>
+    <sources>
+      <source name="Microsoft.Azure.SignalR" switchName="SignalRSwitch">
+        <listeners>
+          <add name="ASRS" />
+        </listeners>
+      </source>
+    </sources>
+    <!-- Sets the trace verbosity level -->
+    <switches>
+      <add name="SignalRSwitch" value="Information" />
+    </switches>
+    <!-- Specifies the trace writer for output -->
+    <sharedListeners>
+      <add name="ASRS" type="System.Diagnostics.TextWriterTraceListener" initializeData="asrs.log.txt" />
+    </sharedListeners>
+    <trace autoflush="true" />
+  </system.diagnostics>
 </configuration>


### PR DESCRIPTION
 to one single source `Microsoft.Azure.SignalR` so that it is easier to enable the trace. Also add a sample config in the sample project.

The Trace system in ASP.NET requires one to know the full name of the TraceSource to configure the trace settings. In our current design, the name of the TraceSource is the full name of the classes logging the trace. We also have logs from the underlying `HttpConnection`. As a result, users need a long list of TraceSource names to collect all the logs from our SDK.

This PR is to change the TraceSource name to `Microsoft.Azure.SignalR` and move the class name to the trace message so that it is easier to config.