### PR TITLE
Refactor about HubDispatcher

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                   endpoint,
                   serviceMessageHandler,
                   connectionType,
+                  ServerConnectionMigrationLevel.Off,
                   loggerFactory?.CreateLogger<ServiceConnection>())
         {
             _connectionFactory = connectionFactory;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.SignalR
             HubServiceEndpoint endpoint,
             IServiceMessageHandler serviceMessageHandler,
             ServiceConnectionType connectionType,
+            ServerConnectionMigrationLevel migrationLevel,
             ILogger logger)
         {
             ServiceProtocol = serviceProtocol;
@@ -108,7 +109,7 @@ namespace Microsoft.Azure.SignalR
             if (serviceProtocol != null)
             {
                 _cachedPingBytes = serviceProtocol.GetMessageBytes(PingMessage.Instance);
-                _handshakeRequest = new HandshakeRequestMessage(serviceProtocol.Version, (int)connectionType);
+                _handshakeRequest = new HandshakeRequestMessage(serviceProtocol.Version, (int)connectionType, (int)migrationLevel);
             }
 
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -58,8 +58,7 @@ namespace Microsoft.Azure.SignalR.Management
                             loggerFactory,
                             connectionDelegate,
                             clientConnectionFactory,
-                            new DefaultServerNameProvider(),
-                            ServerConnectionMigrationLevel.Off
+                            new DefaultServerNameProvider()
                             );
                         var weakConnectionContainer = new WeakServiceConnectionContainer(
                             serviceConnectionFactory,

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Azure.SignalR.Management
                             loggerFactory,
                             connectionDelegate,
                             clientConnectionFactory,
-                            new DefaultServerNameProvider()
+                            new DefaultServerNameProvider(),
+                            ServerConnectionMigrationLevel.Off
                             );
                         var weakConnectionContainer = new WeakServiceConnectionContainer(
                             serviceConnectionFactory,

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -73,10 +73,12 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="version">version</param>
         /// <param name="connectionType">connection type</param>
-        public HandshakeRequestMessage(int version, int connectionType)
+        /// <param name="migrationLevel">migration level</param>
+        public HandshakeRequestMessage(int version, int connectionType, int migrationLevel)
         {
             Version = version;
             ConnectionType = connectionType;
+            MigrationLevel = migrationLevel;
         }
     }
 

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+#if !NETSTANDARD2_0
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
+#endif
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Protocol;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -75,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton(typeof(IServiceEndpointManager), typeof(ServiceEndpointManager))
                 .AddSingleton(typeof(IServerNameProvider), typeof(DefaultServerNameProvider))
                 .AddSingleton(typeof(ServiceHubDispatcher<>))
+                .AddSingleton(typeof(ServerLifetimeManager))
                 .AddSingleton(typeof(AzureSignalRMarkerService))
                 .AddSingleton<IClientConnectionFactory, ClientConnectionFactory>()
                 .AddSingleton<IHostedService, HeartBeat>()

--- a/src/Microsoft.Azure.SignalR/HubHost/ServerLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServerLifetimeManager.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.SignalR
+{
+    internal class ServerLifetimeManager
+    {
+        private readonly IList<Func<Task>> _shutdownHooks = new List<Func<Task>>();
+
+        private object _lock = new object();
+
+        public ServerLifetimeManager(
+            IServiceProvider provider
+        )
+        {
+#if NETCOREAPP
+            var lifetime = provider.GetService<IHostApplicationLifetime>();
+#elif NETSTANDARD
+            var lifetime = provider.GetService<IApplicationLifetime>();
+#else
+            var lifetime = null;
+#endif
+
+            lifetime?.ApplicationStopping.Register(Shutdown);
+        }
+
+        internal void Register(Func<Task> func)
+        {
+            lock (_lock)
+            {
+                _shutdownHooks.Add(func);
+            }
+        }
+
+        private void Shutdown()
+        {
+            lock (_lock)
+            {
+                Task.WaitAll(_shutdownHooks.Select(func => func()).ToArray());
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR/HubHost/ServerLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServerLifetimeManager.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Azure.SignalR
             var lifetime = provider.GetService<IHostApplicationLifetime>();
 #elif NETSTANDARD
             var lifetime = provider.GetService<IApplicationLifetime>();
-#else
-            var lifetime = null;
 #endif
 
             lifetime?.ApplicationStopping.Register(Shutdown);

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Azure.SignalR
                 _loggerFactory,
                 connectionDelegate,
                 _clientConnectionFactory,
-                _nameProvider,
-                _options.MigrationLevel)
+                _nameProvider)
             {
-                ConfigureContext = contextConfig
+                ConfigureContext = contextConfig,
+                MigrationLevel = _options.MigrationLevel
             };
 
             var factory = new ServiceConnectionContainerFactory(

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.SignalR
             ILoggerFactory loggerFactory,
             IEndpointRouter router,
             IServerNameProvider nameProvider,
+            ServerLifetimeManager serverLifetimeManager,
             IClientConnectionFactory clientConnectionFactory)
         {
             _serviceProtocol = serviceProtocol;
@@ -52,6 +53,8 @@ namespace Microsoft.Azure.SignalR
             _clientConnectionFactory = clientConnectionFactory;
             _nameProvider = nameProvider;
             _hubName = typeof(THub).Name;
+
+            serverLifetimeManager?.Register(ShutdownAsync);
         }
 
         public void Start(ConnectionDelegate connectionDelegate, Action<HttpContext> contextConfig = null)
@@ -66,13 +69,18 @@ namespace Microsoft.Azure.SignalR
             _ = _serviceConnectionManager.StartAsync();
         }
 
-        public async Task ShutdownAsync(TimeSpan timeout)
+        public async Task ShutdownAsync()
         {
+            if (!_options.EnableGracefulShutdown)
+            {
+                return;
+            }
+
             using CancellationTokenSource source = new CancellationTokenSource();
 
             var expected = OfflineAndWaitForCompletedAsync(_options.MigrationLevel != ServerConnectionMigrationLevel.Off);
             var actual = await Task.WhenAny(
-                Task.Delay(timeout, source.Token), expected
+                Task.Delay(_options.ServerShutdownTimeout, source.Token), expected
             );
 
             if (actual != expected)
@@ -93,14 +101,16 @@ namespace Microsoft.Azure.SignalR
         private IMultiEndpointServiceConnectionContainer GetMultiEndpointServiceConnectionContainer(string hub, ConnectionDelegate connectionDelegate, Action<HttpContext> contextConfig = null)
         {
             var connectionFactory = new ConnectionFactory(_nameProvider, _loggerFactory);
-            var serviceConnectionFactory = new ServiceConnectionFactory(_serviceProtocol,
+
+            var serviceConnectionFactory = new ServiceConnectionFactory(
+                _serviceProtocol,
                 _clientConnectionManager,
                 connectionFactory,
                 _loggerFactory,
                 connectionDelegate,
                 _clientConnectionFactory,
-                _nameProvider
-                )
+                _nameProvider,
+                _options.MigrationLevel)
             {
                 ConfigureContext = contextConfig
             };

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Azure.SignalR
         private const string ClientConnectionCountInHub = "#clientInHub";
         private const string ClientConnectionCountInServiceConnection = "#client";
 
-        private bool EnableMigration { get; set; }
-
         private readonly IConnectionFactory _connectionFactory;
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly int _closeTimeOutMilliseconds;
@@ -40,6 +38,8 @@ namespace Microsoft.Azure.SignalR
             new string[4] { ClientConnectionCountInHub, null, ClientConnectionCountInServiceConnection, null };
 
         private readonly ConnectionDelegate _connectionDelegate;
+
+        private readonly bool _enableMigration;
 
         public Action<HttpContext> ConfigureContext { get; set; }
 
@@ -63,8 +63,7 @@ namespace Microsoft.Azure.SignalR
             _connectionDelegate = connectionDelegate;
             _clientConnectionFactory = clientConnectionFactory;
             _closeTimeOutMilliseconds = closeTimeOutMilliseconds;
-
-            EnableMigration = migrationLevel != ServerConnectionMigrationLevel.Off;
+            _enableMigration = migrationLevel != ServerConnectionMigrationLevel.Off;
         }
 
         protected override Task<ConnectionContext> CreateConnection(string target = null)
@@ -141,7 +140,7 @@ namespace Microsoft.Azure.SignalR
         protected override Task OnClientDisconnectedAsync(CloseConnectionMessage closeConnectionMessage)
         {
             var connectionId = closeConnectionMessage.ConnectionId;
-            if (EnableMigration && _clientConnectionManager.ClientConnections.TryGetValue(connectionId, out var context))
+            if (_enableMigration && _clientConnectionManager.ClientConnections.TryGetValue(connectionId, out var context))
             {
                 if (closeConnectionMessage.Headers.TryGetValue(Constants.AsrsMigrateTo, out var to))
                 {

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -24,13 +24,11 @@ namespace Microsoft.Azure.SignalR
         // Fix issue: https://github.com/Azure/azure-signalr/issues/198
         // .NET Framework has restriction about reserved string as the header name like "User-Agent"
         private static readonly Dictionary<string, string> CustomHeader = new Dictionary<string, string> { { Constants.AsrsUserAgent, ProductInfo.GetProductInfo() } };
-        
+
         private const string ClientConnectionCountInHub = "#clientInHub";
         private const string ClientConnectionCountInServiceConnection = "#client";
 
-        private readonly ServerConnectionMigrationLevel _migrationLevel;
-
-        private bool EnableMigration => _migrationLevel != ServerConnectionMigrationLevel.Off;
+        private bool EnableMigration { get; set; }
 
         private readonly IConnectionFactory _connectionFactory;
         private readonly IClientConnectionFactory _clientConnectionFactory;
@@ -65,7 +63,8 @@ namespace Microsoft.Azure.SignalR
             _connectionDelegate = connectionDelegate;
             _clientConnectionFactory = clientConnectionFactory;
             _closeTimeOutMilliseconds = closeTimeOutMilliseconds;
-            _migrationLevel = migrationLevel;
+
+            EnableMigration = migrationLevel != ServerConnectionMigrationLevel.Off;
         }
 
         protected override Task<ConnectionContext> CreateConnection(string target = null)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.SignalR
         private readonly ConnectionDelegate _connectionDelegate;
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly IServerNameProvider _nameProvider;
-        private readonly ServerConnectionMigrationLevel _migrationLevel;
+
+        public ServerConnectionMigrationLevel MigrationLevel { get; set} = ServerConnectionMigrationLevel.Off;
 
         public Action<HttpContext> ConfigureContext { get; set; }
 
@@ -26,9 +27,8 @@ namespace Microsoft.Azure.SignalR
             ILoggerFactory loggerFactory,
             ConnectionDelegate connectionDelegate,
             IClientConnectionFactory clientConnectionFactory,
-            IServerNameProvider nameProvider,
-            ServerConnectionMigrationLevel migrationLevel = ServerConnectionMigrationLevel.Off
-            )
+            IServerNameProvider nameProvider
+        )
         {
             _serviceProtocol = serviceProtocol;
             _clientConnectionManager = clientConnectionManager;
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.SignalR
             _connectionDelegate = connectionDelegate;
             _clientConnectionFactory = clientConnectionFactory;
             _nameProvider = nameProvider;
-            _migrationLevel = migrationLevel;
         }
 
         public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServiceConnectionType type)
@@ -54,7 +53,7 @@ namespace Microsoft.Azure.SignalR
                 endpoint,
                 serviceMessageHandler,
                 type,
-                _migrationLevel
+                MigrationLevel
             )
             {
                 ConfigureContext = ConfigureContext

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.SignalR
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly IServerNameProvider _nameProvider;
 
-        public ServerConnectionMigrationLevel MigrationLevel { get; set} = ServerConnectionMigrationLevel.Off;
+        public ServerConnectionMigrationLevel MigrationLevel { get; set; } = ServerConnectionMigrationLevel.Off;
 
         public Action<HttpContext> ConfigureContext { get; set; }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionFactory.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.SignalR
         private readonly ConnectionDelegate _connectionDelegate;
         private readonly IClientConnectionFactory _clientConnectionFactory;
         private readonly IServerNameProvider _nameProvider;
+        private readonly ServerConnectionMigrationLevel _migrationLevel;
 
         public Action<HttpContext> ConfigureContext { get; set; }
 
@@ -25,7 +26,9 @@ namespace Microsoft.Azure.SignalR
             ILoggerFactory loggerFactory,
             ConnectionDelegate connectionDelegate,
             IClientConnectionFactory clientConnectionFactory,
-            IServerNameProvider nameProvider)
+            IServerNameProvider nameProvider,
+            ServerConnectionMigrationLevel migrationLevel = ServerConnectionMigrationLevel.Off
+            )
         {
             _serviceProtocol = serviceProtocol;
             _clientConnectionManager = clientConnectionManager;
@@ -34,6 +37,7 @@ namespace Microsoft.Azure.SignalR
             _connectionDelegate = connectionDelegate;
             _clientConnectionFactory = clientConnectionFactory;
             _nameProvider = nameProvider;
+            _migrationLevel = migrationLevel;
         }
 
         public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServiceConnectionType type)
@@ -49,7 +53,9 @@ namespace Microsoft.Azure.SignalR
                 Guid.NewGuid().ToString(),
                 endpoint,
                 serviceMessageHandler,
-                type)
+                type,
+                _migrationLevel
+            )
             {
                 ConfigureContext = ConfigureContext
             };

--- a/src/Microsoft.Azure.SignalR/ServiceRouteBuilder.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceRouteBuilder.cs
@@ -2,15 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Linq;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.SignalR
 {
@@ -21,7 +17,6 @@ namespace Microsoft.Azure.SignalR
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly RouteBuilder _routes;
-        private readonly IList<Func<TimeSpan, Task>> _shutdownHooks = new List<Func<TimeSpan, Task>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceRouteBuilder"/> class.
@@ -31,18 +26,6 @@ namespace Microsoft.Azure.SignalR
         {
             _routes = routes;
             _serviceProvider = _routes.ServiceProvider;
-
-#if NETCOREAPP
-            var lifetime = _serviceProvider.GetService<IHostApplicationLifetime>();
-#elif NETSTANDARD
-            var lifetime = _serviceProvider.GetService<IApplicationLifetime>();
-#else
-            var lifetime = null;
-#endif
-            if (lifetime != null)
-            {
-                // lifetime.ApplicationStopping.Register(Shutdown);
-            }
         }
 
         /// <summary>
@@ -75,14 +58,6 @@ namespace Microsoft.Azure.SignalR
 
             var dispatcher = _serviceProvider.GetRequiredService<ServiceHubDispatcher<THub>>();
             dispatcher.Start(app);
-
-            _shutdownHooks.Add(dispatcher.ShutdownAsync);
-        }
-
-        private void Shutdown()
-        {
-            var timeout = TimeSpan.FromSeconds(30);
-            Task.WaitAll(_shutdownHooks.Select(func => func(timeout)).ToArray());
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
             new HubServiceEndpoint(),
             null, // TODO replace it with a NullMessageHandler
             ServiceConnectionType.Default,
+            ServerConnectionMigrationLevel.Off,
             logger ?? NullLogger.Instance
         )
         {

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 ConnectionDelegate handler = builder.Build();
                 var connection = new ServiceConnection(protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
                     "serverId", Guid.NewGuid().ToString("N"),
-                    null, null, ServiceConnectionType.Default, 1000);
+                    null, null, closeTimeOutMilliseconds: 1000);
 
                 var connectionTask = connection.StartAsync();
 
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 ConnectionDelegate handler = builder.Build();
                 var connection = new ServiceConnection(protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
                                                        "serverId", Guid.NewGuid().ToString("N"), null, null,
-                                                       ServiceConnectionType.Default, 500);
+                                                       closeTimeOutMilliseconds: 500);
 
                 var connectionTask = connection.StartAsync();
 
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 ConnectionDelegate handler = builder.Build();
 
                 var connection = new ServiceConnection(protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
-                    "serverId", Guid.NewGuid().ToString("N"), null, null, ServiceConnectionType.Default, 500);
+                    "serverId", Guid.NewGuid().ToString("N"), null, null, closeTimeOutMilliseconds: 500);
 
                 var connectionTask = connection.StartAsync();
 
@@ -399,7 +399,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 builder.UseConnectionHandler<EndlessConnectionHandler>();
                 ConnectionDelegate handler = builder.Build();
                 var connection = new ServiceConnection(protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
-                    "serverId", Guid.NewGuid().ToString("N"), null, null, ServiceConnectionType.Default, 500);
+                    "serverId", Guid.NewGuid().ToString("N"), null, null, closeTimeOutMilliseconds: 500);
 
                 var connectionTask = connection.StartAsync();
 
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 Guid.NewGuid().ToString("N"),
                 null,
                 null,
-                enableConnectionMigration: true
+                migrationLevel: ServerConnectionMigrationLevel.ShutdownOnly
             )
             {
             }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -18,19 +18,25 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             var clientManager = new TestClientConnectionManager();
             var serviceManager = new TestServiceConnectionManager<Hub>();
+
+            var options = new TestOptions();
+            options.Value.EnableGracefulShutdown = true;
+            options.Value.ServerShutdownTimeout = TimeSpan.FromSeconds(1);
+
             var dispatcher = new ServiceHubDispatcher<Hub>(
                 null,
                 serviceManager,
                 clientManager,
                 null,
-                new TestOptions(),
+                options,
                 NullLoggerFactory.Instance,
                 new TestRouter(),
+                null,
                 null,
                 null
             );
 
-            await dispatcher.ShutdownAsync(TimeSpan.FromSeconds(1));
+            await dispatcher.ShutdownAsync();
 
             Assert.True(clientManager.completeTime.Subtract(serviceManager.offlineTime) > TimeSpan.FromMilliseconds(100));
             Assert.True(clientManager.completeTime.Subtract(serviceManager.stopTime) < -TimeSpan.FromMilliseconds(100));
@@ -90,7 +96,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         private sealed class TestOptions : IOptions<ServiceOptions>
         {
-            public ServiceOptions Value => new ServiceOptions();
+            public ServiceOptions Value { get; } = new ServiceOptions();
         }
 
         private sealed class TestServiceConnectionManager<THub> : IServiceConnectionManager<THub> where THub : Hub


### PR DESCRIPTION
According to our latest change for the `.NetCore 3.0`, which is using reflection to get `HubDispathcer` and starting it.

We introduced a singleton instance `ServerLifetimeManager` to register shutdown hooks and account for the **graceful shutdown**.

And also,
1. Some default value changes. (timeout, migration level)
2. Add required properties. (migration level)