### PR TITLE
Fix UT under cross reference scenario for preview7

### DIFF
--- a/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
+++ b/test/Microsoft.Azure.SignalR.Tests/Microsoft.Azure.SignalR.Tests.csproj
@@ -27,4 +27,8 @@
   <ItemGroup Condition=" '$(AzureSignalRSDKE2ETest)' == 'true' ">
     <PackageReference Include="Microsoft.Azure.SignalR" Version="$(VersionPrefix)-*" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(IsTargetMultiFramework)' != 'false'">
+    <DefineConstants>MULTIFRAMEWORK</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// From AspNetCore 3.0 preview7, there's a break change in HubConnectionContext
+// which will break cross reference bettwen NETCOREAPP3.0 to NETStandard2.0 SDK
+// So skip this part of UT when target 2.0 only
+#if (MULTIFRAMEWORK)
+
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
@@ -25,7 +30,6 @@ namespace Microsoft.Azure.SignalR.Tests
         private const string ConnectionString2 = "Endpoint=http://localhost2;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
         private const string ConnectionString3 = "Endpoint=http://localhost3;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
         private const string ConnectionString4 = "Endpoint=http://localhost4;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
-        private const string UserPath = "/user/path";
 
         private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new JwtSecurityTokenHandler();
 
@@ -395,3 +399,5 @@ namespace Microsoft.Azure.SignalR.Tests
         }
     }
 }
+
+#endif


### PR DESCRIPTION
From AspNetCore 3.0 preview7, there's a break change in HubConnectionContext which will break cross reference for a NETCOREAPP 3.0 reference NETStandard2.0 SDK case. 
This part of test is already covered under NETCOREAPP 3.0 reference NETCOREAPP 3.0 SDK. So skip this part of UT when target 2.0 only.