### PR TITLE
[AAD] AccessKey object

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         private const string ServerPath = "aspnetserver";
 
         private readonly string _endpoint;
-        private readonly string _accessKey;
+        private readonly AccessKey _accessKey;
         private readonly string _appName;
         private readonly int? _port;
         private readonly TimeSpan _accessTokenLifetime;

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.Azure.SignalR
+{
+    internal class AccessKey
+    {
+        public string Value { get; set; }
+        public string Id { get; set; }
+
+        public AccessKey(string key, string keyId = null)
+        {
+            Value = key;
+            if (string.IsNullOrEmpty(keyId))
+            {
+                Id = key.GetHashCode().ToString();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
 
 namespace Microsoft.Azure.SignalR
 {
@@ -23,7 +22,7 @@ namespace Microsoft.Azure.SignalR
 
         internal string Version { get; }
 
-        internal string AccessKey { get; }
+        internal AccessKey AccessKey { get; private set; }
 
         internal int? Port { get; }
 
@@ -40,7 +39,9 @@ namespace Microsoft.Azure.SignalR
             // The provider is responsible to check if the connection string is empty and throw correct error message
             if (!string.IsNullOrEmpty(connectionString))
             {
-                (Endpoint, AccessKey, Version, Port) = ConnectionStringParser.Parse(connectionString);
+                string key;
+                (Endpoint, key, Version, Port) = ConnectionStringParser.Parse(connectionString);
+                AccessKey = new AccessKey(key);
             }
 
             EndpointType = type;
@@ -62,8 +63,14 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
+
         // test only
         internal ServiceEndpoint() { }
+
+        internal void UpdateAccessKey(AccessKey key)
+        {
+            AccessKey = key;
+        }
 
         public override string ToString()
         {

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/AuthUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/AuthUtility.cs
@@ -23,19 +23,21 @@ namespace Microsoft.Azure.SignalR
             string audience = null,
             IEnumerable<Claim> claims = null,
             DateTime? expires = null,
-            string signingKey = null,
+            AccessKey signingKey = null,
             DateTime? issuedAt = null,
             DateTime? notBefore = null,
             AccessTokenAlgorithm algorithm = AccessTokenAlgorithm.HS256)
         {
             var subject = claims == null ? null : new ClaimsIdentity(claims);
             SigningCredentials credentials = null;
-            if (!string.IsNullOrEmpty(signingKey))
+            if (signingKey != null)
             {
                 // Refer: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/5.5.0
                 // From version 5.5.0, SignatureProvider caching is turned On by default, assign KeyId to enable correct cache for same SigningKey
-                var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
-                securityKey.KeyId = signingKey.GetHashCode().ToString();
+                var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey.Value))
+                {
+                    KeyId = signingKey.Id
+                };
                 credentials = new SigningCredentials(securityKey, GetSecurityAlgorithm(algorithm));
             }
 
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.SignalR
         }
 
         public static string GenerateAccessToken(
-            string signingKey, 
+            AccessKey signingKey, 
             string audience, 
             IEnumerable<Claim> claims, 
             TimeSpan lifetime,

--- a/src/Microsoft.Azure.SignalR.Management/RestApiAccessTokenGenerator.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestApiAccessTokenGenerator.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Azure.SignalR.Management
 {
     internal class RestApiAccessTokenGenerator
     {
-        private string _accessKey;
+        private AccessKey _accessKey;
         private Claim[] _claims;
 
-        public RestApiAccessTokenGenerator(string accessKey)
+        public RestApiAccessTokenGenerator(AccessKey accessKey)
         {
             _accessKey = accessKey;
             _claims = new[]

--- a/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Azure.SignalR.Management
 
         public RestApiProvider(string connectionString, string hubName, string appName)
         {
-            string accessKey;
-            (_baseEndpoint, accessKey, _, _port) = ConnectionStringParser.Parse(connectionString);
+            string key;
+            (_baseEndpoint, key, _, _port) = ConnectionStringParser.Parse(connectionString);
             _hubName = hubName;
             _appName = appName;
-            _restApiAccessTokenGenerator = new RestApiAccessTokenGenerator(accessKey);
+            _restApiAccessTokenGenerator = new RestApiAccessTokenGenerator(new AccessKey(key));
             _requestPrefix = _port == null ? $"{_baseEndpoint}/api/v1/hubs/{GetPrefixedHubName(_appName, _hubName)}" : $"{_baseEndpoint}:{_port}/api/v1/hubs/{GetPrefixedHubName(_appName, _hubName)}";
             _audiencePrefix = $"{_baseEndpoint}/api/v1/hubs/{GetPrefixedHubName(_appName, _hubName)}";
         }

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.SignalR
             $"Please specify a configuration entry for {Constants.Keys.ConnectionStringDefaultKey}, " +
             "or explicitly pass one using IServiceCollection.AddAzureSignalR(connectionString) in Startup.ConfigureServices.";
 
-        private readonly string _accessKey;
+        private readonly AccessKey _accessKey;
         private readonly string _appName;
         private readonly TimeSpan _accessTokenLifetime;
         private readonly IServiceEndpointGenerator _generator;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/AuthenticationHelperTest.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/AuthenticationHelperTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         public void TestAccessTokenTooLongThrowsException()
         {
             var claims = GenerateClaims(100);
-            var exception = Assert.Throws<AzureSignalRAccessTokenTooLongException>(() => AuthUtility.GenerateAccessToken(SigningKey, Audience, claims, DefaultLifetime, AccessTokenAlgorithm.HS256));
+            var exception = Assert.Throws<AzureSignalRAccessTokenTooLongException>(() => AuthUtility.GenerateAccessToken(new AccessKey(SigningKey), Audience, claims, DefaultLifetime, AccessTokenAlgorithm.HS256));
 
             Assert.Equal("AccessToken must not be longer than 4K.", exception.Message);
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             var count = 0;
             while (count < 1000)
             {
-                AuthUtility.GenerateJwtBearer(audience: Audience, expires: DateTime.UtcNow.Add(DefaultLifetime), signingKey: SigningKey);
+                AuthUtility.GenerateJwtBearer(audience: Audience, expires: DateTime.UtcNow.Add(DefaultLifetime), signingKey: new AccessKey(SigningKey));
                 count++;
             };
 

--- a/test/Microsoft.Azure.SignalR.Tests/JwtTokenHelper.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/JwtTokenHelper.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.SignalR.Tests
 {
@@ -15,7 +13,7 @@ namespace Microsoft.Azure.SignalR.Tests
     {
         public static readonly JwtSecurityTokenHandler JwtHandler = new JwtSecurityTokenHandler();
 
-        public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, string accessKey, IEnumerable<Claim> customClaims = null)
+        public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, AccessKey accessKey, IEnumerable<Claim> customClaims = null)
         {
             var requestId = token.Claims.FirstOrDefault(claim => claim.Type == Constants.ClaimType.Id)?.Value;
 
@@ -32,24 +30,31 @@ namespace Microsoft.Azure.SignalR.Tests
                 claims.AddRange(customClaims.ToList());
             }
 
-            var tokenString = GenerateJwtBearer(audience, claims, token.ValidTo,
+            var tokenString = GenerateJwtBearer(
+                audience, claims,
+                token.ValidTo,
                 token.ValidFrom,
                 token.ValidFrom,
-                accessKey,
-                requestId);
+                accessKey
+            );
 
             return tokenString;
         }
 
-        public static string GenerateJwtBearer(string audience,
+        public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, string key, IEnumerable<Claim> customClaims = null)
+        {
+            return GenerateExpectedAccessToken(token, audience, new AccessKey(key), customClaims: customClaims);
+        }
+
+        public static string GenerateJwtBearer(
+            string audience,
             IEnumerable<Claim> subject,
             DateTime expires,
             DateTime notBefore,
             DateTime issueAt,
-            string signingKey,
-            string requestId)
+            AccessKey signingKey
+        )
         {
-            
             return AuthUtility.GenerateJwtBearer(
                 issuer: null,
                 audience: audience,
@@ -57,7 +62,20 @@ namespace Microsoft.Azure.SignalR.Tests
                 notBefore: notBefore,
                 expires: expires,
                 issuedAt: issueAt,
-                signingKey: signingKey);
+                signingKey: signingKey
+            );
+        }
+
+        public static string GenerateJwtBearer(
+            string audience,
+            IEnumerable<Claim> subject,
+            DateTime expires,
+            DateTime notBefore,
+            DateTime issueAt,
+            string signingKey
+        )
+        {
+            return GenerateJwtBearer(audience, subject, expires, notBefore, issueAt, new AccessKey(signingKey));
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
@@ -139,8 +139,8 @@ namespace Microsoft.Azure.SignalR.Tests
                 token.ValidTo,
                 token.ValidFrom,
                 token.ValidFrom,
-                AccessKey,
-                string.Empty);
+                AccessKey
+            );
 
             Assert.Equal(expectedTokenString, tokenString);
         }
@@ -161,8 +161,8 @@ namespace Microsoft.Azure.SignalR.Tests
                 token.ValidTo,
                 token.ValidFrom,
                 token.ValidFrom,
-                AccessKey,
-                string.Empty);
+                AccessKey
+            );
 
             Assert.Equal(expectedTokenString, tokenString);
         }
@@ -180,8 +180,8 @@ namespace Microsoft.Azure.SignalR.Tests
                 token.ValidTo,
                 token.ValidFrom,
                 token.ValidFrom,
-                AccessKey,
-                requestId);
+                AccessKey
+            );
 
             Assert.Equal(expectedTokenString, tokenString);
         }
@@ -199,8 +199,8 @@ namespace Microsoft.Azure.SignalR.Tests
                 token.ValidTo,
                 token.ValidFrom,
                 token.ValidFrom,
-                AccessKey,
-                requestId);
+                AccessKey
+            );
 
             Assert.Equal(expectedTokenString, tokenString);
         }


### PR DESCRIPTION
Introduce a new object type `AccessKey` to storage the relationship between `AccessKey` and its `KeyId`, even expiration time in the future.