### PR TITLE
Preserve user query string for aspnet

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
@@ -10,6 +10,7 @@ using System.Net.Mime;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hosting;
 using Microsoft.AspNet.SignalR.Hubs;
@@ -158,7 +159,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                                             Constants.QueryParameter.ConnectionRequestId,
                                             clientRequestId)
                                     })
-                                .Select(s => $"{s.Key}={WebUtility.UrlEncode(s.Value)}"));
+                                .Select(s => $"{Uri.EscapeDataString(s.Key)}={Uri.EscapeDataString(s.Value)}"));
                 }
 
                 originalPath = GetOriginalPath(context.Request.LocalPath);

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -499,8 +499,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("/user/path/negotiate", "?clientProtocol=1.89", "a", "")]
         [InlineData("/user/path/negotiate", "?clientProtocol=1.0", "a", "")]
         [InlineData("/user/path/negotiate", "?clientProtocol=2.1", "a", "?asrs_request_id=a&asrs.op=%2Fuser%2Fpath")]
-        [InlineData("/negotiate", "?customKey=customeValue&clientProtocol=2.1", "?a=c", "?asrs_request_id=%3Fa%3Dc")]
-        [InlineData("/user/negotiate", "?clientProtocol=2.2&customKey=customeValue", "&", "?asrs_request_id=%26&asrs.op=%2Fuser")]
+        [InlineData("/negotiate", "?%3DKey=%3Fa%3Dc&clientProtocol=2.1", "?a=c", "?%3DKey=%3Fa%3Dc&asrs_request_id=%3Fa%3Dc")]
+        [InlineData("/user/negotiate", "?clientProtocol=2.2&customKey=customeValue", "&", "?customKey=customeValue&asrs_request_id=%26&asrs.op=%2Fuser")]
         public async Task TestNegotiateRedirectUrl(string path, string query, string id, string expectedQuery)
         {
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))


### PR DESCRIPTION
For #473 
With this change, QueryString and Headers can be fetched from `Hub.Context.Request`. User is still getting `null` from `Hub.Context.GetHttpContext()` though.