### PR TITLE
Add Interfaces for `Graceful shutdown`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,4 +297,3 @@ __pycache__/
 
 # docker
 .docker/
-

--- a/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/ClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/ClientConnectionManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hosting;
@@ -120,6 +121,8 @@ namespace Microsoft.Azure.SignalR.AspNet
                 return reader.ReadToEnd();
             }
         }
+
+        public Task WhenAllCompleted() => Task.CompletedTask;
 
         private sealed class ClientConnectionHubDispatcher : HubDispatcher
         {

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IClientConnectionLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IClientConnectionLifetimeManager.cs
@@ -1,6 +1,9 @@
-﻿namespace Microsoft.Azure.SignalR
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR
 {
     interface IClientConnectionLifetimeManager
     {
+        Task WhenAllCompleted();
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.SignalR
 
         Task ConnectionInitializedTask { get; }
 
+        Task ConnectionOfflineTask { get; }
+
         event Action<StatusChange> ConnectionStatusChanged;
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.SignalR
         private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1, 1);
 
         private readonly TaskCompletionSource<bool> _serviceConnectionStartTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object> _serviceConnectionOfflineTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         private readonly ServerConnectionType _connectionType;
 
@@ -83,6 +84,8 @@ namespace Microsoft.Azure.SignalR
         }
 
         public Task ConnectionInitializedTask => _serviceConnectionStartTcs.Task;
+
+        public Task ConnectionOfflineTask => _serviceConnectionOfflineTcs.Task;
 
         protected ServiceConnectionBase(IServiceProtocol serviceProtocol, string connectionId,
             HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServerConnectionType connectionType, ILogger logger)
@@ -259,6 +262,11 @@ namespace Microsoft.Azure.SignalR
             {
                 Log.ReceivedInstanceOfflinePing(Logger, instanceId);
                 return CleanupConnections(instanceId);
+            } 
+            if (pingMessage.TryGetValue(Constants.ServicePingMessageKey.ShutdownKey, out string val) && val == Constants.ServicePingMessageValue.ShutdownFinAck)
+            {
+                _serviceConnectionOfflineTcs.TrySetResult(null);
+                return Task.CompletedTask;
             }
             return _serviceMessageHandler.HandlePingAsync(pingMessage);
         }

--- a/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionManager.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.SignalR
             _clientConnections.TryRemove(connectionId, out var connection);
             return connection;
         }
+
+        public Task WhenAllCompleted() => Task.WhenAll(_clientConnections.Select(c => c.Value.CompleteTask));
 
         public IReadOnlyDictionary<string, ServiceConnectionContext> ClientConnections => _clientConnections;
     }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.SignalR
 
         public ServiceConnection(IServiceProtocol serviceProtocol,
                                  IClientConnectionManager clientConnectionManager,
-                                 IConnectionFactory connectionFactory, 
+                                 IConnectionFactory connectionFactory,
                                  ILoggerFactory loggerFactory,
                                  ConnectionDelegate connectionDelegate,
                                  IClientConnectionFactory clientConnectionFactory,
@@ -145,6 +145,7 @@ namespace Microsoft.Azure.SignalR
             {
                 connection.Application.Input.Complete();
                 await PerformDisconnectAsyncCore(connection.ConnectionId, true);
+                connection.OnCompleted();
             }
         }
 
@@ -168,6 +169,7 @@ namespace Microsoft.Azure.SignalR
 
             // Waiting for the application to shutdown so we can clean up the connection
             _ = WaitOnApplicationTask(connection);
+
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionContext.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Azure.SignalR
             readerScheduler: PipeScheduler.ThreadPool,
             useSynchronizationContext: false);
 
+        private readonly TaskCompletionSource<object> _connectionEndTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task CompleteTask => _connectionEndTcs.Task;
+
         private readonly object _heartbeatLock = new object();
         private List<(Action<object> handler, object state)> _heartbeatHandlers;
 
@@ -55,6 +59,11 @@ namespace Microsoft.Azure.SignalR
             configureContext?.Invoke(HttpContext);
 
             Features = BuildFeatures();
+        }
+
+        public void OnCompleted()
+        {
+            _connectionEndTcs.TrySetResult(null);
         }
 
         public void OnHeartbeat(Action<object> action, object state)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
     {
         private readonly ClientConnectionManager _clientConnectionManager;
 
-        public ClientConnectionManagerTests()
+        private ClientConnectionManager CreateClientConnectionManager()
         {
             var hubConfig = new HubConfiguration
             {
@@ -28,7 +28,12 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             var transport = new AzureTransportManager(hubConfig.Resolver);
             hubConfig.Resolver.Register(typeof(ITransportManager), () => transport);
 
-            _clientConnectionManager = new ClientConnectionManager(hubConfig, null);
+            return new ClientConnectionManager(hubConfig, null);
+        }
+
+        public ClientConnectionManagerTests()
+        {
+            _clientConnectionManager = CreateClientConnectionManager();
         }
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
             _contains = contains;
         }
 
+        public Task WhenAllCompleted()
+        {
+            return Task.CompletedTask;
+        }
+
         public Task<IServiceTransport> CreateConnection(OpenConnectionMessage message, IServiceConnection serviceConnection)
         {
             var transport = new TestTransport

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public Task ConnectionInitializedTask => Task.CompletedTask;
 
+        public Task ConnectionOfflineTask => Task.CompletedTask;
+
         public TestServiceConnectionContainer(ServiceConnectionStatus status)
         {
             Status = status;

--- a/test/Microsoft.Azure.SignalR.Tests/ClientConnectionManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientConnectionManagerTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    public class ClientConnectionManagerTests
+    {
+        private async Task RemoveConnection(IClientConnectionManager manager, ServiceConnectionContext ctx)
+        {
+            await Task.Delay(100);
+            ctx.OnCompleted();
+        }
+
+        [Fact]
+        public void TestAllClientConnectionsCompleted()
+        {
+            var manager = new ClientConnectionManager();
+
+            var c1 = new ServiceConnectionContext(new Protocol.OpenConnectionMessage("foo", new Claim[0]));
+            var c2 = new ServiceConnectionContext(new Protocol.OpenConnectionMessage("bar", new Claim[0]));
+
+            manager.AddClientConnection(c1);
+            manager.AddClientConnection(c2);
+
+            _ = RemoveConnection(manager, c1);
+            _ = RemoveConnection(manager, c2);
+
+            var expected = manager.WhenAllCompleted();
+            var actual = Task.WaitAny(
+                expected,
+                Task.Delay(TimeSpan.FromSeconds(1))
+            );
+            Assert.Equal(0, actual);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -262,5 +262,10 @@ namespace Microsoft.Azure.SignalR.Tests
                 tcs.TrySetResult(message);
             }
         }
+
+        public Task WhenAllCompleted()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.SignalR.Tests
 
             public Task ConnectionInitializedTask => Task.Delay(TimeSpan.FromSeconds(1));
 
+            public Task ConnectionOfflineTask => Task.CompletedTask;
+
             public event Action<StatusChange> ConnectionStatusChanged;
 
             public SimpleTestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Disconnected)

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -300,6 +300,11 @@ namespace Microsoft.Azure.SignalR.Tests
                 return connection;
             }
 
+            public Task WhenAllCompleted()
+            {
+                return Task.CompletedTask;
+            }
+
             public IReadOnlyDictionary<string, ServiceConnectionContext> ClientConnections => _ccm.ClientConnections;
         }
     }

--- a/test/Microsoft.Azure.SignalR.Tests/TestSimpleServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestSimpleServiceConnection.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.SignalR.Tests
 
         public Task ConnectionInitializedTask => Task.CompletedTask;
 
+        public Task ConnectionOfflineTask => Task.CompletedTask;
+
         private readonly bool _throws;
         private readonly TaskCompletionSource<object> _writeAsyncTcs = null;
 


### PR DESCRIPTION
Related to #689 
1. Add `ConnectionOfflineTask` for `IServiceConnection`
    - Use for waiting for a server connection to be offlined.
2. Add `AllConnectionsCompleted` for `IClientConnectionLifetimeManager`
    - Use for waiting for existing client connections to be stopped.