### PR TITLE
add a e2e test project

### DIFF
--- a/AzureSignalR.sln
+++ b/AzureSignalR.sln
@@ -62,7 +62,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.SignalR.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChatSample.CoreApp3", "samples\ChatSample\ChatSample.CoreApp3\ChatSample.CoreApp3.csproj", "{1F6D9B7A-36A0-4B71-825B-77F832B425A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorComponentSample", "samples\RazorComponentSample\RazorComponentSample.csproj", "{44181F77-1BD8-421C-B53E-DA7CEC2F319B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RazorComponentSample", "samples\RazorComponentSample\RazorComponentSample.csproj", "{44181F77-1BD8-421C-B53E-DA7CEC2F319B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.SignalR.E2ETests", "test\Microsoft.Azure.SignalR.E2ETests\Microsoft.Azure.SignalR.E2ETests.csproj", "{B8BA8F89-8028-4691-82C6-8F9E946B6B22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -142,6 +144,10 @@ Global
 		{44181F77-1BD8-421C-B53E-DA7CEC2F319B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44181F77-1BD8-421C-B53E-DA7CEC2F319B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44181F77-1BD8-421C-B53E-DA7CEC2F319B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8BA8F89-8028-4691-82C6-8F9E946B6B22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8BA8F89-8028-4691-82C6-8F9E946B6B22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8BA8F89-8028-4691-82C6-8F9E946B6B22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8BA8F89-8028-4691-82C6-8F9E946B6B22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -166,6 +172,7 @@ Global
 		{C51AA61E-5210-4545-B49E-61255C136B83} = {C965ED06-6A17-4329-B3C6-811830F4F4ED}
 		{1F6D9B7A-36A0-4B71-825B-77F832B425A5} = {C965ED06-6A17-4329-B3C6-811830F4F4ED}
 		{44181F77-1BD8-421C-B53E-DA7CEC2F319B} = {C4BC9889-B49F-41B6-806B-F84941B2549B}
+		{B8BA8F89-8028-4691-82C6-8F9E946B6B22} = {2429FBD8-1FCE-4C42-AA28-DF32F7249E77}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7945A4E4-ACDB-4F6E-95CA-6AC6E7C2CD59}

--- a/test/Microsoft.Azure.SignalR.E2ETests/Microsoft.Azure.SignalR.E2ETests.csproj
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Microsoft.Azure.SignalR.E2ETests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Put all e2e tests into this project later.

Avoid breakding change conflict in `Azure SignalR SDK Signing` pipeline for HttpClientConnection which is referenced by both SignalR client and Azure SignalR SDK.

E2E test will not run in  `Azure SignalR SDK Signing` pipeline, only in nightly build.