### PR TITLE
fixing #675 by keeping the Status property in sync with the state of the service connection

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -249,6 +249,9 @@ namespace Microsoft.Azure.SignalR
                 // But messages in the pipe from service -> server should be processed as usual. Just log without
                 // throw exception here.
                 _errorMessage = serviceErrorMessage.ErrorMessage;
+
+                // Update the status immediately
+                Status = ServiceConnectionStatus.Disconnected;
                 Log.ReceivedServiceErrorMessage(Logger, ConnectionId, serviceErrorMessage.ErrorMessage);
             }
 


### PR DESCRIPTION
Fixing #675 by keeping the connection Status property in sync with the state of the service connection.
When a service sends ServiceErrorMessage to the App Server it won't be able to accept new messages. App Server should mark this connection as disconnected immediately to prevent sending new messages to it.