### PR TITLE
Add service active check to weak connections

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/HubServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/HubServiceEndpoint.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.SignalR
             Provider = provider;
         }
 
+        internal HubServiceEndpoint() : base() { }
+
         public string Hub { get; }
 
         public IServiceEndpointProvider Provider { get; }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
+        // test only
+        internal ServiceEndpoint() { }
+
         public override string ToString()
         {
             var prefix = string.IsNullOrEmpty(Name) ? "" : $"[{Name}]";

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Azure.SignalR
         private readonly object _statusLock = new object();
 
         private readonly AckHandler _ackHandler;
-        private readonly ILogger _logger;
         private volatile List<IServiceConnection> _fixedServiceConnections;
 
         private volatile ServiceConnectionStatus _status;
+
+        protected ILogger Logger { get; }
 
         protected List<IServiceConnection> FixedServiceConnections
         {
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.SignalR
             FixedServiceConnections = initial;
             FixedConnectionCount = initial.Count;
             ConnectionStatusChanged += OnStatusChanged;
-            _logger = logger ?? NullLogger<ServiceConnectionBase>.Instance;
+            Logger = logger ?? NullLogger<ServiceConnectionBase>.Instance;
         }
 
         public Task StartAsync()
@@ -181,11 +182,11 @@ namespace Microsoft.Azure.SignalR
             Endpoint.Online = online;
             if (!online)
             {
-                Log.EndpointOffline(_logger, Endpoint);
+                Log.EndpointOffline(Logger, Endpoint);
             }
             else
             {
-                Log.EndpointOnline(_logger, Endpoint);
+                Log.EndpointOnline(Logger, Endpoint);
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -15,17 +15,17 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
         private const int CheckWindow = 5;
         private static readonly TimeSpan DefaultGetServiceStatusInterval = TimeSpan.FromSeconds(10);
         private static readonly long DefaultGetServiceStatusTicks = DefaultGetServiceStatusInterval.Seconds * Stopwatch.Frequency;
+        private static readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
 
-        private readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
         private readonly object _lock = new object();
         private int _inactiveCount;
         private DateTime? _firstInactiveTime;
         private long _lastSendTimestamp;
 
-        // active ones are those who client connections connected to the whole endpoint
+        // active ones are those whose client connections connected to the whole endpoint
         private volatile bool _active = true;
 
-        private TimerAwaitable _timer;
+        private readonly TimerAwaitable _timer;
 
         protected override ServerConnectionType InitialConnectionType => ServerConnectionType.Weak;
 
@@ -149,17 +149,11 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
             private static readonly Action<ILogger, Exception> _failedSendingServiceStatusPing =
                 LoggerMessage.Define(LogLevel.Warning, new EventId(2, "FailedSendingServiceStatusPing"), "Failed sending a service status ping message to service.");
 
-            private static readonly Action<ILogger, ServiceEndpoint, string, Exception> _endpointInactive =
-                LoggerMessage.Define<ServiceEndpoint, string>(LogLevel.Debug, new EventId(3, "EndpointInactive"), "Endpoint {endpoint} for hub {hub} is now inactive.");
-
-            private static readonly Action<ILogger, ServiceEndpoint, string, Exception> _endpointActive =
-                LoggerMessage.Define<ServiceEndpoint, string>(LogLevel.Debug, new EventId(4, "EndpointActive"), "Endpoint {endpoint} for hub {hub} is now active.");
-
             private static readonly Action<ILogger, string, ServiceEndpoint, string, Exception> _ignoreSendingMessageToInactiveEndpoint =
-                LoggerMessage.Define<string, ServiceEndpoint, string>(LogLevel.Debug, new EventId(5, "IgnoreSendingMessageToInactiveEndpoint"), "Message {type} sending to {endpoint} for hub {hub} is ignored because the endpoint is inactive.");
+                LoggerMessage.Define<string, ServiceEndpoint, string>(LogLevel.Debug, new EventId(3, "IgnoreSendingMessageToInactiveEndpoint"), "Message {type} sending to {endpoint} for hub {hub} is ignored because the endpoint is inactive.");
 
             private static readonly Action<ILogger, bool, ServiceEndpoint, string, Exception> _receivedServiceStatusPing =
-                LoggerMessage.Define<bool, ServiceEndpoint, string>(LogLevel.Debug, new EventId(6, "ReceivedServiceStatusPing"), "Received a service status active={isActive} from {endpoint} for hub {hub}.");
+                LoggerMessage.Define<bool, ServiceEndpoint, string>(LogLevel.Debug, new EventId(4, "ReceivedServiceStatusPing"), "Received a service status active={isActive} from {endpoint} for hub {hub}.");
 
             public static void StartingServiceStatusPingTimer(ILogger logger, TimeSpan keepAliveInterval)
             {
@@ -174,16 +168,6 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
             public static void FailedSendingServiceStatusPing(ILogger logger, Exception exception)
             {
                 _failedSendingServiceStatusPing(logger, exception);
-            }
-
-            public static void EndpointInactive(ILogger logger, HubServiceEndpoint endpoint)
-            {
-                _endpointInactive(logger, endpoint, endpoint.Hub, null);
-            }
-
-            public static void EndpointActive(ILogger logger, HubServiceEndpoint endpoint)
-            {
-                _endpointActive(logger, endpoint, endpoint.Hub, null);
             }
 
             public static void IgnoreSendingMessageToInactiveEndpoint(ILogger logger, Type messageType, HubServiceEndpoint endpoint)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -9,17 +12,189 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
 {
     internal class WeakServiceConnectionContainer : ServiceConnectionContainerBase
     {
+        private const int CheckWindow = 5;
+        private static readonly TimeSpan DefaultGetServiceStatusInterval = TimeSpan.FromSeconds(10);
+        private static readonly long DefaultGetServiceStatusTicks = DefaultGetServiceStatusInterval.Seconds * Stopwatch.Frequency;
+
+        private readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
+        private readonly object _lock = new object();
+        private int _inactiveCount;
+        private DateTime? _firstInactiveTime;
+        private long _lastSendTimestamp;
+
+        // active ones are those who client connections connected to the whole endpoint
+        private volatile bool _active = true;
+
+        private TimerAwaitable _timer;
+
         protected override ServerConnectionType InitialConnectionType => ServerConnectionType.Weak;
 
         public WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory,
             int fixedConnectionCount, HubServiceEndpoint endpoint, ILogger logger = null)
             : base(serviceConnectionFactory, fixedConnectionCount, endpoint, logger: logger)
         {
+            _timer = StartServiceStatusPingTimer();
         }
 
         public override Task HandlePingAsync(PingMessage pingMessage)
         {
+            if (pingMessage.TryGetServiceStatusPingMessage(out var status))
+            {
+                _active = GetServiceStatus(status.IsActive, CheckWindow, CheckTimeSpan);
+                Log.ReceivedServiceStatusPing(Logger, status.IsActive, Endpoint);
+            }
+
             return Task.CompletedTask;
+        }
+
+        public override Task WriteAsync(ServiceMessage serviceMessage)
+        {
+            if (!_active && !(serviceMessage is PingMessage))
+            {
+                // If the endpoint is inactive, there is no need to send messages to it
+                Log.IgnoreSendingMessageToInactiveEndpoint(Logger, serviceMessage.GetType(), Endpoint);
+                return Task.CompletedTask;
+            }
+
+            return base.WriteAsync(serviceMessage);
+        }
+
+        internal bool GetServiceStatus(bool active, int checkWindow, TimeSpan checkTimeSpan)
+        {
+            lock (_lock)
+            {
+                if (active)
+                {
+                    _firstInactiveTime = null;
+                    _inactiveCount = 0;
+                    return true;
+                }
+                else
+                {
+                    if (_firstInactiveTime == null)
+                    {
+                        _firstInactiveTime = DateTime.UtcNow;
+                    }
+
+                    _inactiveCount++;
+
+                    // Inactive it only when it checks over 5 times and elapsed for over 10 minutes
+                    if (_inactiveCount >= checkWindow && DateTime.UtcNow - _firstInactiveTime >= checkTimeSpan)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        private TimerAwaitable StartServiceStatusPingTimer()
+        {
+            Log.StartingServiceStatusPingTimer(Logger, DefaultGetServiceStatusInterval);
+
+            _lastSendTimestamp = Stopwatch.GetTimestamp();
+            var timer = new TimerAwaitable(DefaultGetServiceStatusInterval, DefaultGetServiceStatusInterval);
+            _ = ServiceStatusPingAsync(timer);
+
+            return timer;
+        }
+
+        private async Task ServiceStatusPingAsync(TimerAwaitable timer)
+        {
+            using (timer)
+            {
+                timer.Start();
+
+                while (await timer)
+                {
+                    try
+                    {
+                        // Check if last send time is longer than default keep-alive ticks and then send ping
+                        if (Stopwatch.GetTimestamp() - Interlocked.Read(ref _lastSendTimestamp) > DefaultGetServiceStatusTicks)
+                        {
+                            await WriteAsync(ServiceStatusPingMessage.ActiveServicePingMessage);
+                            Interlocked.Exchange(ref _lastSendTimestamp, Stopwatch.GetTimestamp());
+                            Log.SentServiceStatusPing(Logger);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Log.FailedSendingServiceStatusPing(Logger, e);
+                    }
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _timer.Stop();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private static class Log
+        {
+            private static readonly Action<ILogger, double, Exception> _startingServiceStatusPingTimer =
+                LoggerMessage.Define<double>(LogLevel.Debug, new EventId(0, "StartingServiceStatusPingTimer"), "Starting service status ping timer. Duration: {KeepAliveInterval:0.00}ms");
+
+            private static readonly Action<ILogger, Exception> _sentServiceStatusPing =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(1, "SentServiceStatusPing"), "Sent a service status ping message to service.");
+
+            private static readonly Action<ILogger, Exception> _failedSendingServiceStatusPing =
+                LoggerMessage.Define(LogLevel.Warning, new EventId(2, "FailedSendingServiceStatusPing"), "Failed sending a service status ping message to service.");
+
+            private static readonly Action<ILogger, ServiceEndpoint, string, Exception> _endpointInactive =
+                LoggerMessage.Define<ServiceEndpoint, string>(LogLevel.Debug, new EventId(3, "EndpointInactive"), "Endpoint {endpoint} for hub {hub} is now inactive.");
+
+            private static readonly Action<ILogger, ServiceEndpoint, string, Exception> _endpointActive =
+                LoggerMessage.Define<ServiceEndpoint, string>(LogLevel.Debug, new EventId(4, "EndpointActive"), "Endpoint {endpoint} for hub {hub} is now active.");
+
+            private static readonly Action<ILogger, string, ServiceEndpoint, string, Exception> _ignoreSendingMessageToInactiveEndpoint =
+                LoggerMessage.Define<string, ServiceEndpoint, string>(LogLevel.Debug, new EventId(5, "IgnoreSendingMessageToInactiveEndpoint"), "Message {type} sending to {endpoint} for hub {hub} is ignored because the endpoint is inactive.");
+
+            private static readonly Action<ILogger, bool, ServiceEndpoint, string, Exception> _receivedServiceStatusPing =
+                LoggerMessage.Define<bool, ServiceEndpoint, string>(LogLevel.Debug, new EventId(6, "ReceivedServiceStatusPing"), "Received a service status active={isActive} from {endpoint} for hub {hub}.");
+
+            public static void StartingServiceStatusPingTimer(ILogger logger, TimeSpan keepAliveInterval)
+            {
+                _startingServiceStatusPingTimer(logger, keepAliveInterval.TotalMilliseconds, null);
+            }
+
+            public static void SentServiceStatusPing(ILogger logger)
+            {
+                _sentServiceStatusPing(logger, null);
+            }
+
+            public static void FailedSendingServiceStatusPing(ILogger logger, Exception exception)
+            {
+                _failedSendingServiceStatusPing(logger, exception);
+            }
+
+            public static void EndpointInactive(ILogger logger, HubServiceEndpoint endpoint)
+            {
+                _endpointInactive(logger, endpoint, endpoint.Hub, null);
+            }
+
+            public static void EndpointActive(ILogger logger, HubServiceEndpoint endpoint)
+            {
+                _endpointActive(logger, endpoint, endpoint.Hub, null);
+            }
+
+            public static void IgnoreSendingMessageToInactiveEndpoint(ILogger logger, Type messageType, HubServiceEndpoint endpoint)
+            {
+                _ignoreSendingMessageToInactiveEndpoint(logger, messageType.Name, endpoint, endpoint.Hub, null);
+            }
+
+            public static void ReceivedServiceStatusPing(ILogger logger, bool isActive, HubServiceEndpoint endpoint)
+            {
+                _receivedServiceStatusPing(logger, isActive, endpoint, endpoint.Hub, null);
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceMessages/ServicePingMessageExtension.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceMessages/ServicePingMessageExtension.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR
+{
+    using ServicePingMessage = Microsoft.Azure.SignalR.Protocol.PingMessage;
+
+    public static class ServicePingMessageExtension
+    {
+        public static bool TryGetServiceStatusPingMessage(this ServicePingMessage message, out ServiceStatusPingMessage serviceStatus)
+        {
+            if (TryGetValue(message, ServiceStatusPingMessage.Key, out var value))
+            {
+                serviceStatus = new ServiceStatusPingMessage(value);
+                return true;
+            }
+
+            serviceStatus = null;
+            return false;
+        }
+
+        private static bool TryGetValue(ServicePingMessage pingMessage, string key, out string value)
+        {
+            if (pingMessage == null)
+            {
+                value = null;
+                return false;
+            }
+
+            int index = 0;
+            while (index < pingMessage.Messages.Length - 1)
+            {
+                var item1 = pingMessage.Messages[index];
+                var item2 = pingMessage.Messages[index + 1];
+                if (item1 == key)
+                {
+                    value = item2;
+                    return true;
+                }
+
+                index += 2;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/ServiceMessages/ServiceStatusPingMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceMessages/ServiceStatusPingMessage.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR
+{
+    using ServicePingMessage = Microsoft.Azure.SignalR.Protocol.PingMessage;
+
+    public class ServiceStatusPingMessage
+    {
+        public static readonly ServicePingMessage ActiveServicePingMessage = new ServiceStatusPingMessage(true).ToServicePingMessage();
+
+        private readonly string _status;
+
+        public const string Key = "status";
+
+        public bool IsActive { get; }
+
+        public ServiceStatusPingMessage(string status)
+        {
+            _status = status;
+            IsActive = status == "1";
+        }
+
+        public ServiceStatusPingMessage(bool isActive)
+        {
+            IsActive = isActive;
+            _status = IsActive ? "1" : "0";
+        }
+
+        public ServicePingMessage ToServicePingMessage()
+        {
+            return new ServicePingMessage { Messages = new[] { Key, _status } };
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Common.Tests/WeakServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/WeakServiceConnectionContainerTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.SignalR.Common.ServiceConnections;
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Common.Tests
+{
+    public class WeakServiceConnectionContainerTests
+    {
+        [Theory]
+        [InlineData(new bool[] { true }, 1, 0, true)]
+        [InlineData(new bool[] { true }, 2, 0, true)]
+        [InlineData(new bool[] { true }, 1, 10000, true)]
+        [InlineData(new bool[] { true }, 2, 10000, true)]
+        [InlineData(new bool[] { true, false }, 2, 0, true)] // count not meet
+        [InlineData(new bool[] { false, false }, 2, 10000, true)] // time not meet
+        [InlineData(new bool[] { true, false, true }, 2, 0, true)] // whenever true comes
+        [InlineData(new bool[] { true, false, false, true }, 2, 0, true)]  // whenever true comes
+        [InlineData(new bool[] { true, false, false, true, false }, 2, 0, true)]  // whenever true comes
+        [InlineData(new bool[] { false }, 2, 0, true)]
+        [InlineData(new bool[] { false, false, true, false, false }, 2, 10000, true)]
+        [InlineData(new bool[] { false }, 1, 0, false)]
+        [InlineData(new bool[] { false, false }, 2, 0, false)]
+        [InlineData(new bool[] { false, true, false, false, false }, 3, 0, false)]
+        [InlineData(new bool[] { false, false, true, true, false, false, false, false }, 3, 0, false)]
+        public void TestGetServiceStatus(bool[] pingStatus, int checkWindow, int checkMilli, bool expectedStatus)
+        {
+            var endpoint = new HubServiceEndpoint();
+            var container = new WeakServiceConnectionContainer(null, 0, endpoint);
+            var checkTimeSpan = TimeSpan.FromMilliseconds(checkMilli);
+            bool status = true;
+            foreach (var ping in pingStatus)
+            {
+                status = container.GetServiceStatus(ping, checkWindow, checkTimeSpan);
+            }
+
+            Assert.Equal(expectedStatus, status);
+        }
+    }
+}


### PR DESCRIPTION
The service returns `active` ping message when there is any client connected to it, and returns `inactive` ping message when there is no client connected to it. 

For weak connections, there is no need to send server->client messages to a `inactive` service.

From SDK side, we check service status every 10 seconds, whenever we get an `active` ping message, we consider the service as `active`. When we get at least 5 continuous `inactive` ping messages in at least 10 minutes, we consider the service as `inactive`.

Due to the delay of the `active`/`inactive` status, we only enable this for weak connections.