### PR TITLE
handle hub connection closed event

### DIFF
--- a/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             IList<HubConnection> connections = null;
             try
             {
-                StrongBox<bool> closed = new StrongBox<bool>(false);
+                var closed = new StrongBox<bool>(false);
                 connections = await CreateAndStartClientConnections(clientEndpoint, clientAccessTokens);
                 HandleHubConnection(connections, closed);
                 ListenOnMessage(connections, receivedMessageDict);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
@@ -144,8 +144,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             IList<HubConnection> connections = null;
             try
             {
-                var closed = new StrongBox<bool>(false);
                 connections = await CreateAndStartClientConnections(clientEndpoint, clientAccessTokens);
+                var closed = new StrongBox<bool>(false);
                 HandleHubConnection(connections, closed);
                 ListenOnMessage(connections, receivedMessageDict);
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/E2ETest/ServiceHubContextE2EFacts.cs
@@ -143,10 +143,11 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         private static async Task RunTestCore(string clientEndpoint, IEnumerable<string> clientAccessTokens, Func<Task> coreTask, int expectedReceivedMessageCount, ConcurrentDictionary<int, int> receivedMessageDict)
         {
             IList<HubConnection> connections = null;
+            CancellationTokenSource cancellationTokenSource = null;
             try
             {
                 connections = await CreateAndStartClientConnections(clientEndpoint, clientAccessTokens);
-                var cancellationTokenSource = new CancellationTokenSource();
+                cancellationTokenSource = new CancellationTokenSource();
                 HandleHubConnection(connections, cancellationTokenSource);
                 ListenOnMessage(connections, receivedMessageDict);
 
@@ -163,6 +164,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             }
             finally
             {
+                cancellationTokenSource?.Dispose();
                 if (connections != null)
                 {
                     await Task.WhenAll(from connection in connections


### PR DESCRIPTION
some users may set the service mode to default mode, which will result in dropping client connections when the 1st message (including ping messages) reaches the service.

handle the hub connection closed event will indicate that the error probably caused by external env, e.g. the service is unavailable/ service mode is incorrect