### PR TITLE
Add back the option to disable application prefix for aspnet 

### DIFF
--- a/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/Program.cs
+++ b/samples/AspNet.ChatSample/AspNet.ChatSample.SelfHostServer/Program.cs
@@ -10,9 +10,15 @@ namespace AspNet.ChatSample.SelfHostServer
     {
         static void Main(string[] args)
         {
-            using (WebApp.Start<Startup>("http://localhost:8009"))
+            if (!(args.Length > 0 && int.TryParse(args[0], out var port)))
             {
-                Console.WriteLine("Server running at http://localhost:8009/");
+                port = 8009;
+            }
+
+            var url = $"http://localhost:{port}";
+            using (WebApp.Start<Startup>(url))
+            {
+                Console.WriteLine($"Server running at {url}");
                 Console.ReadLine();
             }
         }

--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         private readonly string _appName;
         private readonly int? _port;
         private readonly TimeSpan _accessTokenLifetime;
+        private readonly bool _isolateApp;
 
         public ServiceEndpointProvider(ServiceEndpoint endpoint, ServiceOptions options, TimeSpan? ttl = null)
         {
@@ -39,11 +40,17 @@ namespace Microsoft.Azure.SignalR.AspNet
             _endpoint = endpoint.Endpoint;
             _accessKey = endpoint.AccessKey;
             _appName = options.ApplicationName;
+            _isolateApp = options.IsolateApplication;
             _port = endpoint.Port;
         }
 
         private string GetPrefixedHubName(string applicationName, string hubName)
         {
+            if (!_isolateApp)
+            {
+                return hubName;
+            }
+
             return string.IsNullOrEmpty(applicationName) ? hubName.ToLower() : $"{applicationName.ToLower()}_{hubName.ToLower()}";
         }
 

--- a/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.SignalR.AspNet
 {
     internal class NegotiateMiddleware : OwinMiddleware
     {
-        private static readonly ProtocolResolver ProtocolResolver = new ProtocolResolver();
+        private static readonly string AssemblyVersion = typeof(NegotiateMiddleware).Assembly.GetName().Version.ToString();
 
         private readonly string _appName;
         private readonly Func<IOwinContext, IEnumerable<Claim>> _claimsProvider;
@@ -159,7 +160,7 @@ namespace Microsoft.Azure.SignalR.AspNet
 
             if (_isolateApp)
             {
-                yield return new Claim(Constants.ClaimType.IsolateApplication, "");
+                yield return new Claim(Constants.ClaimType.Version, AssemblyVersion);
             }
 
             foreach (var claim in claims)

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -56,11 +56,9 @@ namespace Microsoft.Azure.SignalR.AspNet
         public ServerStickyMode ServerStickyMode { get; set; }
 
         /// <summary>
-        /// Specifies if current app is isolated from others who has a different ApplicationName using the same Azure SignalR Service
-        /// The default value is false.
-        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updateds
+        /// TODO: delete it when runtime is ready, don't expose it to the customer
         /// </summary>
-        public bool IsolateApplication { get; set; }
+        internal bool IsolateApplication { get; set; } = false;
 
         public ServiceOptions()
         {

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -50,8 +50,17 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         /// <summary>
         /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
+        /// By default this mode is disabled
+        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updateds
         /// </summary>
         public ServerStickyMode ServerStickyMode { get; set; }
+
+        /// <summary>
+        /// Specifies if current app is isolated from others who has a different ApplicationName using the same Azure SignalR Service
+        /// The default value is false.
+        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updateds
+        /// </summary>
+        public bool IsolateApplication { get; set; }
 
         public ServiceOptions()
         {

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         /// <summary>
         /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
         /// By default this mode is disabled
-        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updateds
+        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updated
         /// </summary>
         public ServerStickyMode ServerStickyMode { get; set; }
 

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.SignalR
             public const string ServerStickyMode = AzureSignalRSysPrefix + "ssticky";
             public const string Id = AzureSignalRSysPrefix + "id";
             public const string AppName = AzureSignalRSysPrefix + "apn";
-            public const string IsolateApplication = AzureSignalRSysPrefix + "iapp";
+            public const string Version = AzureSignalRSysPrefix + "vn";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.SignalR
             public const string ServerStickyMode = AzureSignalRSysPrefix + "ssticky";
             public const string Id = AzureSignalRSysPrefix + "id";
             public const string AppName = AzureSignalRSysPrefix + "apn";
+            public const string IsolateApplication = AzureSignalRSysPrefix + "iapp";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.SignalR
 
         /// <summary>
         /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
+        /// NOTE: This feature is not available until May 13th when Azure SignalR Service is updated
         /// </summary>
         public ServerStickyMode ServerStickyMode { get; set; } = ServerStickyMode.Disabled;
     }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -414,6 +414,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     Assert.Equal("hello", user);
                     Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName));
                     Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode));
+                    Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Version));
                     var requestId = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Id);
                     Assert.NotNull(requestId);
                     Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
@@ -432,6 +433,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 hubConfiguration.Resolver.Register(typeof(IServerNameProvider), () => serverNameProvider);
                 using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
                 {
+                    options.IsolateApplication = true;
                     options.ServerStickyMode = ServerStickyMode.Prefered;
                     options.ConnectionString = ConnectionString;
                     options.ClaimsProvider = context => new Claim[]
@@ -459,6 +461,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     var mode = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode)?.Value;
                     Assert.Equal("Prefered", mode);
                     Assert.NotNull(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode));
+                    var version = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Version)?.Value;
+                    Version.TryParse(version, out var versionResult);
+                    Assert.True(versionResult > new Version(1, 0, 8));
+
                     var requestId = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Id);
                     Assert.NotNull(requestId);
                     Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             Assert.Equal("user1", principal.FindFirst(ClaimTypes.NameIdentifier).Value);
         }
 
-        [Theory]
+        [Theory(Skip = "Enable when runtime is ready to accept prefix")]
         [InlineData("Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=http://localhost/;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             Assert.Equal(expectedEndpoint, clientEndpoint);
         }
 
-        [Theory]
+        [Theory(Skip = "Enable when runtime is ready to accept prefix")]
         [InlineData("Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost:8080/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=http://localhost/;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost:8080/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]


### PR DESCRIPTION
as for AspNet it requires Azure SignalR Service runtime side support to make it work