### PR TITLE
Fix apply negotiate endpoint in .NET Core 3.0

### DIFF
--- a/src/Microsoft.Azure.SignalR/Startup/NegotiateMatcherPolicy.cs
+++ b/src/Microsoft.Azure.SignalR/Startup/NegotiateMatcherPolicy.cs
@@ -41,9 +41,13 @@ namespace Microsoft.Azure.SignalR
             for (var i = 0; i < candidates.Count; i++)
             {
                 ref var candidate = ref candidates[i];
-                var newEndpoint = _negotiateEndpointCache.GetOrAdd(candidate.Endpoint, CreateNegotiateEndpoint);
+                // Only apply to RouteEndpoint
+                if (candidate.Endpoint is RouteEndpoint)
+                {
+                    var newEndpoint = _negotiateEndpointCache.GetOrAdd(candidate.Endpoint, CreateNegotiateEndpoint);
 
-                candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
+                    candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
+                }
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Controller is also an Endpoint which should not be converted to negotiate endpoint. Add check for RouteEndpoint only before converting specifically.

Fix #777.