### PR TITLE
Enable application name as prefix for ASP.NET SignalR

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.SignalR.AspNet
         private readonly string _appName;
         private readonly int? _port;
         private readonly TimeSpan _accessTokenLifetime;
-        private readonly bool _isolateApp;
 
         public ServiceEndpointProvider(ServiceEndpoint endpoint, ServiceOptions options, TimeSpan? ttl = null)
         {
@@ -40,17 +39,11 @@ namespace Microsoft.Azure.SignalR.AspNet
             _endpoint = endpoint.Endpoint;
             _accessKey = endpoint.AccessKey;
             _appName = options.ApplicationName;
-            _isolateApp = options.IsolateApplication;
             _port = endpoint.Port;
         }
 
         private string GetPrefixedHubName(string applicationName, string hubName)
         {
-            if (!_isolateApp)
-            {
-                return hubName;
-            }
-
             return string.IsNullOrEmpty(applicationName) ? hubName.ToLower() : $"{applicationName.ToLower()}_{hubName.ToLower()}";
         }
 

--- a/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         private readonly string _serverName;
         private readonly ServerStickyMode _mode;
-        private readonly bool _isolateApp;
 
         public NegotiateMiddleware(OwinMiddleware next, HubConfiguration configuration, string appName, IServiceEndpointManager endpointManager, IEndpointRouter router, ServiceOptions options, IServerNameProvider serverNameProvider, ILoggerFactory loggerFactory)
             : base(next)
@@ -49,7 +48,6 @@ namespace Microsoft.Azure.SignalR.AspNet
             _logger = loggerFactory?.CreateLogger<NegotiateMiddleware>() ?? throw new ArgumentNullException(nameof(loggerFactory));
             _serverName = serverNameProvider?.GetName();
             _mode = options.ServerStickyMode;
-            _isolateApp = options.IsolateApplication;
         }
 
         public override Task Invoke(IOwinContext owinContext)
@@ -158,10 +156,7 @@ namespace Microsoft.Azure.SignalR.AspNet
 
             var claims = ClaimsUtility.BuildJwtClaims(user, userId, GetClaimsProvider(owinContext), _serverName, _mode);
 
-            if (_isolateApp)
-            {
-                yield return new Claim(Constants.ClaimType.Version, AssemblyVersion);
-            }
+            yield return new Claim(Constants.ClaimType.Version, AssemblyVersion);
 
             foreach (var claim in claims)
             {

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -55,11 +55,6 @@ namespace Microsoft.Azure.SignalR.AspNet
         /// </summary>
         internal ServerStickyMode ServerStickyMode { get; set; }
 
-        /// <summary>
-        /// TODO: delete it when runtime is ready, don't expose it to the customer
-        /// </summary>
-        internal bool IsolateApplication { get; set; } = false;
-
         public ServiceOptions()
         {
             var count = ConfigurationManager.ConnectionStrings.Count;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 {
     public class RunAzureSignalRTests : VerifiableLoggedTest
     {
+        private static readonly Version VersionSupportingApplicationNamePrefix = new Version(1, 0, 9);
+
         private const string ServiceUrl = "http://localhost:8086";
         private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
         private const string ConnectionString2 = "Endpoint=http://localhost2;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
@@ -564,7 +566,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     Assert.Equal("hello", user);
                     Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName));
                     Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode));
-                    Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Version));
+
+                    var version = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Version)?.Value;
+                    Assert.True(Version.TryParse(version, out var vs));
+                    Assert.True(vs >= VersionSupportingApplicationNamePrefix);
                     var requestId = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.Id);
                     Assert.NotNull(requestId);
                     Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
@@ -583,7 +588,6 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 hubConfiguration.Resolver.Register(typeof(IServerNameProvider), () => serverNameProvider);
                 using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
                 {
-                    options.IsolateApplication = true;
                     options.ServerStickyMode = ServerStickyMode.Prefered;
                     options.ConnectionString = ConnectionString;
                     options.ClaimsProvider = context => new Claim[]

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             Assert.Equal("user1", principal.FindFirst(ClaimTypes.NameIdentifier).Value);
         }
 
-        [Theory(Skip = "Enable when runtime is ready to accept prefix")]
+        [Theory]
         [InlineData("Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=http://localhost/;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             Assert.Equal(expectedEndpoint, clientEndpoint);
         }
 
-        [Theory(Skip = "Enable when runtime is ready to accept prefix")]
+        [Theory]
         [InlineData("Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost:8080/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=http://localhost/;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost:8080/aspnetserver/?hub=prefix_hub1")]
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]


### PR DESCRIPTION
Service side is ready for this prefix change