### PR TITLE
Move active to ServiceEndpoint so that user can decide whether send or not

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -22,12 +22,18 @@ namespace Microsoft.Azure.SignalR
         internal int? Port { get; }
 
         /// <summary>
-        /// When there are server connections connected to the target endpoint for current hub, the endpoint is considered as Online; otherwise, Offline.
+        /// When current app server instance has server connections connected to the target endpoint for current hub, it can deliver messages to that endpoint.
+        /// The endpoint is then considered as *Online*; otherwise, *Offline*.
+        /// Messages are not able to be delivered to an *Offline* endpoint.
         /// </summary>
         public bool Online { get; internal set; } = true;
 
         /// <summary>
-        /// When the target endpoint has client connections of current hub, the endpoint is considered as Active; otherwise, inactive.
+        /// When the target endpoint has hub clients connected, the endpoint is considered as an *Active* endpoint.
+        /// When the target endpoint has no hub clients connected for 10 minutes, the endpoint is considered as an *Inactive* one.
+        /// User can choose to not send messages to an *Inactive* endpoint to save network traffic.
+        /// But please note that as the *Active* status is reported to the server from remote service, there can be some delay when status changes.
+        /// Don't rely on this status if you don't expect any message lose once a client is connected.
         /// </summary>
         public bool IsActive { get; internal set; } = true;
 

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Azure.SignalR
 
         public virtual string Name { get; internal set; }
 
-        /// <summary>
-        /// Initial status as Online so that when the app server first starts, it can accept incoming negotiate requests, as for backward compatability
-        /// </summary>
-        public bool Online { get; internal set; } = true;
-
         public string Endpoint { get; }
 
         internal string Version { get; }
@@ -25,6 +20,16 @@ namespace Microsoft.Azure.SignalR
         internal AccessKey AccessKey { get; private set; }
 
         internal int? Port { get; }
+
+        /// <summary>
+        /// When there are server connections connected to the target endpoint for current hub, the endpoint is considered as Online; otherwise, Offline.
+        /// </summary>
+        public bool Online { get; internal set; } = true;
+
+        /// <summary>
+        /// When the target endpoint has client connections of current hub, the endpoint is considered as Active; otherwise, inactive.
+        /// </summary>
+        public bool IsActive { get; internal set; } = true;
 
         public ServiceEndpoint(string key, string connectionString) : this(connectionString)
         {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -365,16 +365,10 @@ namespace Microsoft.Azure.SignalR
                 var count = info.count;
                 count++;
                 _inactiveInfo = (count, last);
-                
+
                 // Inactive it only when it checks over 5 times and elapsed for over 10 minutes
-                if (count >= checkWindow && DateTime.UtcNow - last >= checkTimeSpan)
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
+                var inactive = count >= checkWindow && DateTime.UtcNow - last >= checkTimeSpan;
+                return !inactive;
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -3,23 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.Common
 {
     internal class WeakServiceConnectionContainer : ServiceConnectionContainerBase
     {
-        private const int CheckWindow = 5;
-        private static readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
-
-        private readonly object _lock = new object();
-        private int _inactiveCount;
-        private DateTime? _firstInactiveTime;
-
-        // active ones are those whose client connections connected to the whole endpoint
-        private volatile bool _active = true;
-
         protected override ServiceConnectionType InitialConnectionType => ServiceConnectionType.Weak;
 
         public WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory,
@@ -28,62 +17,9 @@ namespace Microsoft.Azure.SignalR.Common
         {
         }
 
-        public override Task HandlePingAsync(PingMessage pingMessage)
-        {
-            base.HandlePingAsync(pingMessage);
-            var active = HasClients;
-            _active = GetServiceStatus(active, CheckWindow, CheckTimeSpan);
-
-            return Task.CompletedTask;
-        }
-
-        public override Task WriteAsync(ServiceMessage serviceMessage)
-        {
-            if (!_active && !(serviceMessage is PingMessage))
-            {
-                // If the endpoint is inactive, there is no need to send messages to it
-                Log.IgnoreSendingMessageToInactiveEndpoint(Logger, serviceMessage.GetType(), Endpoint);
-                return Task.CompletedTask;
-            }
-
-            return base.WriteAsync(serviceMessage);
-        }
-
         public override Task OfflineAsync(bool migratable)
         {
             return Task.CompletedTask;
-        }
-
-        internal bool GetServiceStatus(bool active, int checkWindow, TimeSpan checkTimeSpan)
-        {
-            lock (_lock)
-            {
-                if (active)
-                {
-                    _firstInactiveTime = null;
-                    _inactiveCount = 0;
-                    return true;
-                }
-                else
-                {
-                    if (_firstInactiveTime == null)
-                    {
-                        _firstInactiveTime = DateTime.UtcNow;
-                    }
-
-                    _inactiveCount++;
-
-                    // Inactive it only when it checks over 5 times and elapsed for over 10 minutes
-                    if (_inactiveCount >= checkWindow && DateTime.UtcNow - _firstInactiveTime >= checkTimeSpan)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
-                }
-            }
         }
 
         private static class Log

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -26,12 +26,15 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public Task ConnectionCreated => _created.Task;
 
-        public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected, bool throws = false, ILogger logger = null) : base(
+        public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected, bool throws = false,
+            ILogger logger = null,
+            IServiceMessageHandler serviceMessageHandler = null
+            ) : base(
             new ServiceProtocol(),
             "serverId",
             Guid.NewGuid().ToString(),
             new HubServiceEndpoint(),
-            null, // TODO replace it with a NullMessageHandler
+            serviceMessageHandler, // TODO replace it with a NullMessageHandler
             ServiceConnectionType.Default,
             ServerConnectionMigrationLevel.Off,
             logger ?? NullLogger.Instance

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
             "serverId",
             Guid.NewGuid().ToString(),
             new HubServiceEndpoint(),
-            serviceMessageHandler, // TODO replace it with a NullMessageHandler
+            serviceMessageHandler,
             ServiceConnectionType.Default,
             ServerConnectionMigrationLevel.Off,
             logger ?? NullLogger.Instance

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionFactory.cs
@@ -2,12 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Azure.SignalR.Tests.Common
 {
     internal sealed class TestServiceConnectionFactory : IServiceConnectionFactory
     {
         private readonly Func<ServiceEndpoint, IServiceConnection> _generator;
+
+        public ConcurrentQueue<IServiceConnection> CreatedConnections { get; } = new ConcurrentQueue<IServiceConnection>();
+        
         public TestServiceConnectionFactory(Func<ServiceEndpoint, IServiceConnection> generator = null)
         {
             _generator = generator;
@@ -15,7 +19,9 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServiceConnectionType type)
         {
-            return _generator?.Invoke(endpoint) ?? new TestServiceConnection();
+            var conn = _generator?.Invoke(endpoint) ?? new TestServiceConnection(serviceMessageHandler: serviceMessageHandler);
+            CreatedConnections.Enqueue(conn);
+            return conn;
         }
     }
 }


### PR DESCRIPTION
Move active to ServiceEndpoint so that user can decide whether to send messages or not instead of making it a default behavior of weak connections