### PR TITLE
Add proxy support for the ServiceManager from ServiceManagerOptions

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.SignalR.Management
             _endpoint = new ServiceEndpoint(_serviceManagerOptions.ConnectionString, EndpointType.Secondary);
             _endpointProvider = new ServiceEndpointProvider(_endpoint, Options.Create(new ServiceOptions
             {
-                ApplicationName = _serviceManagerOptions.ApplicationName
+                ApplicationName = _serviceManagerOptions.ApplicationName,
+                Proxy = serviceManagerOptions.Proxy
             }));
             _serverNameProvider = new DefaultServerNameProvider();
             _productInfo = productInfo;

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Net;
 using Microsoft.Azure.SignalR;
 
 namespace Microsoft.Azure.SignalR.Management
@@ -30,6 +31,11 @@ namespace Microsoft.Azure.SignalR.Management
         /// Gets or sets the total number of connections from SDK to Azure SignalR Service. Default value is 1.
         /// </summary>
         public int ConnectionCount { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the proxy used when ServiceManager will attempt to connect to Azure SignalR Service.
+        /// </summary>
+        public IWebProxy Proxy { get; set; }
 
         internal void ValidateOptions()
         {

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.SignalR
         internal TimeSpan ServerShutdownTimeout { get; set; } = TimeSpan.FromSeconds(Constants.DefaultShutdownTimeoutInSeconds);
 
         /// <summary>
-        /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
+        /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR Service.
         /// </summary>
         public IWebProxy Proxy { get; set; }
     }


### PR DESCRIPTION
The idea of this PR is the same as the already Merged PR #534 

This issue has been created to address `ServiceManager` connectivity throught a proxy,
i tried to provide a PR #727 

### Investigation
The `ServiceManager` rely on the `ServiceEndpointProvider` for connectivity
the `ServiceEndpointProvider` already `ServiceOptions` which already has Proxy support (see #534 / #535)

### Proposed fix
The idea is just to add an `IWebProxy` property to the `ServiceManagerOptions` so that is can be forwarded to the `ServiceEndpointProvider` through the `ServiceOptions` :

```
            _endpointProvider = new ServiceEndpointProvider(_endpoint, Options.Create(new ServiceOptions
            {
                // ....
                Proxy = serviceManagerOptions.Proxy
            }));
```