### PR TITLE
Fix bug: If input null for loggerFactory, use default one in AddLogging()

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -47,8 +47,12 @@ namespace Microsoft.Azure.SignalR.Management
                         var serviceCollection = new ServiceCollection();
                         serviceCollection.AddSignalRCore();
 
+                        if (loggerFactory != null)
+                        {
+                            serviceCollection.AddSingleton(typeof(ILoggerFactory), loggerFactory);
+                        }
+
                         serviceCollection
-                            .AddSingleton(typeof(ILoggerFactory), loggerFactory)
                             .AddLogging()
                             .AddSingleton(typeof(HubLifetimeManager<>), typeof(WebSocketsHubLifetimeManager<>))
                             .AddSingleton(typeof(IServiceConnectionManager<>), typeof(ServiceConnectionManager<>))


### PR DESCRIPTION
#474 