### PR TITLE
[AAD] make GetAccessToken async

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR.AspNet
 {
@@ -53,13 +54,14 @@ namespace Microsoft.Azure.SignalR.AspNet
             return string.IsNullOrEmpty(applicationName) ? hubName.ToLower() : $"{applicationName.ToLower()}_{hubName.ToLower()}";
         }
 
-        public string GenerateClientAccessToken(string hubName = null, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null)
+        public async Task<string> GenerateClientAccessTokenAsync(string hubName = null, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null)
         {
             var audience = $"{_endpoint}/{ClientPath}";
+            await _accessKey.AuthorizedTask;
             return AuthUtility.GenerateAccessToken(_accessKey, audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);
         }
 
-        public string GenerateServerAccessToken(string hubName, string userId, TimeSpan? lifetime = null)
+        public async Task<string> GenerateServerAccessTokenAsync(string hubName, string userId, TimeSpan? lifetime = null)
         {
             IEnumerable<Claim> claims = null;
             if (userId != null)
@@ -70,6 +72,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 };
             }
 
+            await _accessKey.AuthorizedTask;
             var audience = $"{_endpoint}/{ServerPath}/?hub={GetPrefixedHubName(_appName, hubName)}";
 
             return AuthUtility.GenerateAccessToken(_accessKey, audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
@@ -1,17 +1,18 @@
-﻿namespace Microsoft.Azure.SignalR
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR
 {
     internal class AccessKey
     {
-        public string Value { get; set; }
-        public string Id { get; set; }
+        public string Value { get; }
+        public string Id { get; }
 
-        public AccessKey(string key, string keyId = null)
+        public Task AuthorizedTask => Task.CompletedTask;
+
+        public AccessKey(string key)
         {
             Value = key;
-            if (string.IsNullOrEmpty(keyId))
-            {
-                Id = key.GetHashCode().ToString();
-            }
+            Id = key.GetHashCode().ToString();
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointProvider.cs
@@ -5,16 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR
 {
     internal interface IServiceEndpointProvider
     {
-        string GenerateClientAccessToken(string hubName, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null);
+        Task<string> GenerateClientAccessTokenAsync(string hubName, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null);
 
         string GetClientEndpoint(string hubName, string originalPath, string queryString);
 
-        string GenerateServerAccessToken(string hubName, string userId, TimeSpan? lifetime = null);
+        Task<string> GenerateServerAccessTokenAsync(string hubName, string userId, TimeSpan? lifetime = null);
 
         string GetServerEndpoint(string hubName);
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.SignalR
         {
             var provider = endpoint.Provider;
             var hubName = endpoint.Hub;
-            Func<Task<string>> accessTokenGenerater = () => Task.FromResult(provider.GenerateServerAccessToken(hubName, _userId));
+            Func<Task<string>> accessTokenGenerater = () => provider.GenerateServerAccessTokenAsync(hubName, _userId);
             var url = GetServiceUrl(provider, hubName, connectionId, target);
             var connectionOptions = new WebSocketConnectionOptions
             {

--- a/src/Microsoft.Azure.SignalR.Management/IServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// <param name="claims">The claim list to be put into access token.</param>
         /// <param name="lifeTime">The lifetime of the token. The default value is one hour.</param>
         /// <returns>Client access token to Azure SignalR Service.</returns>
-        string GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null);
+        Task<string> GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null);
 
         /// <summary>
         /// Creates an client endpoint for SignalR hub connections to connect to Azure SignalR Service

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.SignalR.Management
             }
         }
 
-        public string GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null)
+        public Task<string> GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null)
         {
             var claimsWithUserId = new List<Claim>();
             if (userId != null)
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.SignalR.Management
             {
                 claimsWithUserId.AddRange(claims);
             }
-            return _endpointProvider.GenerateClientAccessToken(hubName, claimsWithUserId, lifeTime);
+            return _endpointProvider.GenerateClientAccessTokenAsync(hubName, claimsWithUserId, lifeTime);
         }
 
         public string GetClientEndpoint(string hubName) => _endpointProvider.GetClientEndpoint(hubName, null, null);

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR
 {
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.SignalR
             _generator = new DefaultServiceEndpointGenerator(endpoint.Endpoint, version, port);
         }
 
-        public string GenerateClientAccessToken(string hubName, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null)
+        public async Task<string> GenerateClientAccessTokenAsync(string hubName, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null)
         {
             if (string.IsNullOrEmpty(hubName))
             {
@@ -52,10 +53,11 @@ namespace Microsoft.Azure.SignalR
 
             var audience = _generator.GetClientAudience(hubName, _appName);
 
+            await _accessKey.AuthorizedTask;
             return AuthUtility.GenerateAccessToken(_accessKey, audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);
         }
 
-        public string GenerateServerAccessToken(string hubName, string userId, TimeSpan? lifetime = null)
+        public async Task<string> GenerateServerAccessTokenAsync(string hubName, string userId, TimeSpan? lifetime = null)
         {
             if (string.IsNullOrEmpty(hubName))
             {
@@ -65,6 +67,7 @@ namespace Microsoft.Azure.SignalR
             var audience = _generator.GetServerAudience(hubName, _appName);
             var claims = userId != null ? new[] { new Claim(ClaimTypes.NameIdentifier, userId) } : null;
 
+            await _accessKey.AuthorizedTask;
             return AuthUtility.GenerateAccessToken(_accessKey, audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);
         }
 

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.SignalR
             _endpointsCount = options.Value.Endpoints.Length;
         }
 
-        public NegotiationResponse Process(HttpContext context, string hubName)
+        public async Task<NegotiationResponse> Process(HttpContext context, string hubName)
         {
             var claims = BuildClaims(context);
             var request = context.Request;
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.SignalR
             return new NegotiationResponse
             {
                 Url = provider.GetClientEndpoint(hubName, originalPath, queryString),
-                AccessToken = provider.GenerateClientAccessToken(hubName, claims),
+                AccessToken = await provider.GenerateClientAccessTokenAsync(hubName, claims),
                 // Need to set this even though it's technically protocol violation https://github.com/aspnet/SignalR/issues/2133
                 AvailableTransports = new List<AvailableTransport>()
             };

--- a/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
+++ b/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.SignalR
             NegotiationResponse negotiateResponse = null;
             try
             {
-                negotiateResponse = handler.Process(context, hubName);
+                negotiateResponse = await handler.Process(context, hubName);
 
                 if (context.Response.HasStarted)
                 {

--- a/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
@@ -331,10 +331,17 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 var serviceHubContext = await serviceManager.CreateHubContextAsync(HubName, loggerFactory);
 
                 var clientEndpoint = serviceManager.GetClientEndpoint(HubName);
-                var clientAccessTokens = from userName in _userNames
+                var tasks = from userName in _userNames
                                          select serviceManager.GenerateClientAccessToken(HubName, userName);
 
-                return (clientEndpoint, clientAccessTokens.ToArray(), serviceHubContext);
+                await Task.WhenAll(tasks);
+
+                var tokens = new List<string>();
+                foreach (var task in tasks)
+                {
+                    tokens.Add(task.Result);
+                }
+                return (clientEndpoint, tokens, serviceHubContext);
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
         [Theory]
         [MemberData(nameof(TestGenerateAccessTokenData))]
-        internal void GenerateClientAccessTokenTest(string userId, Claim[] claims, string appName)
+        internal async Task GenerateClientAccessTokenTest(string userId, Claim[] claims, string appName)
         {
             var manager = new ServiceManager(new ServiceManagerOptions() { ConnectionString = _testConnectionString, ApplicationName = appName }, null);
-            var tokenString = manager.GenerateClientAccessToken(HubName, userId, claims, _tokenLifeTime);
+            var tokenString = await manager.GenerateClientAccessToken(HubName, userId, claims, _tokenLifeTime);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             string expectedToken = JwtTokenHelper.GenerateExpectedAccessToken(token, GetExpectedClientEndpoint(appName), AccessKey, claims);

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Localization;
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [InlineData(typeof(CustomUserIdProvider), CustomUserId)]
         [InlineData(typeof(NullUserIdProvider), null)]
         [InlineData(typeof(DefaultUserIdProvider), DefaultUserId)]
-        public void GenerateNegotiateResponseWithUserId(Type type, string expectedUserId)
+        public async Task GenerateNegotiateResponseWithUserId(Type type, string expectedUserId)
         {
             var config = new ConfigurationBuilder().Build();
             var serviceProvider = new ServiceCollection()
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.SignalR.Tests
             };
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "hub");
+            var negotiateResponse = await handler.Process(httpContext, "hub");
 
             Assert.NotNull(negotiateResponse);
             Assert.NotNull(negotiateResponse.Url);
@@ -85,7 +86,7 @@ namespace Microsoft.Azure.SignalR.Tests
         }
 
         [Fact]
-        public void GenerateNegotiateResponseWithUserIdAndServerSticky()
+        public async Task GenerateNegotiateResponseWithUserIdAndServerSticky()
         {
             var name = nameof(GenerateNegotiateResponseWithUserIdAndServerSticky);
             var serverNameProvider = new TestServerNameProvider(name);
@@ -117,7 +118,7 @@ namespace Microsoft.Azure.SignalR.Tests
             };
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "hub");
+            var negotiateResponse = await handler.Process(httpContext, "hub");
 
             Assert.NotNull(negotiateResponse);
             Assert.NotNull(negotiateResponse.Url);
@@ -142,7 +143,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [InlineData("/user/path/negotiate/", "", "a", "asrs.op=%2Fuser%2Fpath&asrs_request_id=a")]
         [InlineData("", "?customKey=customeValue", "?a=c", "customKey=customeValue&asrs_request_id=%3Fa%3Dc")]
         [InlineData("/user/path/negotiate", "?customKey=customeValue", "&", "asrs.op=%2Fuser%2Fpath&customKey=customeValue&asrs_request_id=%26")]
-        public void GenerateNegotiateResponseWithPathAndQuery(string path, string queryString, string id, string expectedQueryString)
+        public async Task GenerateNegotiateResponseWithPathAndQuery(string path, string queryString, string id, string expectedQueryString)
         {
             var requestIdProvider = new TestRequestIdProvider(id);
             var config = new ConfigurationBuilder().Build();
@@ -164,7 +165,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var httpContext = new DefaultHttpContext(features);
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "chat");
+            var negotiateResponse = await handler.Process(httpContext, "chat");
 
             Assert.NotNull(negotiateResponse);
             Assert.EndsWith($"?hub=chat&{expectedQueryString}", negotiateResponse.Url);
@@ -173,7 +174,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [Theory]
         [InlineData("", "&", "?hub=chat&asrs_request_id=%26")]
         [InlineData("appName", "abc", "?hub=appname_chat&asrs_request_id=abc")]
-        public void GenerateNegotiateResponseWithAppName(string appName, string id, string expectedResponse)
+        public async Task GenerateNegotiateResponseWithAppName(string appName, string id, string expectedResponse)
         {
             var requestIdProvider = new TestRequestIdProvider(id);
             var config = new ConfigurationBuilder().Build();
@@ -197,7 +198,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var httpContext = new DefaultHttpContext(features);
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "chat");
+            var negotiateResponse = await handler.Process(httpContext, "chat");
 
             Assert.NotNull(negotiateResponse);
             Assert.EndsWith(expectedResponse, negotiateResponse.Url);
@@ -208,7 +209,7 @@ namespace Microsoft.Azure.SignalR.Tests
         [InlineData(typeof(ConnectionAbortedTokenUserIdProvider), ServiceHubConnectionContext.ConnectionAbortedUnavailableError)]
         [InlineData(typeof(ItemsUserIdProvider), ServiceHubConnectionContext.ItemsUnavailableError)]
         [InlineData(typeof(ProtocolUserIdProvider), ServiceHubConnectionContext.ProtocolUnavailableError)]
-        public void CustomUserIdProviderAccessUnavailablePropertyThrowsException(Type type, string errorMessage)
+        public async Task CustomUserIdProviderAccessUnavailablePropertyThrowsException(Type type, string errorMessage)
         {
             var config = new ConfigurationBuilder().Build();
             var serviceProvider = new ServiceCollection().AddSignalR()
@@ -225,12 +226,12 @@ namespace Microsoft.Azure.SignalR.Tests
                 User = new ClaimsPrincipal()
             };
 
-            var exception = Assert.Throws<InvalidOperationException>(() => handler.Process(httpContext, "hub"));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await handler.Process(httpContext, "hub"));
             Assert.Equal(errorMessage, exception.Message);
         }
 
         [Fact]
-        public void TestNegotiateHandlerWithMultipleEndpointsAndCustomerRouterAndAppName()
+        public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomerRouterAndAppName()
         {
             var requestIdProvider = new TestRequestIdProvider("a");
             var config = new ConfigurationBuilder().Build();
@@ -264,14 +265,14 @@ namespace Microsoft.Azure.SignalR.Tests
             var httpContext = new DefaultHttpContext(features);
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "chat");
+            var negotiateResponse = await handler.Process(httpContext, "chat");
 
             Assert.NotNull(negotiateResponse);
             Assert.Equal($"http://localhost3/client/?hub=testprefix_chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
         }
 
         [Fact]
-        public void TestNegotiateHandlerWithMultipleEndpointsAndCustomRouter()
+        public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomRouter()
         {
             var requestIdProvider = new TestRequestIdProvider("a");
             var config = new ConfigurationBuilder().Build();
@@ -301,7 +302,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var httpContext = new DefaultHttpContext(features);
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "chat");
+            var negotiateResponse = await handler.Process(httpContext, "chat");
 
             Assert.NotNull(negotiateResponse);
             Assert.Equal($"http://localhost3/client/?hub=chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
@@ -318,7 +319,7 @@ namespace Microsoft.Azure.SignalR.Tests
             httpContext = new DefaultHttpContext(features);
 
             handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            negotiateResponse = handler.Process(httpContext, "chat");
+            negotiateResponse = await handler.Process(httpContext, "chat");
 
             Assert.Null(negotiateResponse);
 
@@ -337,11 +338,11 @@ namespace Microsoft.Azure.SignalR.Tests
             httpContext = new DefaultHttpContext(features);
 
             handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            Assert.Throws<InvalidOperationException>(() => handler.Process(httpContext, "chat"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => handler.Process(httpContext, "chat"));
         }
 
         [Fact]
-        public void TestNegotiateHandlerRespectClientRequestCulture()
+        public async Task TestNegotiateHandlerRespectClientRequestCulture()
         {
             var config = new ConfigurationBuilder().Build();
             var serviceProvider = new ServiceCollection()
@@ -372,7 +373,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var httpContext = new DefaultHttpContext(features);
 
             var handler = serviceProvider.GetRequiredService<NegotiateHandler>();
-            var negotiateResponse = handler.Process(httpContext, "hub");
+            var negotiateResponse = await handler.Process(httpContext, "hub");
 
             var queryContainsCulture = negotiateResponse.Url.Contains($"{Constants.QueryParameter.RequestCulture}=ar-SA");
             Assert.True(queryContainsCulture);

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -107,7 +108,7 @@ namespace Microsoft.Azure.SignalR.Tests
         }
 
         [Fact(Skip = "Access token does not need to be unique")]
-        internal void GenerateMultipleAccessTokenShouldBeUnique()
+        internal async Task GenerateMultipleAccessTokenShouldBeUnique()
         {
             var count = 1000;
             var sep = new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithPreviewVersion), _optionsWithoutAppName);
@@ -115,8 +116,8 @@ namespace Microsoft.Azure.SignalR.Tests
             var tokens = new List<string>();
             for (int i = 0; i < count; i++)
             {
-                tokens.Add(sep.GenerateClientAccessToken(nameof(TestHub)));
-                tokens.Add(sep.GenerateServerAccessToken(nameof(TestHub), userId));
+                tokens.Add(await sep.GenerateClientAccessTokenAsync(nameof(TestHub)));
+                tokens.Add(await sep.GenerateServerAccessTokenAsync(nameof(TestHub), userId));
             }
 
             var distinct = tokens.Distinct();
@@ -125,10 +126,10 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(DefaultEndpointProviders))]
-        internal void GenerateServerAccessToken(IServiceEndpointProvider provider)
+        internal async Task GenerateServerAccessToken(IServiceEndpointProvider provider)
         {
             const string userId = "UserA";
-            var tokenString = provider.GenerateServerAccessToken(nameof(TestHub), userId);
+            var tokenString = await provider.GenerateServerAccessTokenAsync(nameof(TestHub), userId);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             var expectedTokenString = JwtTokenHelper.GenerateJwtBearer($"{Endpoint}/server/?hub={HubName}",
@@ -147,10 +148,10 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(DefaultEndpointProvidersPlusPrefix))]
-        internal void GenerateServerAccessTokenWithPrefix(IServiceEndpointProvider provider)
+        internal async Task GenerateServerAccessTokenWithPrefix(IServiceEndpointProvider provider)
         {
             const string userId = "UserA";
-            var tokenString = provider.GenerateServerAccessToken(nameof(TestHub), userId);
+            var tokenString = await provider.GenerateServerAccessTokenAsync(nameof(TestHub), userId);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             var expectedTokenString = JwtTokenHelper.GenerateJwtBearer($"{Endpoint}/server/?hub={AppName}_{HubName}",
@@ -169,10 +170,10 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(DefaultEndpointProviders))]
-        internal void GenerateClientAccessToken(IServiceEndpointProvider provider)
+        internal async Task GenerateClientAccessToken(IServiceEndpointProvider provider)
         {
             var requestId = Guid.NewGuid().ToString();
-            var tokenString = provider.GenerateClientAccessToken(HubName);
+            var tokenString = await provider.GenerateClientAccessTokenAsync(HubName);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             var expectedTokenString = JwtTokenHelper.GenerateJwtBearer($"{Endpoint}/client/?hub={HubName}",
@@ -188,10 +189,9 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(DefaultEndpointProvidersPlusPrefix))]
-        internal void GenerateClientAccessTokenWithPrefix(IServiceEndpointProvider provider)
+        internal async Task GenerateClientAccessTokenWithPrefix(IServiceEndpointProvider provider)
         {
-            var requestId = Guid.NewGuid().ToString();
-            var tokenString = provider.GenerateClientAccessToken(HubName);
+            var tokenString = await provider.GenerateClientAccessTokenAsync(HubName);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             var expectedTokenString = JwtTokenHelper.GenerateJwtBearer($"{Endpoint}/client/?hub={AppName}_{HubName}",
@@ -208,10 +208,10 @@ namespace Microsoft.Azure.SignalR.Tests
         [Theory]
         [InlineData(AccessTokenAlgorithm.HS256)]
         [InlineData(AccessTokenAlgorithm.HS512)]
-        public void GenerateServerAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
+        public async Task GenerateServerAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
         {
             var provider = new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithV1Version), new ServiceOptions() { AccessTokenAlgorithm = algorithm });
-            var generatedToken = provider.GenerateServerAccessToken("hub1", "user1");
+            var generatedToken = await provider.GenerateServerAccessTokenAsync("hub1", "user1");
 
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(generatedToken);
 
@@ -221,10 +221,10 @@ namespace Microsoft.Azure.SignalR.Tests
         [Theory]
         [InlineData(AccessTokenAlgorithm.HS256)]
         [InlineData(AccessTokenAlgorithm.HS512)]
-        public void GenerateClientAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
+        public async Task GenerateClientAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
         {
             var provider = new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithV1Version), new ServiceOptions() { AccessTokenAlgorithm = algorithm });
-            var generatedToken = provider.GenerateClientAccessToken("hub1");
+            var generatedToken = await provider.GenerateClientAccessTokenAsync("hub1");
 
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(generatedToken);
 


### PR DESCRIPTION
Since a server-generated `AccessKey` may need to be authorized in the future. Change the `GetAccessToken` methods to **async** (for both server and client connections)