### PR TITLE
Redirect send2conn from sending to Hub to SvcConn

### DIFF
--- a/samples/ChatSample/ChatSample/Startup.cs
+++ b/samples/ChatSample/ChatSample/Startup.cs
@@ -28,7 +28,7 @@ namespace ChatSample
             app.UseAzureSignalR(routes =>
             {
                 routes.MapHub<Chat>("/chat");
-                routes.MapHub<BenchHub>("/bench");
+                routes.MapHub<BenchHub>("/signalrbench");
             });
         }
     }

--- a/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/ClientConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ClientConnections/ClientConnectionManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hosting;

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Azure.SignalR
 
         public Dictionary<ServiceEndpoint, IServiceConnectionContainer> Connections { get; }
 
-        public MultiEndpointServiceConnectionContainer(string hub, Func<HubServiceEndpoint, IServiceConnectionContainer> generator, IServiceEndpointManager endpointManager, IMessageRouter router, ILoggerFactory loggerFactory)
+        public MultiEndpointServiceConnectionContainer(string hub,
+                                                       Func<HubServiceEndpoint, IServiceConnectionContainer> generator,
+                                                       IServiceEndpointManager endpointManager,
+                                                       IMessageRouter router,
+                                                       ILoggerFactory loggerFactory)
         {
             if (generator == null)
             {
@@ -144,7 +148,6 @@ namespace Microsoft.Azure.SignalR
             {
                 return _inner.WriteAsync(serviceMessage);
             }
-
             return WriteMultiEndpointMessageAsync(serviceMessage, connection => connection.WriteAsync(serviceMessage));
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.SignalR
         {
             _ = WriteFinAsync(c);
 
-            var source = new CancellationTokenSource();
+            using var source = new CancellationTokenSource();
             var task = await Task.WhenAny(c.ConnectionOfflineTask, Task.Delay(RemoveFromServiceTimeout, source.Token));
             source.Cancel();
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
@@ -111,8 +111,7 @@ namespace Microsoft.Azure.SignalR
 
         public Task ApplicationTask { get; set; }
 
-        // The associated HubConnectionContext
-        public HubConnectionContext HubConnectionContext { get; set; }
+        public ServiceConnectionBase ServiceConnection { get; set; }
 
         public HttpContext HttpContext { get; set; }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Azure.SignalR
         protected override Task OnClientConnectedAsync(OpenConnectionMessage message)
         {
             var connection = _clientConnectionFactory.CreateConnection(message, ConfigureContext);
+            connection.ServiceConnection = this;
             AddClientConnection(connection, GetInstanceId(message.Headers));
             Log.ConnectedStarting(Logger, connection.ConnectionId);
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -22,6 +24,8 @@ namespace Microsoft.Azure.SignalR.Tests
         private static readonly List<string> TestUsers = new List<string> {"user1", "user2"};
 
         private static readonly List<string> TestGroups = new List<string> {"group1", "group2"};
+
+        private const string MockProtocol = "blazorpack";
 
         private const string TestMethod = "TestMethod";
 
@@ -78,8 +82,14 @@ namespace Microsoft.Azure.SignalR.Tests
         public async void ServiceLifetimeManagerGroupTest(string functionName, Type type)
         {
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
-            var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
-                new ClientConnectionManager(), HubProtocolResolver, Logger, Marker, _globalHubOptions, _localHubOptions);
+            var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(
+                serviceConnectionManager,
+                new ClientConnectionManager(),
+                HubProtocolResolver,
+                Logger,
+                Marker,
+                _globalHubOptions,
+                _localHubOptions);
 
             await InvokeMethod(serviceLifetimeManager, functionName);
 
@@ -147,8 +157,8 @@ namespace Microsoft.Azure.SignalR.Tests
                     new CustomHubProtocol(),
                 },
                 NullLogger<DefaultHubProtocolResolver>.Instance);
-            IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { "json", "messagepack", "blazorpack" } });
-            IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { "json", "messagepack", "blazorpack" } });
+            IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { "json", "messagepack", MockProtocol } });
+            IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { "json", "messagepack", MockProtocol } });
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
             var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
                 new ClientConnectionManager(), protocolResolver, Logger, Marker, globalHubOptions, localHubOptions);
@@ -169,24 +179,65 @@ namespace Microsoft.Azure.SignalR.Tests
         [InlineData("SendUsersAsync", typeof(MultiUserDataMessage))]
         public async void ServiceLifetimeManagerOnlyBlazorHubProtocolTest(string functionName, Type type)
         {
-            var protocolResolver = new DefaultHubProtocolResolver(new IHubProtocol[]
-                {
-                    new JsonHubProtocol(),
-                    new MessagePackHubProtocol(),
-                    new CustomHubProtocol(),
-                },
-                NullLogger<DefaultHubProtocolResolver>.Instance);
-            IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { "blazorpack" } });
-            IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { "blazorpack" } });
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
-            var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
-                new ClientConnectionManager(), protocolResolver, Logger, Marker, globalHubOptions, localHubOptions);
+            var serviceLifetimeManager = MockLifetimeManager(serviceConnectionManager);
 
             await InvokeMethod(serviceLifetimeManager, functionName);
 
             Assert.Equal(1, serviceConnectionManager.GetCallCount(type));
             VerifyServiceMessage(functionName, serviceConnectionManager.ServiceMessage);
             Assert.Equal(1, (serviceConnectionManager.ServiceMessage as MulticastDataMessage).Payloads.Count);
+        }
+
+        [Fact]
+        public async void TestSendConnectionAsyncisOverwrittenWhenClientConnectionExisted()
+        {
+            var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
+            var clientConnectionManager = new ClientConnectionManager();
+
+            var context = new ClientConnectionContext(new OpenConnectionMessage("conn1", new Claim[] { }));
+            var connection = new TestServiceConnectionPrivate();
+            context.ServiceConnection = connection;
+            clientConnectionManager.AddClientConnection(context);
+
+            var manager = MockLifetimeManager(serviceConnectionManager, clientConnectionManager);
+
+            await manager.SendConnectionAsync("conn1", "foo", new object[] { 1, 2 });
+
+            Assert.NotNull(connection.last);
+            if (connection.last is MultiConnectionDataMessage m)
+            {
+                Assert.Equal("conn1", m.ConnectionList[0]);
+                Assert.Equal(1, m.Payloads.Count);
+                Assert.True(m.Payloads.ContainsKey(MockProtocol));
+                return;
+            }
+            Assert.True(false);
+        }
+
+        private HubLifetimeManager<TestHub> MockLifetimeManager(IServiceConnectionManager<TestHub> serviceConnectionManager, IClientConnectionManager clientConnectionManager = null)
+        {
+            clientConnectionManager ??= new ClientConnectionManager();
+
+            var protocolResolver = new DefaultHubProtocolResolver(new IHubProtocol[]
+                {
+                    new JsonHubProtocol(),
+                    new MessagePackHubProtocol(),
+                    new CustomHubProtocol(),
+                },
+                NullLogger<DefaultHubProtocolResolver>.Instance
+            );
+            IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { MockProtocol } });
+            IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { MockProtocol } });
+            return new ServiceLifetimeManager<TestHub>(
+                serviceConnectionManager,
+                clientConnectionManager,
+                protocolResolver,
+                Logger,
+                Marker,
+                globalHubOptions,
+                localHubOptions
+            );
         }
 
         private static async Task InvokeMethod(HubLifetimeManager<TestHub> serviceLifetimeManager, string methodName)
@@ -278,9 +329,20 @@ namespace Microsoft.Azure.SignalR.Tests
             }
         }
 
-        private class CustomHubProtocol : IHubProtocol
+        private sealed class TestServiceConnectionPrivate : TestServiceConnection
         {
-            public string Name => "blazorpack";
+            public ServiceMessage last = null;
+
+            public override Task WriteAsync(ServiceMessage serviceMessage)
+            {
+                last = serviceMessage;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class CustomHubProtocol : IHubProtocol
+        {
+            public string Name => MockProtocol;
 
             public TransferFormat TransferFormat => throw new NotImplementedException();
 


### PR DESCRIPTION
We almost have all kinds of messages sending to our `ServiceConnection` directly in the existing codes.

Only `sendToConnection` will be sent to `HubContext` and I redirected it to `ServiceConnection` in this PR to fit the rules we are following now.

- And also add an `EchoHub` for our `ChatSample`, which will let our customers doing their perf test easier.