### PR TITLE
Server connection migration implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,8 +292,8 @@ __pycache__/
 
 .publish/
 
-# docker
-.docker/
-
 # vim
 *.swp
+
+# docker
+.docker/

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.SignalR
 
         public const int DefaultShutdownTimeoutInSeconds = 30;
 
+        public const string AsrsMigrateIn = "Asrs-Migrate-In";
+        public const string AsrsMigrateOut = "Asrs-Migrate-Out";
         public const string AsrsUserAgent = "Asrs-User-Agent";
         public const string AsrsInstanceId = "Asrs-Instance-Id";
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.SignalR
 {
     internal abstract class ServiceConnectionBase : IServiceConnection
     {
-        private static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(15);
+        protected static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(15);
         // Service ping rate is 5 sec to let server know service status. Set timeout for 30 sec for some space.
         private static readonly TimeSpan DefaultServiceTimeout = TimeSpan.FromSeconds(30);
         private static readonly long DefaultServiceTimeoutTicks = DefaultServiceTimeout.Seconds * Stopwatch.Frequency;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.SignalR
             await c.WriteAsync(_shutdownFinMessage);
         }
 
-        protected async Task RemoveConnectionFromService(IServiceConnection c)
+        protected async Task RemoveConnectionAsync(IServiceConnection c)
         {
             _ = WriteFinAsync(c);
 
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.SignalR
 
         public virtual Task OfflineAsync()
         {
-            return Task.WhenAll(FixedServiceConnections.Select(c => RemoveConnectionFromService(c)));
+            return Task.WhenAll(FixedServiceConnections.Select(c => RemoveConnectionAsync(c)));
         }
 
         private static class Log

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.SignalR
         public override Task OfflineAsync()
         {
             var task1 = base.OfflineAsync();
-            var task2 = Task.WhenAll(_onDemandServiceConnections.Select(c => RemoveConnectionFromService(c)));
+            var task2 = Task.WhenAll(_onDemandServiceConnections.Select(c => RemoveConnectionAsync(c)));
             return Task.WhenAll(task1, task2);
         }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Primitives;
@@ -39,6 +38,8 @@ namespace Microsoft.Azure.SignalR
 
         public Task CompleteTask => _connectionEndTcs.Task;
 
+        public bool IsMigrated { get; }
+
         private readonly object _heartbeatLock = new object();
         private List<(Action<object> handler, object state)> _heartbeatHandlers;
 
@@ -46,6 +47,11 @@ namespace Microsoft.Azure.SignalR
         {
             ConnectionId = serviceMessage.ConnectionId;
             User = serviceMessage.GetUserPrincipal();
+
+            if (serviceMessage.Headers.TryGetValue(Constants.AsrsMigrateIn, out _))
+            {
+                IsMigrated = true;
+            }
 
             // Create the Duplix Pipeline for the virtual connection
             transportPipeOptions = transportPipeOptions ?? DefaultPipeOptions;

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, Exception> _applicationTaskTimedOut =
                 LoggerMessage.Define(LogLevel.Error, new EventId(21, "ApplicationTaskTimedOut"), "Timed out waiting for the application task to complete.");
 
+            private static readonly Action<ILogger, string, Exception> _migrationStarting =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(22, "MigrationStarting"), "Connection {TransportConnectionId} migrated from another server.");
+
+            private static readonly Action<ILogger, string, Exception> _errorSkippingHandshakeResponse =
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(23, "ErrorSkippingHandshakeResponse"), "Error while skipping handshake response during migration, the connection will be dropped on the client-side. Error detail: {message}");
+
             public static void FailedToCleanupConnections(ILogger logger, Exception exception)
             {
                 _failedToCleanupConnections(logger, exception);
@@ -82,6 +88,11 @@ namespace Microsoft.Azure.SignalR
                 _connectedStarting(logger, connectionId, null);
             }
 
+            public static void MigrationStarting(ILogger logger, string connectionId)
+            {
+                _migrationStarting(logger, connectionId, null);
+            }
+
             public static void ConnectedEnding(ILogger logger, string connectionId)
             {
                 _connectedEnding(logger, connectionId, null);
@@ -100,6 +111,11 @@ namespace Microsoft.Azure.SignalR
             public static void ApplicationTaskTimedOut(ILogger logger)
             {
                 _applicationTaskTimedOut(logger, null);
+            }
+
+            public static void ErrorSkippingHandshakeResponse(ILogger logger, Exception ex)
+            {
+                _errorSkippingHandshakeResponse(logger, ex.Message, ex);
             }
         }
     }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    class TestClientConnectionFactory : IClientConnectionFactory
+    {
+        public IList<ClientConnectionContext> Connections = new List<ClientConnectionContext>();
+
+        public ClientConnectionContext CreateConnection(OpenConnectionMessage message, Action<HttpContext> configureContext = null)
+        {
+            var context = new ClientConnectionContext(message, configureContext);
+            Connections.Add(context);
+            return context;
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -42,7 +44,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 new Claim("exp", "1234567890"),
                 new Claim("iat", "1234567890"),
                 new Claim("nbf", "1234567890"),
-                new Claim(Constants.ClaimType.UserId, "customUserId"), 
+                new Claim(Constants.ClaimType.UserId, "customUserId"),
             };
             var serviceConnectionContext = new ClientConnectionContext(new OpenConnectionMessage("1", claims));
             Assert.NotNull(serviceConnectionContext.User.Identity);
@@ -159,6 +161,20 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.Equal(1, request.Query.Count);
             Assert.Equal(path, request.Query[Constants.QueryParameter.OriginalPath]);
             Assert.Equal(path, request.Path);
+        }
+
+        [Fact]
+        public void ServiceConnectionShouldBeMigrated()
+        {
+            var open = new OpenConnectionMessage("foo", new Claim[0]);
+            var context = new ClientConnectionContext(open);
+            Assert.False(context.IsMigrated);
+
+            open.Headers = new Dictionary<string, StringValues>{
+                { Constants.AsrsMigrateIn, "another-server" }
+            };
+            context = new ClientConnectionContext(open);
+            Assert.True(context.IsMigrated);
         }
 
         [Theory]


### PR DESCRIPTION
Related to #689 

The migration will start on the `Runtime` side after the graceful shutdown process begins.

And there is nothing to do with **the old server**. 
> we simply close each connection after receiving `CloseConnectionMessage`.

But we have to prevent `HandshakeResponse` from reaching our `Runtime` after the client connection has been migrated to **the new server** since the client connection has not been really dropped by our `Runtime`. It would be weird if we sent `HandshakeReponse` to our client again.