### PR TITLE
Graceful shutdown support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,8 +292,8 @@ __pycache__/
 
 .publish/
 
-# vim
-*.swp
-
 # docker
 .docker/
+
+# vim
+*.swp

--- a/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 configuration.Resolver.Register(typeof(IServiceConnectionFactory), () => scf);
             }
 
-            var sccf = new ServiceConnectionContainerFactory(scf, endpoint, router, options, serverNameProvider, ccm, loggerFactory);
+            var sccf = new ServiceConnectionContainerFactory(scf, endpoint, router, options, serverNameProvider, loggerFactory);
 
             if (hubs?.Count > 0)
             {

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.SignalR.AspNet
             }
             else
             {
-                // the manager still contains this connectionId, probably this connection is not yet cleaned up 
+                // the manager still contains this connectionId, probably this connection is not yet cleaned up
                 Log.DuplicateConnectionId(Logger, connectionId, null);
                 return WriteAsync(
                     new CloseConnectionMessage(connectionId, $"Duplicate connection ID {connectionId}"));
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.SignalR.AspNet
             public string InstanceId { get; }
 
             public ChannelReader<ServiceMessage> Input { get; }
-            
+
             public ChannelWriter<ServiceMessage> Output { get; }
 
             public IServiceTransport Transport { get; set; }

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Azure.SignalR.AspNet
             return Task.WhenAll(GetConnections().Select(s => s.StopAsync()));
         }
 
-        public Task ShutdownAsync(TimeSpan timeout)
+        public Task OfflineAsync()
         {
-            return Task.WhenAll(GetConnections().Select(s => s.ShutdownAsync(timeout)));
+            return Task.WhenAll(GetConnections().Select(s => s.OfflineAsync()));
         }
 
         public IServiceConnectionContainer WithHub(string hubName)

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
@@ -15,7 +14,7 @@ namespace Microsoft.Azure.SignalR
 
         Task StopAsync();
 
-        Task ShutdownAsync(TimeSpan timeout);
+        Task OfflineAsync();
 
         Task WriteAsync(ServiceMessage serviceMessage);
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Azure.SignalR
             {
                 Log.UnexpectedExceptionInStop(Logger, ConnectionId, ex);
             }
-
             return Task.CompletedTask;
         }
 
@@ -395,7 +394,6 @@ namespace Microsoft.Azure.SignalR
                             {
                                 Log.HandshakeError(Logger, handshakeResponse.ErrorMessage, ConnectionId);
                             }
-
                             return false;
                         }
                     }
@@ -416,6 +414,7 @@ namespace Microsoft.Azure.SignalR
         private async Task ProcessIncomingAsync(ConnectionContext connection)
         {
             var keepAliveTimer = StartKeepAliveTimer();
+
             try
             {
                 while (true)
@@ -468,6 +467,7 @@ namespace Microsoft.Azure.SignalR
             finally
             {
                 keepAliveTimer.Stop();
+                _serviceConnectionOfflineTcs.TrySetResult(true);
             }
         }
 
@@ -625,7 +625,6 @@ namespace Microsoft.Azure.SignalR
 
             private static readonly Action<ILogger, string, Exception> _receivedInstanceOfflinePing =
                 LoggerMessage.Define<string>(LogLevel.Information, new EventId(31, "ReceivedInstanceOfflinePing"), "Received instance offline service ping: {InstanceId}");
-
 
             public static void FailedToWrite(ILogger logger, string serviceConnectionId, Exception exception)
             {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.SignalR
         private readonly IServiceEndpointManager _serviceEndpointManager;
         private readonly IMessageRouter _router;
         private readonly IServerNameProvider _nameProvider;
-        private readonly IClientConnectionLifetimeManager _lifetime;
         private readonly IServiceConnectionFactory _serviceConnectionFactory;
 
         public ServiceConnectionContainerFactory(
@@ -22,7 +21,6 @@ namespace Microsoft.Azure.SignalR
         IMessageRouter router,
         IServiceEndpointOptions options,
         IServerNameProvider nameProvider,
-        IClientConnectionLifetimeManager lifetime,
         ILoggerFactory loggerFactory)
         {
             _serviceConnectionFactory = serviceConnectionFactory;
@@ -30,13 +28,12 @@ namespace Microsoft.Azure.SignalR
             _router = router ?? throw new ArgumentNullException(nameof(router));
             _options = options;
             _nameProvider = nameProvider;
-            _lifetime = lifetime;
             _loggerFactory = loggerFactory;
         }
 
         public IServiceConnectionContainer Create(string hub)
         {
-            return new MultiEndpointServiceConnectionContainer(_serviceConnectionFactory, hub, _options.ConnectionCount, _serviceEndpointManager, _router, _nameProvider, _lifetime, _loggerFactory);
+            return new MultiEndpointServiceConnectionContainer(_serviceConnectionFactory, hub, _options.ConnectionCount, _serviceEndpointManager, _router, _nameProvider, _loggerFactory);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -42,13 +43,11 @@ namespace Microsoft.Azure.SignalR
             );
         }
 
-        public override Task ShutdownAsync(TimeSpan timeout)
+        public override Task OfflineAsync()
         {
-            var task = base.StopAsync();
-            return Task.WhenAll(
-                task,
-                Task.CompletedTask // TODO
-            );
+            var task1 = base.OfflineAsync();
+            var task2 = Task.WhenAll(_onDemandServiceConnections.Select(c => RemoveConnectionFromService(c)));
+            return Task.WhenAll(task1, task2);
         }
 
         protected override ServiceConnectionStatus GetStatus()

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -47,8 +47,6 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
             return Task.CompletedTask;
         }
 
-        public override Task ShutdownAsync(TimeSpan timeout) => StopAsync();
-
         public override Task WriteAsync(ServiceMessage serviceMessage)
         {
             if (!_active && !(serviceMessage is PingMessage))
@@ -59,6 +57,11 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
             }
 
             return base.WriteAsync(serviceMessage);
+        }
+
+        public override Task OfflineAsync()
+        {
+            return Task.CompletedTask;
         }
 
         internal bool GetServiceStatus(bool active, int checkWindow, TimeSpan checkTimeSpan)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -17,7 +16,7 @@ namespace Microsoft.Azure.SignalR
 
         Task StopAsync();
 
-        Task ShutdownAsync(TimeSpan timeout);
+        Task OfflineAsync();
 
         Task WriteAsync(ServiceMessage seviceMessage);
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -31,9 +29,9 @@ namespace Microsoft.Azure.SignalR
             return _serviceConnection.StopAsync();
         }
 
-        public Task ShutdownAsync(TimeSpan timeout)
+        public async Task OfflineAsync()
         {
-            return _serviceConnection.ShutdownAsync(timeout);
+            await _serviceConnection.OfflineAsync();
         }
 
         public Task WriteAsync(ServiceMessage serviceMessage)

--- a/src/Microsoft.Azure.SignalR/ServiceOptionsSetup.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptionsSetup.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Azure.SignalR
         private readonly string _connectionString;
         private readonly ServiceEndpoint[] _endpoints;
 
+        private readonly bool _gracefulShutdownEnabled = false;
+        private readonly TimeSpan _shutdownTimeout = TimeSpan.FromSeconds(Constants.DefaultShutdownTimeoutInSeconds);
+
         public ServiceOptionsSetup(IConfiguration configuration)
         {
             _appName = configuration[Constants.ApplicationNameDefaultKeyPrefix];
@@ -44,6 +47,8 @@ namespace Microsoft.Azure.SignalR
             options.Endpoints = _endpoints;
             options.ApplicationName = _appName;
             options.ServerStickyMode = _serverStickyMode;
+            options.EnableGracefulShutdown = _gracefulShutdownEnabled;
+            options.ServerShutdownTimeout = _shutdownTimeout;
         }
 
         private static (string, ServiceEndpoint[]) GetEndpoint(IConfiguration configuration, string key)

--- a/src/Microsoft.Azure.SignalR/ServiceRouteBuilder.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceRouteBuilder.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.SignalR
 {
@@ -58,6 +59,18 @@ namespace Microsoft.Azure.SignalR
 
             var dispatcher = _serviceProvider.GetRequiredService<ServiceHubDispatcher<THub>>();
             dispatcher.Start(app);
+
+#if NETCOREAPP
+            var lifetime = _serviceProvider.GetService<IHostApplicationLifetime>();
+#elif NETSTANDARD
+            var lifetime = _serviceProvider.GetService<IApplicationLifetime>();
+#else
+            var lifetime = null;
+#endif
+            if (lifetime != null)
+            {
+                // lifetime.ApplicationStopping.Register(() => dispatcher.ShutdownAsync(TimeSpan.FromSeconds(30)).Wait());
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
                                                           IEndpointRouter router,
                                                           ILoggerFactory loggerFactory
 
-                ) : base(hub, generator, endpoint, router, null, loggerFactory)
+                ) : base(hub, generator, endpoint, router, loggerFactory)
             {
             }
         }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestBaseServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestBaseServiceConnectionContainer.cs
@@ -19,10 +19,5 @@ namespace Microsoft.Azure.SignalR.Tests.Common
         {
             return Task.CompletedTask;
         }
-
-        protected override Task OnConnectionComplete(IServiceConnection connection)
-        {
-            return Task.CompletedTask;
-        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
             return Task.CompletedTask;
         }
 
-        public Task ShutdownAsync(TimeSpan timeout)
+        public Task OfflineAsync()
         {
             return Task.CompletedTask;
         }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -57,9 +57,6 @@ namespace Microsoft.Azure.SignalR.Tests
             return Task.CompletedTask;
         }
 
-        public Task ShutdownAsync(TimeSpan timeout)
-        {
-            return Task.CompletedTask;
-        }
+        public Task OfflineAsync() => Task.CompletedTask;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Xunit;
@@ -29,28 +30,50 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.NotEqual(ServiceConnectionStatus.Connected, container.Connections[1].Status);
         }
 
+        [Fact]
+        public async Task TestOffline()
+        {
+            List<IServiceConnection> connections = new List<IServiceConnection>
+            {
+                new SimpleTestServiceConnection(),
+                new SimpleTestServiceConnection()
+            };
+            using TestServiceConnectionContainer container = new TestServiceConnectionContainer(connections, factory: new SimpleTestServiceConnectionFactory());
+
+            foreach (SimpleTestServiceConnection c in connections)
+            {
+                Assert.False(c.ConnectionOfflineTask.IsCompleted);
+            }
+
+            await container.OfflineAsync();
+
+            foreach (SimpleTestServiceConnection c in connections)
+            {
+                Assert.True(c.ConnectionOfflineTask.IsCompleted);
+            }
+        }
+
         private sealed class SimpleTestServiceConnectionFactory : IServiceConnectionFactory
         {
-            public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServerConnectionType type)
-            {
-                return new SimpleTestServiceConnection();
-            }
+            public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServerConnectionType type) => new SimpleTestServiceConnection();
         }
 
         private sealed class SimpleTestServiceConnection : IServiceConnection
         {
-            public ServiceConnectionStatus Status { get; set; }
-
             public Task ConnectionInitializedTask => Task.Delay(TimeSpan.FromSeconds(1));
 
-            public Task ConnectionOfflineTask => Task.CompletedTask;
+            public ServiceConnectionStatus Status { get; set; } = ServiceConnectionStatus.Disconnected;
 
-            public event Action<StatusChange> ConnectionStatusChanged;
+            private readonly TaskCompletionSource<bool> _offline = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+
+            public Task ConnectionOfflineTask => _offline.Task;
 
             public SimpleTestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Disconnected)
             {
                 Status = status;
             }
+
+            public event Action<StatusChange> ConnectionStatusChanged;
 
             public Task StartAsync(string target = null)
             {
@@ -60,12 +83,16 @@ namespace Microsoft.Azure.SignalR.Tests
 
             public Task StopAsync()
             {
-                throw new NotImplementedException();
+                return Task.CompletedTask;
             }
 
             public Task WriteAsync(ServiceMessage serviceMessage)
             {
-                throw new NotImplementedException();
+                if (serviceMessage is PingMessage ping && ping.TryGetValue(Constants.ServicePingMessageKey.ShutdownKey, out var val) && val == Constants.ServicePingMessageValue.ShutdownFin)
+                {
+                    _offline.SetResult(true);
+                }
+                return Task.CompletedTask;
             }
         }
     }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerTests.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+
+    public class ServiceConnectionContainerTests
+    {
+
+        private async Task MockServiceAsync(TestServiceConnectionForCloseAsync conn)
+        {
+            IServiceProtocol proto = new ServiceProtocol();
+
+            await conn.ConnectionCreated;
+
+            // open 2 new connections (to create 2 new outgoing tasks
+            proto.WriteMessage(new OpenConnectionMessage(Guid.NewGuid().ToString(), new Claim[0]), conn.Application.Output);
+            proto.WriteMessage(new OpenConnectionMessage(Guid.NewGuid().ToString(), new Claim[0]), conn.Application.Output);
+            await conn.Application.Output.FlushAsync();
+
+            while (true)
+            {
+                var result = await conn.Application.Input.ReadAsync();
+                var buffer = result.Buffer;
+
+                try
+                {
+                    // write back a FinAck after receiving a Fin
+                    if (proto.TryParseMessage(ref buffer, out ServiceMessage message))
+                    {
+                        if (message is PingMessage ping && ping.TryGetValue(Constants.ServicePingMessageKey.ShutdownKey, out string val))
+                        {
+                            if (val == Constants.ServicePingMessageValue.ShutdownFin)
+                            {
+                                PingMessage pong = new PingMessage
+                                {
+                                    Messages = new string[2] { Constants.ServicePingMessageKey.ShutdownKey, Constants.ServicePingMessageValue.ShutdownFinAck }
+                                };
+                                proto.WriteMessage(pong, conn.Application.Output);
+                                await conn.Application.Output.FlushAsync();
+                                break;
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    conn.Application.Input.AdvanceTo(buffer.Start, buffer.End);
+                }
+            }
+        }
+
+        private PingMessage BuildPingMessage(string key, string val)
+        {
+            return new PingMessage
+            {
+                Messages = new string[2] { key, val }
+            };
+        }
+
+        private async Task MockServiceAsyncWithException(TestServiceConnectionForCloseAsync conn)
+        {
+            IServiceProtocol proto = new ServiceProtocol();
+
+            await conn.ConnectionCreated;
+
+            // open 2 new connections (to create 2 new outgoing tasks
+            proto.WriteMessage(new OpenConnectionMessage(Guid.NewGuid().ToString(), new Claim[0]), conn.Application.Output);
+            proto.WriteMessage(new OpenConnectionMessage(Guid.NewGuid().ToString(), new Claim[0]), conn.Application.Output);
+            await conn.Application.Output.FlushAsync();
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            proto.WriteMessage(BuildPingMessage("_exception", "1"), conn.Application.Output);
+            await conn.Application.Output.FlushAsync();
+        }
+
+        private async Task AssertTask(Task task, TimeSpan timeout)
+        {
+            // prevent our test cases from running permanently
+            Task r = await Task.WhenAny(task, Task.Delay(timeout));
+            Assert.Equal(r, task);
+        }
+
+        [Fact]
+        public async void TestCloseAsync()
+        {
+            var conn = new TestServiceConnectionForCloseAsync();
+            var hub = new HubServiceEndpoint();
+            using var container = new TestBaseServiceConnectionContainer(new List<IServiceConnection> { conn }, hub);
+
+            _ = conn.StartAsync();
+            _ = MockServiceAsync(conn);
+
+            // close connection after 1 seconds.
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            // await AssertTask(container.CloseClientConnectionForTest(conn), TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async void TestCloseAsyncWithoutStartAsync()
+        {
+            var conn = new TestServiceConnectionForCloseAsync();
+            var hub = new HubServiceEndpoint();
+            using var container = new TestBaseServiceConnectionContainer(new List<IServiceConnection> { conn }, hub);
+
+            // await AssertTask(container.CloseClientConnectionForTest(conn), TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async void TestCloseAsyncWithExceptionAndNoFinAck()
+        {
+            var conn = new TestServiceConnectionForCloseAsync();
+            var hub = new HubServiceEndpoint();
+            using var container = new TestBaseServiceConnectionContainer(new List<IServiceConnection> { conn }, hub);
+
+            _ = conn.StartAsync();
+            _ = MockServiceAsyncWithException(conn);
+
+            // close connection after 2 seconds to make sure we have received an exception.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+            // TODO double check if we received an exception.
+            // await AssertTask(container.CloseClientConnectionForTest(conn), TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    public class ServiceHubDispatcherTests
+    {
+        [Fact]
+        public async void TestShutdown()
+        {
+            var clientManager = new TestClientConnectionManager();
+            var serviceManager = new TestServiceConnectionManager<Hub>();
+            var dispatcher = new ServiceHubDispatcher<Hub>(
+                null,
+                serviceManager,
+                clientManager,
+                null,
+                new TestOptions(),
+                NullLoggerFactory.Instance,
+                new TestRouter(),
+                null,
+                null
+            );
+
+            await dispatcher.ShutdownAsync(TimeSpan.FromSeconds(1));
+
+            Assert.True(clientManager.completeTime.Subtract(serviceManager.offlineTime) > TimeSpan.FromMilliseconds(100));
+            Assert.True(clientManager.completeTime.Subtract(serviceManager.stopTime) < -TimeSpan.FromMilliseconds(100));
+            Assert.True(serviceManager.offlineTime != serviceManager.stopTime);
+        }
+
+        private sealed class TestRouter : IEndpointRouter
+        {
+            public IEnumerable<ServiceEndpoint> GetEndpointsForBroadcast(IEnumerable<ServiceEndpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<ServiceEndpoint> GetEndpointsForConnection(string connectionId, IEnumerable<ServiceEndpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<ServiceEndpoint> GetEndpointsForGroup(string groupName, IEnumerable<ServiceEndpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<ServiceEndpoint> GetEndpointsForUser(string userId, IEnumerable<ServiceEndpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private sealed class TestClientConnectionManager : IClientConnectionManager
+        {
+            public IReadOnlyDictionary<string, ServiceConnectionContext> ClientConnections => throw new NotImplementedException();
+
+            public DateTime completeTime = new DateTime();
+
+            public void AddClientConnection(ServiceConnectionContext clientConnection)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ServiceConnectionContext RemoveClientConnection(string connectionId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task WhenAllCompleted()
+            {
+                await Task.Delay(100);
+                completeTime = DateTime.Now;
+            }
+        }
+
+        private sealed class TestOptions : IOptions<ServiceOptions>
+        {
+            public ServiceOptions Value => new ServiceOptions();
+        }
+
+        private sealed class TestServiceConnectionManager<THub> : IServiceConnectionManager<THub> where THub : Hub
+        {
+            public DateTime offlineTime = new DateTime();
+            public DateTime stopTime = new DateTime();
+
+            public async Task OfflineAsync()
+            {
+                await Task.Delay(100);
+                offlineTime = DateTime.Now;
+            }
+
+            public void SetServiceConnection(IServiceConnectionContainer serviceConnection)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task StartAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task StopAsync()
+            {
+                await Task.Delay(100);
+                stopTime = DateTime.Now;
+            }
+
+            public Task WriteAckableMessageAsync(ServiceMessage seviceMessage, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteAsync(ServiceMessage seviceMessage)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionContainer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,6 +12,10 @@ namespace Microsoft.Azure.SignalR.Tests
 {
     internal sealed class TestServiceConnectionContainer : ServiceConnectionContainerBase
     {
+        public bool IsOffline { get; set; } = false;
+
+        public bool MockOffline { get; set; } = false;
+
         public TestServiceConnectionContainer(List<IServiceConnection> serviceConnections, HubServiceEndpoint endpoint = null, AckHandler ackHandler = null, IServiceConnectionFactory factory = null)
             : base(factory, 0, endpoint, serviceConnections, ackHandler: ackHandler, logger: NullLogger.Instance)
         {
@@ -22,6 +27,18 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             var prop = typeof(ServiceConnectionContainerBase).GetField("_terminated", BindingFlags.NonPublic | BindingFlags.Instance);
             prop.SetValue(this, true);
+        }
+
+        public override async Task OfflineAsync()
+        {
+            if (MockOffline)
+            {
+                await Task.Delay(100);
+                IsOffline = true;
+            } else
+            {
+                await base.OfflineAsync();
+            }
         }
 
         public override Task HandlePingAsync(PingMessage pingMessage)

--- a/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionForCloseAsync.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionForCloseAsync.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    class TestServiceConnectionForCloseAsync : TestServiceConnection
+    {
+        public TestServiceConnectionForCloseAsync() : base(ServiceConnectionStatus.Connected, false)
+        {
+        }
+
+        /**
+         * Register an outgoing Task.
+         */
+        protected override Task OnConnectedAsync(OpenConnectionMessage openConnectionMessage)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteAsync(ServiceMessage serviceMessage)
+        {
+            return WriteAsyncBase(serviceMessage);
+        }
+    }
+}


### PR DESCRIPTION
The target of this PR is to ensure all incoming and outgoing packages will be processed before a scheduled shutdown. 

**UPDATE 11/13**
> 1. Add test cases for `HubDispatcher` and `MultiEndpointContainer`.

**UPDATE 11/12**
> 1. Lift the `ShutdownAsync` method up to the `HubDispatcher` level.

**UPDATE 11/06**
> 1. Lift the `ShutdownAsync` method up to the `MultiEndpointServiceConnectionContainer` level.
> 2. Add `OfflineAsync` method to `IServiceConnectionContainer`.

**UPDATE 11/05**
> 1. Move `CloseAsync` method to `ServiceConnectionContainer` level.

**UPDATE 11/01**
> 1. Replace **CloseConnectionMessage** with **PingMessage**.
> 2. Wait on TCS instead of connection **outgoing tasks**.
> 3. Prevent rebalanced (ondemand) connection from starting in the shutdown process. 

**UPDATE 10/31**

> Add test cases for corner cases.

**UPDATE 10/29**

> Add test cases for common scenarios.

**UPDATE 10/28**

> Reimplement `CloseAsync` process by using `TaskCompletionSource` which makes the code more readable.

**UPDATE 10/24**

>After discussed thoroughly with @KKhurin  and @vicancy, we decided **NOT** do anything with the messages during the shutdown process in this scenario. We just remove server connections from the routing table to **prevent new client connections to be assigned to this server** and wait until either client or server to close client connections **by themselves**.

> Since the server-side may not have the ability to notify the client to reconnect, maybe we will introduce a mechanism between server and ASRS to let the server has this ability in the future.

> And there will also a TIMEOUT (by default it's 30s). 
> We simply drop every connection after reaching the time limit.

The `CloseAsync` (for each server connection) contains the following 6 steps:

1. Try acquiring `closeConnectionLock` to ensure at most 1 `closeAsync` in progress.
2. Send a `CloseConnectionMessage` with a `FIN` to `ASRS`
    - Once `ASRS` receives a `FIN`, it will remove the server connection immediately from its route table (to prevent new client connections from assigning to this server connection)
3. Wait until `ASRS`  has sent back a `CloseConnectionMessage` with a `FINACK`.
4. Wait until all `client connections` have stopped.
    - Our `ASRS` will handle the client connections and find a proper time to close them, or in some cases we just let our customer close them by themselves. So we intentionally do nothing on the SDK side during this step.
5. Complete `incoming pipe`
6. Wait until the connection `(StartAsync)` has stopped safely.

![image](https://user-images.githubusercontent.com/4176855/67757511-e82f2700-fa76-11e9-8dca-f03b249cb301.png)