### PR TITLE
Separate build for different framework versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,4 +26,10 @@
     <LangVersion>latest</LangVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <AssemblySigningCertName>Microsoft400</AssemblySigningCertName>
+    <PackageSigningCertName>NuGet</PackageSigningCertName>
+  </PropertyGroup>
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,12 +25,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <IsTargetMultiFramework>true</IsTargetMultiFramework>
-  </PropertyGroup>
-  
-  <PropertyGroup>
     <AssemblySigningCertName>Microsoft400</AssemblySigningCertName>
     <PackageSigningCertName>NuGet</PackageSigningCertName>
+    <IsTargetMultiFramework>true</IsTargetMultiFramework>
   </PropertyGroup>
-
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
+    <IsPreview>true</IsPreview>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <IsPreview>true</IsPreview>
+    <IsTargetMultiFramework>true</IsTargetMultiFramework>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/build/package-test.3.proj
+++ b/build/package-test.3.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
   </PropertyGroup>
 

--- a/build/package-test.proj
+++ b/build/package-test.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
   </PropertyGroup>
 

--- a/build/repo.props
+++ b/build/repo.props
@@ -14,7 +14,7 @@
     <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Protocols\bin\$(Configuration)\netstandard2.0\Microsoft.Azure.SignalR.Protocols.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
-  <ItemGroup Condition ="'$(IsPreview)' == 'true'">
+  <ItemGroup Condition ="'$(IsTargetMultiFramework)' == 'true'">
     <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\$(Configuration)\netcoreapp3.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
     <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\$(Configuration)\netcoreapp3.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>

--- a/build/repo.props
+++ b/build/repo.props
@@ -7,13 +7,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\Release\netcoreapp3.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.AspNet\bin\Release\net461\Microsoft.Azure.SignalR.AspNet.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Common\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\Release\netcoreapp3.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
-    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Protocols\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Protocols.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\$(Configuration)\netstandard2.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.AspNet\bin\$(Configuration)\net461\Microsoft.Azure.SignalR.AspNet.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Common\bin\$(Configuration)\netstandard2.0\Microsoft.Azure.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\$(Configuration)\netstandard2.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Protocols\bin\$(Configuration)\netstandard2.0\Microsoft.Azure.SignalR.Protocols.dll" Certificate="$(AssemblySigningCertName)" />
+  </ItemGroup>
+
+  <ItemGroup Condition ="'$(IsPreview)' == 'true'">
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\$(Configuration)\netcoreapp3.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\$(Configuration)\netcoreapp3.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
 </Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -5,4 +5,15 @@
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp20PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\Release\netcoreapp3.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.AspNet\bin\Release\net461\Microsoft.Azure.SignalR.AspNet.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Common\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\Release\netcoreapp3.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Management\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Management.dll" Certificate="$(AssemblySigningCertName)" />
+    <FilesToSign Include="$(RepositoryRoot)src\Microsoft.Azure.SignalR.Protocols\bin\Release\netstandard2.0\Microsoft.Azure.SignalR.Protocols.dll" Certificate="$(AssemblySigningCertName)" />
+  </ItemGroup>
+
 </Project>

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="SignFiles" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="..\Directory.Build.props" />
 

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="SignFiles" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="..\Directory.Build.props" />
 

--- a/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
+++ b/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
@@ -1,8 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <PackageVersion>1.0.0-preview1-$(BuildNumber)</PackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '16.0' AND '$(IsPreview)' == 'true'">
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(VisualStudioVersion)' != '16.0' OR '$(IsPreview)' != 'true'">
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
+++ b/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
@@ -4,10 +4,10 @@
     <PackageVersion>1.0.0-preview1-$(BuildNumber)</PackageVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(VisualStudioVersion)' &gt;= '16.0' AND '$(IsPreview)' == 'true'">
+  <PropertyGroup Condition="'$(IsTargetMultiFramework)' == 'true'">
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' != '16.0' OR '$(IsPreview)' != 'true'">
+  <PropertyGroup Condition="'$(IsTargetMultiFramework)' != 'true'">
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
+++ b/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
@@ -6,10 +6,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(VisualStudioVersion)' >= '16.0' AND '$(IsPreview)' == 'true'">
+  <PropertyGroup Condition="'$(IsTargetMultiFramework)' == 'true'">
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' != '16.0' OR '$(IsPreview)' != 'true'">
+  <PropertyGroup Condition="'$(IsTargetMultiFramework)' != 'true'">
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
+++ b/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
@@ -1,10 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>.NET Standard SDK for Azure SignalR.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.SignalR</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(VisualStudioVersion)' >= '16.0' AND '$(IsPreview)' == 'true'">
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(VisualStudioVersion)' != '16.0' OR '$(IsPreview)' != 'true'">
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.SignalR.Tests/AzureSignalRMarkerServiceFact.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AzureSignalRMarkerServiceFact.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Builder.Internal;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.NotNull(serviceProvider.GetService<HubLifetimeManager<TestHub>>());
         }
 
-        [Fact]
+        [SkipIfTargetNetstandard]
         public void UseEndpointsWithAddAzureSignalR()
         {
             var services = new ServiceCollection();
@@ -145,6 +145,28 @@ namespace Microsoft.Azure.SignalR.Tests
                 routes.MapHub<TestHub>("/chat");
             }));
             Assert.StartsWith("No connection string was specified.", exception.Message);
+        }
+
+        private sealed class SkipIfTargetNetstandard : FactAttribute
+        {
+            public SkipIfTargetNetstandard()
+            {
+                if (IsTargetNetStandard())
+                {
+                    Skip = "Not applicable in netstandard 2.0.";
+                }
+            }
+
+            private static bool IsTargetNetStandard()
+            {
+                var attribute = typeof(ServiceOptions).Assembly.GetCustomAttributes(typeof(TargetFrameworkAttribute), inherit: true);
+                var frameworkAttribute = (TargetFrameworkAttribute)attribute.GetValue(0);
+                if (frameworkAttribute.FrameworkName.Contains(".NETStandard", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                return false;
+            }
         }
     }
 

--- a/version.props
+++ b/version.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>1.0.9</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
+    <VersionPrefix Condition ="'$(IsPreview)' == 'true'">1.1.0</VersionPrefix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>1.0.9</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
-    <VersionPrefix Condition ="'$(IsPreview)' == 'true'">1.1.0</VersionPrefix>
+    <VersionPrefix Condition ="'$(IsTargetMultiFramework)' == 'true'">1.1.0</VersionPrefix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
1. Add `IsTargetMultiFramework` to configure different version build/deploy.
2. Assign files to sign due to limitation in KoreBuild for multiframework.
3. Fix UT.