### PR TITLE
Add an AbortConnection token to aspnetcore ServiceConnection

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Utilities/CancellationTokenExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/CancellationTokenExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/CancellationTokenExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/CancellationTokenExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.SignalR
         {
             await cancellationToken;
         }
+
         public static CancellationTokenAwaiter GetAwaiter(this CancellationToken cancellationToken)
         {
             return new CancellationTokenAwaiter(cancellationToken);

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/TaskExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/TaskExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR
+{
+    /// <summary>
+    /// From https://github.com/dotnet/corefx/issues/2704#issuecomment-162370041
+    /// </summary>
+    public static class CancellationTokenExtensions
+    {
+        public static async Task AsTask(this CancellationToken cancellationToken)
+        {
+            await cancellationToken;
+        }
+        public static CancellationTokenAwaiter GetAwaiter(this CancellationToken cancellationToken)
+        {
+            return new CancellationTokenAwaiter(cancellationToken);
+        }
+
+        public class CancellationTokenAwaiter : INotifyCompletion
+        {
+            private readonly CancellationToken _cancellationToken;
+
+            public CancellationTokenAwaiter(CancellationToken cancellationToken)
+            {
+                _cancellationToken = cancellationToken;
+            }
+
+            public void GetResult()
+            {
+            }
+
+            public bool IsCompleted
+            {
+                get
+                {
+                    return _cancellationToken.IsCancellationRequested;
+                }
+            }
+
+            public void OnCompleted(Action action)
+            {
+                _cancellationToken.Register(action);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.SignalR
             var outgoing = ProcessOutgoingMessagesAsync(connection, token);
 
             // Waiting for the application to shutdown so we can clean up the connection
-            _ = ProcessIncomingMessageAsync(connection, token);
+            _ = ProcessIncomingMessageAsync(connection);
 
             // TODO: add more details
             // Current clean up is inside outgoing task when outgoing task completes

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.SignalR
             _connectionIds.TryAdd(connection.ConnectionId, instanceId);
         }
 
-        private async Task ProcessIncomingMessageAsync(ClientConnectionContext connection, CancellationToken token = default)
+        private async Task ProcessIncomingMessageAsync(ClientConnectionContext connection)
         {
             Exception exception = null;
 


### PR DESCRIPTION
Add an AbortConnection token to aspnetcore ServiceConnection so that the ClientConnection process loop can be aborted, also some minor format changes