### PR TITLE
Fix blazor bug

### DIFF
--- a/src/Microsoft.Azure.SignalR/Startup/NegotiateMatcherPolicy.cs
+++ b/src/Microsoft.Azure.SignalR/Startup/NegotiateMatcherPolicy.cs
@@ -45,10 +45,14 @@ namespace Microsoft.Azure.SignalR
                 // Only apply to RouteEndpoint
                 if (candidate.Endpoint is RouteEndpoint routeEndpoint)
                 {
-                    var hubType = routeEndpoint.Metadata.GetMetadata<HubMetadata>().HubType;
-                    var newEndpoint = _negotiateEndpointCache.GetOrAdd(hubType, e => CreateNegotiateEndpoint(routeEndpoint));
+                    var hubMetadata = routeEndpoint.Metadata.GetMetadata<HubMetadata>();
+                    // skip endpoint not apply hub.
+                    if (hubMetadata != null)
+                    {
+                        var newEndpoint = _negotiateEndpointCache.GetOrAdd(hubMetadata.HubType, e => CreateNegotiateEndpoint(routeEndpoint));
 
-                    candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
+                        candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
+                    }
                 }
             }
 

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>


### PR DESCRIPTION
RouteEndpoint may not apply hub and could be null before get HubType. Skip this kind of endpoint when redirect service.