### PR TITLE
Upgrade pipeline version and channel version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -23,7 +23,8 @@
     <MicrosoftAspNetSignalRClientVersion>2.4.1</MicrosoftAspNetSignalRClientVersion>
     <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>2.1.0</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingTraceSourcePackageVersion>2.1.0</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
-    <SystemThreadingChannelsPackageVersion>4.5.0</SystemThreadingChannelsPackageVersion>
+    <SystemThreadingChannelsPackageVersion>4.6.0</SystemThreadingChannelsPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0</SystemIOPipelinesPackageVersion>
     
     <!-- SignalR Management -->
     <MicrosoftConfigurationFileExtensionVersion>2.2.0</MicrosoftConfigurationFileExtensionVersion>

--- a/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
+++ b/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="$(MicrosoftAspNetCoreHttpConnectionsClientPackageVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
-    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
+++ b/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="$(MicrosoftAspNetCoreHttpConnectionsClientPackageVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.SignalR.Common/Microsoft.Azure.SignalR.Common.csproj
+++ b/src/Microsoft.Azure.SignalR.Common/Microsoft.Azure.SignalR.Common.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtPackageVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'">


### PR DESCRIPTION
For AspNet SDK, we've had several customers reporting writing messages slow/hung.
It happens that we are using a quite old version of System.IO.Pipeline and there have been quite a few fixes happened to System.IO.Pipeline related to `WriteAsync`: https://github.com/dotnet/corefx/commit/00c43bd29cd408db3b6b4a8255f32a8f420024ca#diff-9a0b343d0ae95ef90f79dcc5a297c613
Upgrade to the latest version and explicitly use the latest pipeline in SDK projects.