### PR TITLE
Update messagepack version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/submodules/MessagePack-CSharp"]
 	path = src/submodules/MessagePack-CSharp
 	url = https://github.com/neuecc/MessagePack-CSharp
-	branch = v2.0
+	branch = v2.1.115

--- a/3rdPartyNotices.txt
+++ b/3rdPartyNotices.txt
@@ -2,8 +2,8 @@ Portions of this repository comes from other repositories :
 
 ===================================================================================================================================================
 * https://github.com/neuecc/MessagePack-CSharp/ => /src/submodule/MessagePack-CSharp
-  Commit hash 2e421efb7bc53956fc66356565f9402d3271a588
-  License file : https://github.com/neuecc/MessagePack-CSharp/blob/2e421efb7bc53956fc66356565f9402d3271a588/LICENSE
+  Commit hash 38f095bf0d9b72e2f9e8484282937f433bf3dfcb
+  License file : https://github.com/neuecc/MessagePack-CSharp/blob/38f095bf0d9b72e2f9e8484282937f433bf3dfcb/LICENSE
 
 ===================================================================================================================================================
 Which provides this license: 

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -297,6 +298,20 @@ $@"Binary encoding changed from
 to
     [{actual}]
 Please verify the MsgPack output and update the baseline");
+        }
+
+        [Fact]
+        public void WriteAndParseLargeData()
+        {
+            var protocol = new ServiceProtocol();
+            var count = 70000;
+            var str = new string(Enumerable.Range(0, count).Select(s => 'a').ToArray());
+            var largeData = Encoding.UTF8.GetBytes(str);
+            var message = new ConnectionDataMessage("abc", largeData);
+            var bytes = protocol.GetMessageBytes(message);
+            var seq = new ReadOnlySequence<byte>(bytes);
+            var parsing = protocol.TryParseMessage(ref seq, out var result);
+            Assert.Equal(count, (result as ConnectionDataMessage).Payload.Length);
         }
 
         [Fact]


### PR DESCRIPTION
In old version 2.0 of `MessagePack`, when message length > 64K, the length is treated as `Int64` for `ReadOnlySequence`, however, according to the spec of `MessagePack`, it should be at most treated as `Int32`. The latest version 2.1.115 fixed the issue.

This issue is causing: message length > 64K is not able to get delivered to service.