### PR TITLE
Revert commit e240ca8 for "Use 2 as the default connection count"

### DIFF
--- a/docs/use-signalr-service.md
+++ b/docs/use-signalr-service.md
@@ -71,9 +71,9 @@ There are two approaches to configure SignalR Service's connection string in you
 There are a few options you can customize when using Azure SignalR Service SDK.
 
 #### `ConnectionCount`
-- Default value is `2`.
-- This option controls the count of connections initially established between application server and Azure SignalR Service.
-The actual server connection count will be optimized during the app server's lifecycle based on the count of app servers and the unit count of the Azure SignalR service.
+- Default value is `5`.
+- This option controls the count of connections between application server and Azure SignalR Service.
+The default value will be performant enough most of the time.
 You can increase it for better performance if the total client count is too big.
 For example, if you have 100,000 clients in total, the connection count can be increased to `10` or `15` for better throughput.
 

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.SignalR.AspNet
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets or sets the initial number of connections from SDK to Azure SignalR Service for the application and each hub. Default value is 2.
+        /// Gets or sets the total number of connections from SDK to Azure SignalR Service. Default value is 5.
         /// </summary>
-        public int ConnectionCount { get; set; } = Constants.DefaultInitConnectionCountPerHub;
+        public int ConnectionCount { get; set; } = 5;
 
         /// <summary>
         /// Gets applicationName, which will be used as a prefix to apply to each hub name

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.SignalR
 {
     internal static class Constants
     {
-        public const int DefaultInitConnectionCountPerHub = 2;
         public const string ServerStickyModeDefaultKey = "Azure:SignalR:ServerStickyMode";
         public const string ConnectionStringDefaultKey = "Azure:SignalR:ConnectionString";
         public const string ApplicationNameDefaultKey = "Azure:SignalR:ApplicationName";

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.SignalR
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets or sets the initial number of connections from SDK to Azure SignalR Service per hub. Default value is 2.
+        /// Gets or sets the total number of connections from SDK to Azure SignalR Service. Default value is 5.
         /// </summary>
-        public int ConnectionCount { get; set; } = Constants.DefaultInitConnectionCountPerHub;
+        public int ConnectionCount { get; set; } = 5;
 
         /// <summary>
         /// Gets or sets the prefix to apply to each hub name

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
                 Assert.Equal(DefaultValue, options.ConnectionString);
-                Assert.Equal(Constants.DefaultInitConnectionCountPerHub, options.ConnectionCount);
+                Assert.Equal(5, options.ConnectionCount);
                 Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
                 Assert.Null(options.ClaimsProvider);
             }


### PR DESCRIPTION
This reverts commit e240ca8116ca67c84417d9175e3e0649746e6654.

Rebalance server connection is not yet supporting sending messages from server to client. So we still need more initial server connections for now.