### PR TITLE
Fix aspnet application exception cases

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/IClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/IClientConnectionManager.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.AspNet
 {
     internal interface IClientConnectionManager
     {
-        IServiceTransport CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection);
+        Task<IServiceTransport> CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection);
 
         bool TryGetServiceConnection(string key, out IServiceConnection serviceConnection);
+
+        bool TryRemoveServiceConnection(string connectionId, out IServiceConnection connection);
     }
 }

--- a/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/IClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/IClientConnectionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -9,6 +10,8 @@ namespace Microsoft.Azure.SignalR.AspNet
     internal interface IClientConnectionManager
     {
         Task<IServiceTransport> CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection);
+
+        bool TryAdd(string connectionId, IServiceConnection serviceConnection);
 
         bool TryGetServiceConnection(string key, out IServiceConnection serviceConnection);
 

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.Log.cs
@@ -12,28 +12,28 @@ namespace Microsoft.Azure.SignalR.AspNet
         {
             // Category: ServiceConnection
             private static readonly Action<ILogger, Exception> _failedToCleanupConnections =
-                LoggerMessage.Define(LogLevel.Error, new EventId(5, "FailedToCleanupConnection"), "Failed to clean up client connections.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(1, "FailedToCleanupConnection"), "Failed to clean up client connections.");
 
             private static readonly Action<ILogger, string, Exception> _sendLoopStopped =
-                LoggerMessage.Define<string>(LogLevel.Error, new EventId(7, "SendLoopStopped"), "Error while processing messages from {TransportConnectionId}.");
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(2, "SendLoopStopped"), "Error while processing messages from {TransportConnectionId}.");
 
             private static readonly Action<ILogger, string, Exception> _failToWriteMessageToApplication =
-                LoggerMessage.Define<string>(LogLevel.Error, new EventId(9, "FailToWriteMessageToApplication"), "Failed to write message to {TransportConnectionId}.");
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(3, "FailToWriteMessageToApplication"), "Failed to write message to {TransportConnectionId}.");
 
             private static readonly Action<ILogger, string, Exception> _connectedStarting =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(11, "ConnectedStarting"), "Connection {TransportConnectionId} started.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "ConnectedStarting"), "Connection {TransportConnectionId} started.");
 
             private static readonly Action<ILogger, string, Exception> _connectedStartingFailed =
-                LoggerMessage.Define<string>(LogLevel.Error, new EventId(11, "ConnectedStartingFailed"), "Connection {TransportConnectionId} failed to start.");
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(5, "ConnectedStartingFailed"), "Connection {TransportConnectionId} failed to start.");
 
             private static readonly Action<ILogger, string, Exception> _duplicateConnectionId =
-                LoggerMessage.Define<string>(LogLevel.Error, new EventId(11, "DuplicateConnectionId"), "Failed to create connection due to duplicate connection Id {TransportConnectionId}.");
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(6, "DuplicateConnectionId"), "Duplicate OpenConnectionMessage for connection Id {TransportConnectionId}, ignored.");
 
             private static readonly Action<ILogger, string, Exception> _connectedEnding =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(12, "ConnectedEnding"), "Connection {TransportConnectionId} ended.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, "ConnectedEnding"), "Connection {TransportConnectionId} ended.");
 
             private static readonly Action<ILogger, long, string, Exception> _writeMessageToApplication =
-                LoggerMessage.Define<long, string>(LogLevel.Trace, new EventId(19, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
+                LoggerMessage.Define<long, string>(LogLevel.Trace, new EventId(8, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
 
             public static void FailedToCleanupConnections(ILogger logger, Exception exception)
             {

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.Log.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.SignalR.AspNet
             private static readonly Action<ILogger, string, Exception> _sendLoopStopped =
                 LoggerMessage.Define<string>(LogLevel.Error, new EventId(2, "SendLoopStopped"), "Error while processing messages from {TransportConnectionId}.");
 
-            private static readonly Action<ILogger, string, Exception> _failToWriteMessageToApplication =
-                LoggerMessage.Define<string>(LogLevel.Error, new EventId(3, "FailToWriteMessageToApplication"), "Failed to write message to {TransportConnectionId}.");
+            private static readonly Action<ILogger, string, string, Exception> _failToWriteMessageToApplication =
+                LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(3, "FailToWriteMessageToApplication"), "Failed to write message {messageType} to {TransportConnectionId}.");
 
             private static readonly Action<ILogger, string, Exception> _connectedStarting =
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "ConnectedStarting"), "Connection {TransportConnectionId} started.");
@@ -35,6 +35,12 @@ namespace Microsoft.Azure.SignalR.AspNet
             private static readonly Action<ILogger, long, string, Exception> _writeMessageToApplication =
                 LoggerMessage.Define<long, string>(LogLevel.Trace, new EventId(8, "WriteMessageToApplication"), "Writing {ReceivedBytes} to connection {TransportConnectionId}.");
 
+            private static readonly Action<ILogger, Exception> _applicationTaskFailed =
+                LoggerMessage.Define(LogLevel.Error, new EventId(9, "ApplicationTaskFailed"), "Application task failed.");
+
+            private static readonly Action<ILogger, Exception> _applicationTaskTimedOut =
+                LoggerMessage.Define(LogLevel.Error, new EventId(10, "ApplicationTaskTimedOut"), "Timed out waiting for the application task to complete.");
+
             public static void FailedToCleanupConnections(ILogger logger, Exception exception)
             {
                 _failedToCleanupConnections(logger, exception);
@@ -45,9 +51,9 @@ namespace Microsoft.Azure.SignalR.AspNet
                 _sendLoopStopped(logger, connectionId, exception);
             }
 
-            public static void FailToWriteMessageToApplication(ILogger logger, string connectionId, Exception exception)
+            public static void FailToWriteMessageToApplication(ILogger logger, string messageType, string connectionId, Exception exception)
             {
-                _failToWriteMessageToApplication(logger, connectionId, exception);
+                _failToWriteMessageToApplication(logger, messageType, connectionId, exception);
             }
 
             public static void ConnectedStarting(ILogger logger, string connectionId)
@@ -73,6 +79,16 @@ namespace Microsoft.Azure.SignalR.AspNet
             public static void WriteMessageToApplication(ILogger logger, long count, string connectionId)
             {
                 _writeMessageToApplication(logger, count, connectionId, null);
+            }
+
+            public static void ApplicationTaskFailed(ILogger logger, Exception exception)
+            {
+                _applicationTaskFailed(logger, exception);
+            }
+
+            public static void ApplicationTaskTimedOut(ILogger logger)
+            {
+                _applicationTaskTimedOut(logger, null);
             }
         }
     }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Transports;
 using Microsoft.Azure.SignalR.Protocol;
@@ -34,10 +35,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("?connectionToken=invalidOne", "a")]
         [InlineData("?connectionToken=conn2:user1%32c", "conn1")]
         [InlineData("connectionToken=conn2:user1%32c", "conn3")]
-        public void TestCreateConnectionAlwaysUsesConnectionIdInOpenConnectionMessage(string queryString, string expectedConnectionId)
+        public async Task TestCreateConnectionAlwaysUsesConnectionIdInOpenConnectionMessage(string queryString, string expectedConnectionId)
         {
             var message = new OpenConnectionMessage(expectedConnectionId, new Claim[0], null, queryString);
-            var connection = _clientConnectionManager.CreateConnection(message, null);
+            var connection = await _clientConnectionManager.CreateConnection(message, null);
             Assert.Equal(expectedConnectionId, connection.ConnectionId);
         }
 
@@ -45,10 +46,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("?transport=webSockets")]
         [InlineData("transport=webSockets")]
         [InlineData("connectionToken=")]
-        public void TestCreateConnectionWithInvalidQueryStringThrows(string queryString)
+        public async Task TestCreateConnectionWithInvalidQueryStringThrows(string queryString)
         {
             var message = new OpenConnectionMessage(Guid.NewGuid().ToString("N"), new Claim[0], null, queryString);
-            Assert.Throws<InvalidOperationException>(() => _clientConnectionManager.CreateConnection(message, null));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _clientConnectionManager.CreateConnection(message, null));
         }
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.WebSockets;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Transports;
 using Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
@@ -76,12 +78,13 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
             {
                 var hubConfig = Utility.GetActualHubConfig(loggerFactory);
-
+                var appName = "app1";
+                var hub = "chat";
                 var scm = new TestServiceConnectionHandler();
                 hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
                 var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
                 hubConfig.Resolver.Register(typeof(IClientConnectionManager), () => ccm);
-                DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig, new ServiceOptions { ConnectionString = ConnectionString }, "app1", loggerFactory);
+                DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig, new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
                 using (var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory))
                 {
                     // start the server connection
@@ -89,10 +92,19 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
                     var clientConnection = Guid.NewGuid().ToString("N");
 
+                    var connectTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage)).OrTimeout();
                     // Application layer sends OpenConnectionMessage
-                    var openConnectionMessage = new OpenConnectionMessage(clientConnection, new Claim[0], null, "?transport=webSockets&connectionToken=conn1");
+                    var openConnectionMessage = new OpenConnectionMessage(clientConnection, new Claim[0], null, $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
                     await proxy.WriteMessageAsync(openConnectionMessage);
                     await proxy.WaitForClientConnectAsync(clientConnection).OrTimeout();
+
+                    var connectMessage = (await connectTask) as GroupBroadcastDataMessage;
+                    Assert.NotNull(connectMessage);
+                    Assert.Equal($"hg-{hub}.note", connectMessage.GroupName);
+
+                    var message = connectMessage.Payloads["json"].GetJsonMessageFromSingleFramePayload<HubResponseItem>();
+
+                    Assert.Equal("Connected", message.A[0]);
 
                     // group message goes into the manager
                     // make sure the tcs is called before writing message
@@ -100,36 +112,148 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
                     var gbTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage)).OrTimeout();
 
-                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes("{\"H\":\"chat\",\"M\":\"JoinGroup\",\"A\":[\"user1\",\"message1\"],\"I\":1}")));
-                    
-                    await jgTask;
-                    await gbTask;
+                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"JoinGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
+
+                    var groupMessage = (await jgTask) as JoinGroupWithAckMessage;
+                    Assert.NotNull(groupMessage);
+                    Assert.Equal($"hg-{hub}.group1", groupMessage.GroupName);
+                    var broadcastMessage = (await gbTask) as GroupBroadcastDataMessage;
+                    Assert.NotNull(broadcastMessage);
+                    Assert.Equal($"hg-{hub}.group1", broadcastMessage.GroupName);
 
                     var lgTask = scm.WaitForTransportOutputMessageAsync(typeof(LeaveGroupWithAckMessage)).OrTimeout();
                     gbTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage)).OrTimeout();
 
-                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes("{\"H\":\"chat\",\"M\":\"LeaveGroup\",\"A\":[\"user1\",\"message1\"],\"I\":1}")));
+                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"LeaveGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
 
-                    await lgTask;
-                    await gbTask;
+                    var leaveGroupMessage = (await lgTask) as LeaveGroupWithAckMessage;
+                    Assert.NotNull(leaveGroupMessage);
+                    Assert.Equal($"hg-{hub}.group1", leaveGroupMessage.GroupName);
 
-                    var dTask = proxy.WaitForClientDisconnectAsync(clientConnection).OrTimeout();
+                    broadcastMessage = (await gbTask) as GroupBroadcastDataMessage;
+                    Assert.NotNull(broadcastMessage);
+                    Assert.Equal($"hg-{hub}.group1", broadcastMessage.GroupName);
+
+                    var disconnectTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage))
+                        .OrTimeout();
+
                     await proxy.WriteMessageAsync(new CloseConnectionMessage(clientConnection));
-                    await dTask;
+
+                    var disconnectMessage = (await disconnectTask) as GroupBroadcastDataMessage;
+
+                    Assert.NotNull(disconnectMessage);
+                    Assert.Equal($"hg-{hub}.note", disconnectMessage.GroupName);
+
+                    message = disconnectMessage.Payloads["json"].GetJsonMessageFromSingleFramePayload<HubResponseItem>();
+
+                    Assert.Equal("Disconnected", message.A[0]);
+
+                    // cleaned up clearly
+                    Assert.Empty(ccm.ClientConnections);
                 }
             }
         }
-        
+
+        [Fact]
+        public async Task ServiceConnectionWithErrorConnectHub()
+        {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c=>true, logChecker:
+                logs =>
+                {
+                    Assert.Single(logs);
+                    Assert.Equal("ConnectedStartingFailed", logs[0].Write.EventId.Name);
+                    return true;
+                }))
+            {
+                var hubConfig = Utility.GetActualHubConfig(loggerFactory);
+                var appName = "app1";
+                var hub = "ec"; // error connect hub
+                var scm = new TestServiceConnectionHandler();
+                hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
+                var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+                hubConfig.Resolver.Register(typeof(IClientConnectionManager), () => ccm);
+                DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig, new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
+                using (var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory))
+                {
+                    // start the server connection
+                    await proxy.StartServiceAsync().OrTimeout();
+
+                    var clientConnection = Guid.NewGuid().ToString("N");
+
+                    var connectTask = proxy.WaitForOutgoingMessageAsync(clientConnection).OrTimeout();
+
+                    // Application layer sends OpenConnectionMessage
+                    var openConnectionMessage = new OpenConnectionMessage(clientConnection, new Claim[0], null, $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
+                    await proxy.WriteMessageAsync(openConnectionMessage);
+                    await proxy.WaitForClientConnectAsync(clientConnection).OrTimeout();
+
+                    // other messages are just ignored because OnConnected failed
+                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"JoinGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
+
+                    await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"LeaveGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
+
+                    await proxy.WriteMessageAsync(new CloseConnectionMessage(clientConnection));
+
+                    var message = await connectTask;
+
+                    Assert.True(message is CloseConnectionMessage);
+
+                    // cleaned up clearly
+                    Assert.Empty(ccm.ClientConnections);
+                }
+            }
+        }
+
         [Fact]
         public async Task ServiceConnectionDispatchOpenConnectionToUnauthorizedHubTest()
         {
-            bool ExpectedErrors(WriteContext writeContext)
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true, logChecker:
+                logs =>
+                {
+                    Assert.Single(logs);
+                    Assert.Equal("ConnectedStartingFailed", logs[0].Write.EventId.Name);
+                    Assert.Equal("Unable to authorize request", logs[0].Write.Exception.Message);
+                    return true;
+                }))
             {
-                return writeContext.LoggerName == typeof(ServiceConnection).FullName &&
-                    writeContext.EventId == new EventId(11, "ConnectedStartingFailed") &&
-                    writeContext.Exception.Message == "Unable to authorize request";
+                var hubConfig = new HubConfiguration();
+                var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+                hubConfig.Resolver.Register(typeof(IClientConnectionManager), () => ccm);
+                using (var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory))
+                {
+                    // start the server connection
+                    await proxy.StartServiceAsync().OrTimeout();
+
+                    var clientConnection = Guid.NewGuid().ToString("N");
+                    var connectTask = proxy.WaitForOutgoingMessageAsync(clientConnection).OrTimeout();
+
+                    // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
+                    var openConnectionMessage = new OpenConnectionMessage(clientConnection, new Claim[0], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
+                    await proxy.WriteMessageAsync(openConnectionMessage);
+                    await proxy.WaitForClientConnectAsync(clientConnection).OrTimeout();
+
+                    var message = await connectTask;
+
+                    Assert.True(message is CloseConnectionMessage);
+
+                    // Verify client connection is not created due to authorized failure.
+                    ccm.TryGetServiceConnection(clientConnection, out var serviceConnection);
+                    Assert.Null(serviceConnection);
+                }
             }
-            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: ExpectedErrors))
+        }
+
+        [Fact]
+        public async Task ServiceConnectionWithNormalClientConnection()
+        {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true, logChecker:
+                logs =>
+                {
+                    Assert.Single(logs);
+                    Assert.Equal("ConnectedStartingFailed", logs[0].Write.EventId.Name);
+                    Assert.Equal("Unable to authorize request", logs[0].Write.Exception.Message);
+                    return true;
+                }))
             {
                 var hubConfig = new HubConfiguration();
                 var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
@@ -141,16 +265,29 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
                     var clientConnection = Guid.NewGuid().ToString("N");
 
+                    var connectTask = proxy.WaitForOutgoingMessageAsync(clientConnection).OrTimeout();
+
                     // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
                     var openConnectionMessage = new OpenConnectionMessage(clientConnection, new Claim[0], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
                     await proxy.WriteMessageAsync(openConnectionMessage);
                     await proxy.WaitForClientConnectAsync(clientConnection).OrTimeout();
-                    
+
+                    var message = await connectTask;
+
+                    Assert.True(message is CloseConnectionMessage);
+
                     // Verify client connection is not created due to authorized failure.
                     ccm.TryGetServiceConnection(clientConnection, out var serviceConnection);
                     Assert.Null(serviceConnection);
                 }
             }
+        }
+
+        private sealed class HubResponseItem
+        {
+            public string H { get; set; }
+            public string M { get; set; }
+            public List<string> A { get; set; }
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     proxy.TestConnectionContext.Application.Output.Complete();
 
                     // wait for application task to timeout
-                    await connectionTask.OrTimeout(10000);
+                    await proxy.WaitForConnectionClose.OrTimeout(10000);
                     Assert.Equal(ServiceConnectionStatus.Disconnected, proxy.Status);
 
                     // cleaned up clearly
@@ -503,6 +503,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                     proxy.TestConnectionContext.Application.Output.Complete();
 
                     await connectionTask.OrTimeout();
+                    await proxy.WaitForConnectionClose.OrTimeout();
                     Assert.Equal(ServiceConnectionStatus.Disconnected, proxy.Status);
 
                     // cleaned up clearly

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 Assert.True(result.TryGetValue(expectedHubs[i], out var current));
                 var message = current as BroadcastDataMessage;
                 Assert.NotNull(message);
-                Assert.Equal(messageValue, message.Payloads["json"].GetSingleFramePayload());
+                Assert.Equal(messageValue, message.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
             }
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 Assert.NotNull(message);
 
                 Assert.Equal(expectedConnectionIds[i], message.ConnectionId);
-                Assert.Equal(messageValue, message.Payload.First.GetSingleFramePayload());
+                Assert.Equal(messageValue, message.Payload.First.GetJsonMessageFromSingleFramePayload<string>());
             }
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 Assert.NotNull(message);
 
                 Assert.Equal(expectedConnectionIds[i], message.ConnectionId);
-                Assert.Equal(messageValue, message.Payload.First.GetSingleFramePayload());
+                Assert.Equal(messageValue, message.Payload.First.GetJsonMessageFromSingleFramePayload<string>());
             }
         }
 
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 var message = current as GroupBroadcastDataMessage;
                 Assert.NotNull(message);
                 Assert.Equal(message.GroupName, expectedGroups[i]);
-                Assert.Equal(messageValue, message.Payloads["json"].GetSingleFramePayload());
+                Assert.Equal(messageValue, message.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
             }
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                 Assert.NotNull(message);
 
                 Assert.Equal(expectedUsers[i], message.UserId);
-                Assert.Equal(messageValue, message.Payloads["json"].GetSingleFramePayload());
+                Assert.Equal(messageValue, message.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageParserTest.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageParserTest.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             var msg = msgs[0].Message as BroadcastDataMessage;
             Assert.NotNull(msg);
             Assert.Equal<string>(excludedConnectionIds, msg.ExcludedList);
-            Assert.Equal(input, msg.Payloads["json"].GetSingleFramePayload());
+            Assert.Equal(input, msg.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
         }
 
         [Theory]
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             var msg = msgs[0].Message as ConnectionDataMessage;
             Assert.NotNull(msg);
             Assert.Equal(expectedId, msg.ConnectionId);
-            Assert.Equal(input, msg.Payload.First.GetSingleFramePayload());
+            Assert.Equal(input, msg.Payload.First.GetJsonMessageFromSingleFramePayload<string>());
         }
 
         [Theory]
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             // For group message, it is the full name as the group, e.g. hg-hub.hub1.h.hub2.abcde
             Assert.Equal(fullName, msg.GroupName);
             Assert.Equal<string>(excludedConnectionIds, msg.ExcludedList);
-            Assert.Equal(input, msg.Payloads["json"].GetSingleFramePayload());
+            Assert.Equal(input, msg.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
         }
 
         [Theory]
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             var msg = msgs[0].Message as UserDataMessage;
             Assert.NotNull(msg);
             Assert.Equal(userName, msg.UserId);
-            Assert.Equal(input, msg.Payloads["json"].GetSingleFramePayload());
+            Assert.Equal(input, msg.Payloads["json"].GetJsonMessageFromSingleFramePayload<string>());
         }
 
         [Fact]

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageUtility.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageUtility.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             return DefaultServiceProtocol.GetMessageBytes(singleFrameMessage);
         }
 
-        public static string GetSingleFramePayload(this ReadOnlyMemory<byte> payload)
+        public static T GetJsonMessageFromSingleFramePayload<T>(this ReadOnlyMemory<byte> payload) where T : class
         {
             var buffer = new ReadOnlySequence<byte>(payload);
             DefaultServiceProtocol.TryParseMessage(ref buffer, out var message);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             Assert.NotNull(frame);
             var msg = Encoding.UTF8.GetString(frame.Payload.First.ToArray());
             Assert.NotNull(msg);
-            var response = JsonConvert.DeserializeObject<Response>(msg);
+            var response = JsonConvert.DeserializeObject<Response<T>>(msg);
             Assert.NotNull(response);
             Assert.Equal("0", response.C);
             Assert.Single(response.M);
@@ -109,10 +109,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             }
         }
 
-        private sealed class Response
+        private sealed class Response<T>
         {
             public string C { get; set; }
-            public List<string> M { get; set; }
+            public List<T> M { get; set; }
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -31,6 +32,11 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             CurrentTransports.TryAdd(message.ConnectionId, transport);
 
             return Task.FromResult<IServiceTransport>(transport);
+        }
+
+        public bool TryAdd(string connectionId, IServiceConnection serviceConnection)
+        {
+            return true;
         }
 
         public bool TryGetServiceConnection(string key, out IServiceConnection serviceConnection)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests
@@ -21,20 +22,27 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             _contains = contains;
         }
 
-        public IServiceTransport CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection)
+        public Task<IServiceTransport> CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection)
         {
             var transport = new TestTransport
             {
                 ConnectionId = message.ConnectionId
             };
             CurrentTransports.TryAdd(message.ConnectionId, transport);
-            return transport;
+
+            return Task.FromResult<IServiceTransport>(transport);
         }
 
         public bool TryGetServiceConnection(string key, out IServiceConnection serviceConnection)
         {
             serviceConnection = _serverConnection;
             return _contains;
+        }
+
+        public bool TryRemoveServiceConnection(string connectionId, out IServiceConnection connection)
+        {
+            connection = null;
+            return CurrentTransports.TryRemove(connectionId, out _);
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
@@ -28,10 +28,6 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             {
                 tcs.SetResult(serviceMessage);
             }
-            else
-            {
-                throw new InvalidOperationException("Not expected to write before tcs is inited");
-            }
 
             return Task.CompletedTask;
         }
@@ -50,7 +46,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             return Task.FromResult(true);
         }
 
-        public Task WaitForTransportOutputMessageAsync(Type messageType)
+        public Task<ServiceMessage> WaitForTransportOutputMessageAsync(Type messageType)
         {
             if (_waitForTransportOutputMessage.TryGetValue(messageType, out var tcs))
             {
@@ -58,7 +54,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             }
 
             // re-init the tcs
-            tcs = _waitForTransportOutputMessage[messageType] = new TaskCompletionSource<ServiceMessage>();
+            tcs = _waitForTransportOutputMessage[messageType] = new TaskCompletionSource<ServiceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             return tcs.Task;
         }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         private readonly ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>> _waitForApplicationMessage = new ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>>();
         private readonly ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>> _waitForOutgoingMessage = new ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>>();
 
-        private TestConnectionContext _connectionContext;
+        public TestConnectionContext TestConnectionContext { get; private set; }
 
         public TestServiceConnectionProxy(IClientConnectionManager clientConnectionManager, ILoggerFactory loggerFactory, ConnectionDelegate callback = null, PipeOptions clientPipeOptions = null, IServiceMessageHandler serviceMessageHandler = null) :
             base(
@@ -43,10 +43,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
         protected override async Task<ConnectionContext> CreateConnection(string target = null)
         {
-            _connectionContext = await base.CreateConnection() as TestConnectionContext;
+            TestConnectionContext = await base.CreateConnection() as TestConnectionContext;
 
             await WriteMessageAsync(new HandshakeResponseMessage());
-            return _connectionContext;
+            return TestConnectionContext;
         }
 
         public override Task WriteAsync(ServiceMessage serviceMessage)
@@ -122,13 +122,13 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
         public async Task WriteMessageAsync(ServiceMessage message)
         {
-            if (_connectionContext == null)
+            if (TestConnectionContext == null)
             {
                 throw new InvalidOperationException("Server connection is not yet established.");
             }
 
-            ServiceProtocol.WriteMessage(message, _connectionContext.Application.Output);
-            await _connectionContext.Application.Output.FlushAsync();
+            ServiceProtocol.WriteMessage(message, TestConnectionContext.Application.Output);
+            await TestConnectionContext.Application.Output.FlushAsync();
         }
 
         public void Dispose()

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
+using Microsoft.AspNet.SignalR.Hubs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+{
+    [HubName("EndlessConnect")]
+    public class EndlessConnectHub : Hub
+    {
+        public override async Task OnConnected()
+        {
+            Clients.Group("note").echo("Connected");
+            while (true)
+            {
+                await Task.Delay(1000);
+            }
+        }
+
+        public override Task OnReconnected()
+        {
+            Clients.Group("note").echo("Reconnected");
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDisconnected(bool stopCalled)
+        {
+            Clients.Group("note").echo("Disconnected");
+            return Task.CompletedTask;
+        }
+
+        public void BroadcastMessage(string name, string message)
+        {
+            Clients.All.broadcastMessage(name, message);
+        }
+
+        public void Echo(string name, string message)
+        {
+            Clients.Client(Context.ConnectionId).echo(name, message + " (echo from server)");
+        }
+
+        public async Task JoinGroup(string name, string groupName)
+        {
+            await Groups.Add(Context.ConnectionId, groupName);
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+        }
+
+        public async Task LeaveGroup(string name, string groupName)
+        {
+            await Groups.Remove(Context.ConnectionId, groupName);
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+        }
+
+        public void SendGroup(string name, string groupName, string message)
+        {
+            Clients.Group(groupName).echo(name, message);
+        }
+
+        public void SendGroups(string name, IList<string> groups, string message)
+        {
+            Clients.Groups(groups).echo(name, message);
+        }
+
+        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+        {
+            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+        }
+
+        public void SendUser(string name, string userId, string message)
+        {
+            Clients.User(userId).echo(name, message);
+        }
+
+        public void SendUsers(string name, IList<string> userIds, string message)
+        {
+            Clients.Users(userIds).echo(name, message);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
+using Microsoft.AspNet.SignalR.Hubs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+{
+    [HubName("EndlessInvoke")]
+    public class EndlessInvokeHub : Hub
+    {
+        public override async Task OnConnected()
+        {
+            Clients.Group("note").echo("Connected");
+        }
+
+        public override Task OnReconnected()
+        {
+            Clients.Group("note").echo("Reconnected");
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDisconnected(bool stopCalled)
+        {
+            Clients.Group("note").echo("Disconnected");
+            return Task.CompletedTask;
+        }
+
+        public void BroadcastMessage(string name, string message)
+        {
+            Clients.All.broadcastMessage(name, message);
+        }
+
+        public void Echo(string name, string message)
+        {
+            Clients.Client(Context.ConnectionId).echo(name, message + " (echo from server)");
+        }
+
+        public async Task JoinGroup(string name, string groupName)
+        {
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+            while (true)
+            {
+                await Task.Delay(1000);
+            }
+        }
+
+        public async Task LeaveGroup(string name, string groupName)
+        {
+            await Groups.Remove(Context.ConnectionId, groupName);
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+        }
+
+        public async Task SendGroup(string name, string groupName, string message)
+        {
+            Clients.Group(groupName).echo(name, message);
+        }
+
+        public void SendGroups(string name, IList<string> groups, string message)
+        {
+            Clients.Groups(groups).echo(name, message);
+        }
+
+        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+        {
+            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+        }
+
+        public void SendUser(string name, string userId, string message)
+        {
+            Clients.User(userId).echo(name, message);
+        }
+
+        public void SendUsers(string name, IList<string> userIds, string message)
+        {
+            Clients.Users(userIds).echo(name, message);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
     [HubName("EndlessInvoke")]
     public class EndlessInvokeHub : Hub
     {
-        public override async Task OnConnected()
+        public override Task OnConnected()
         {
             Clients.Group("note").echo("Connected");
+            return Task.CompletedTask;
         }
 
         public override Task OnReconnected()
@@ -57,9 +58,10 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
             Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
         }
 
-        public async Task SendGroup(string name, string groupName, string message)
+        public Task SendGroup(string name, string groupName, string message)
         {
             Clients.Group(groupName).echo(name, message);
+            return Task.CompletedTask;
         }
 
         public void SendGroups(string name, IList<string> groups, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
+using Microsoft.AspNet.SignalR.Hubs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+{
+    [HubName("ErrorConnect")]
+    public class ErrorConnectHub : Hub
+    {
+        public override Task OnConnected()
+        {
+            throw new InvalidOperationException("error connecting");
+        }
+
+        public override Task OnReconnected()
+        {
+            Clients.Group("note").echo("Reconnected");
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDisconnected(bool stopCalled)
+        {
+            Clients.Group("note").echo("Disconnected");
+            return Task.CompletedTask;
+        }
+
+        public void BroadcastMessage(string name, string message)
+        {
+            Clients.All.broadcastMessage(name, message);
+        }
+
+        public void Echo(string name, string message)
+        {
+            Clients.Client(Context.ConnectionId).echo(name, message + " (echo from server)");
+        }
+
+        public async Task JoinGroup(string name, string groupName)
+        {
+            await Groups.Add(Context.ConnectionId, groupName);
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+        }
+
+        public async Task LeaveGroup(string name, string groupName)
+        {
+            await Groups.Remove(Context.ConnectionId, groupName);
+            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+        }
+
+        public void SendGroup(string name, string groupName, string message)
+        {
+            Clients.Group(groupName).echo(name, message);
+        }
+
+        public void SendGroups(string name, IList<string> groups, string message)
+        {
+            Clients.Groups(groups).echo(name, message);
+        }
+
+        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+        {
+            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+        }
+
+        public void SendUser(string name, string userId, string message)
+        {
+            Clients.User(userId).echo(name, message);
+        }
+
+        public void SendUsers(string name, IList<string> userIds, string message)
+        {
+            Clients.Users(userIds).echo(name, message);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
@@ -12,12 +12,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 {
-    [HubName("ec")]
-    public class ErrorConnectHub : Hub
+    [HubName("ErrorDisconnect")]
+    public class ErrorDisconnectHub : Hub
     {
         public override Task OnConnected()
         {
-            throw new InvalidOperationException("error connecting");
+            Clients.Group("note").echo("Connected");
+            return Task.CompletedTask;
         }
 
         public override Task OnReconnected()
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
         public override Task OnDisconnected(bool stopCalled)
         {
             Clients.Group("note").echo("Disconnected");
-            return Task.CompletedTask;
+            throw new InvalidOperationException("error disconnecting");
         }
 
         public void BroadcastMessage(string name, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorHub.cs
@@ -12,13 +12,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 {
-    [HubName("chat")]
-    public class ChatHub : Hub
+    [HubName("ec")]
+    public class ErrorConnectHub : Hub
     {
         public override Task OnConnected()
         {
-            Clients.Group("note").echo("Connected");
-            return Task.CompletedTask;
+            throw new InvalidOperationException("error connecting");
         }
 
         public override Task OnReconnected()

--- a/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
             if (_expectedErrors != null)
             {
-                if (!results.Any(w => _expectedErrors(w.Write)))
+                if (results.Any(w => !_expectedErrors(w.Write)))
                 {
                     throw new Exception("Fail to match expected error(s).");
                 }


### PR DESCRIPTION
1. Case 1: , when OnConnected throws, the exception is swallowed, and Disconnected will never trigger
2. Case 2: when client connection closed, the client manager never cleans the disconnected connection
