### PR TITLE
[POC] Message ID Sample

### DIFF
--- a/samples/ChatSample/ChatSample/Program.cs
+++ b/samples/ChatSample/ChatSample/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace ChatSample.CoreApp3
 {
@@ -12,6 +13,11 @@ namespace ChatSample.CoreApp3
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    logging.AddConsole();
+                    logging.AddDebug();
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/samples/ChatSample/ChatSample/Startup.cs
+++ b/samples/ChatSample/ChatSample/Startup.cs
@@ -27,7 +27,7 @@ namespace ChatSample.CoreApp3
             app.UseFileServer();
             app.UseRouting();
             app.UseAuthorization();
-
+            
             app.UseEndpoints(routes =>
             {
                 routes.MapHub<Chat>("/chat");

--- a/samples/ChatSample/ChatSample/appsettings.json
+++ b/samples/ChatSample/ChatSample/appsettings.json
@@ -9,7 +9,7 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.Hosting.Lifetime": "Information",
-      "Microsoft.Azure.SignalR": "Debug"
+      "Microsoft.Azure.SignalR.Messaging": "Debug"
     }
   },
   "AllowedHosts": "*"

--- a/samples/ChatSample/ChatSample/appsettings.json
+++ b/samples/ChatSample/ChatSample/appsettings.json
@@ -8,7 +8,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Azure.SignalR": "Debug"
     }
   },
   "AllowedHosts": "*"

--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.SignalR.AspNet
             // broadcast case
             if (TryGetName(message.Key, PrefixHelper.HubPrefix, out var hubName))
             {
-                yield return new HubMessage(hubName, new BroadcastDataMessage(excludedList: GetExcludedIds(message.Filter), payloads: GetPayloads(segment)), message);
+                yield return new HubMessage(hubName, new BroadcastDataMessage(excludedList: GetExcludedIds(message.Filter), payloads: GetPayloads(segment), null), message);// todo: wanl
             }
             // echo case
             else if (TryGetName(message.Key, PrefixHelper.HubConnectionIdPrefix, out _))

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Azure.SignalR
         {
             if (!await SafeWriteAsync(serviceMessage))
             {
+                Log.FailedSendingMessage();
                 throw new ServiceConnectionNotActiveException(_errorMessage);
             }
         }
@@ -645,6 +646,9 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, string, Exception> _receivedInstanceOfflinePing =
                 LoggerMessage.Define<string>(LogLevel.Information, new EventId(31, "ReceivedInstanceOfflinePing"), "Received instance offline service ping: {InstanceId}");
 
+            private static readonly Action<ILogger, string, Exception> _failedSengingMessage =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(32, "FailedSendingMessage"), "Failed sending message: {messageId}");
+
             public static void FailedToWrite(ILogger logger, string serviceConnectionId, Exception exception)
             {
                 _failedToWrite(logger, exception.Message, serviceConnectionId, null);
@@ -738,6 +742,11 @@ namespace Microsoft.Azure.SignalR
                 _failedSendingPing(logger, serviceConnectionId, exception);
             }
 
+            public static void FailedSendingMessage(ILogger logger, string messageId, Exception exception)
+            {
+                _failedSendingPing(logger, messageId, exception);
+            }
+
             public static void ReceivedServiceErrorMessage(ILogger logger, string connectionId, string errorMessage)
             {
                 _receivedServiceErrorMessage(logger, connectionId, errorMessage, null);
@@ -753,9 +762,9 @@ namespace Microsoft.Azure.SignalR
                 _unexpectedExceptionInStop(logger, connectionId, exception);
             }
 
-            public static void ReceivedInstanceOfflinePing(ILogger logger, string instanceId)
+            public static void ReceivedInstanceOfflinePing(ILogger logger, string messageId)
             {
-                _receivedInstanceOfflinePing(logger, instanceId, null);
+                _receivedInstanceOfflinePing(logger, messageId, null);
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ServiceMessageHelper.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ServiceMessageHelper.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.Azure.SignalR
+{
+    internal static class ServiceMessageHelper
+    {
+        // todo: generate a shorter ID
+        public static string GenerateMessageId()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+        public static bool TryGetMessageId(ServiceMessage serviceMessage, out string messageId)
+        {
+            if (serviceMessage is MulticastDataMessage multicastDataMessage)
+            {
+                messageId = multicastDataMessage.MessageId;
+                return true;
+            }
+
+            messageId = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ServiceMessageHelper.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ServiceMessageHelper.cs
@@ -14,16 +14,14 @@ namespace Microsoft.Azure.SignalR
             return Guid.NewGuid().ToString();
         }
 
-        public static bool TryGetMessageId(ServiceMessage serviceMessage, out string messageId)
+        public static string GetMessageId(ServiceMessage serviceMessage)
         {
             if (serviceMessage is MulticastDataMessage multicastDataMessage)
             {
-                messageId = multicastDataMessage.MessageId;
-                return true;
+                return multicastDataMessage.MessageId;
             }
 
-            messageId = null;
-            return false;
+            return null;
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -11,15 +11,21 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// </summary>
     public abstract class MulticastDataMessage : ServiceMessage
     {
-        protected MulticastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads)
+        protected MulticastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads, string messageId = null)
         {
             Payloads = payloads;
+            MessageId = messageId;
         }
 
         /// <summary>
         /// Gets or sets the payload dictionary which contains binary payload of multiple protocols.
         /// </summary>
         public IDictionary<string, ReadOnlyMemory<byte>> Payloads { get; set; }
+
+        /// <summary>
+        /// Gets or sets message Id to the payload
+        /// </summary>
+        public string MessageId { get; set; }
     }
 
     /// <summary>
@@ -100,7 +106,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Initializes a new instance of the <see cref="BroadcastDataMessage"/> class.
         /// </summary>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public BroadcastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads) : this(null, payloads)
+        /// <param name="messageId">The message Id</param>
+        public BroadcastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads, string messageId) : this(null, payloads, messageId)
         {
         }
 
@@ -109,7 +116,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="excludedList">The list of excluded connection Ids.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public BroadcastDataMessage(IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+        /// <param name="messageId">The message Id</param>
+        public BroadcastDataMessage(IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads, string messageId) : base(payloads, messageId)
         {
             ExcludedList = excludedList;
         }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -314,6 +314,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         {
             writer.WriteArrayHeader(3);
             writer.Write(ServiceProtocolConstants.BroadcastDataMessageType);
+            writer.Write(message.MessageId);
             WriteStringArray(ref writer, message.ExcludedList);
             WritePayloads(ref writer, message.Payloads);
         }
@@ -560,10 +561,12 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         private static BroadcastDataMessage CreateBroadcastDataMessage(ref MessagePackReader reader)
         {
+
+            var messageId = ReadString(ref reader, "messageId");
             var excludedList = ReadStringArray(ref reader, "excludedList");
             var payloads = ReadPayloads(ref reader);
-
-            return new BroadcastDataMessage(excludedList, payloads);
+            
+            return new BroadcastDataMessage(excludedList, payloads, messageId);
         }
 
         private static JoinGroupMessage CreateJoinGroupMessage(ref MessagePackReader reader)

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Azure.SignalR.Protocol
                     return CreateMultiUserDataMessage(ref reader);
                 case ServiceProtocolConstants.BroadcastDataMessageType:
                     return CreateBroadcastDataMessage(ref reader);
+                case ServiceProtocolConstants.BroadcastDataMessageWithMessageIdType:
+                    return CreateBroadcastDataMessage(ref reader, withMessageId: true);
                 case ServiceProtocolConstants.JoinGroupMessageType:
                     return CreateJoinGroupMessage(ref reader);
                 case ServiceProtocolConstants.LeaveGroupMessageType:
@@ -559,13 +561,13 @@ namespace Microsoft.Azure.SignalR.Protocol
             return new MultiUserDataMessage(userList, payloads);
         }
 
-        private static BroadcastDataMessage CreateBroadcastDataMessage(ref MessagePackReader reader)
+        private static BroadcastDataMessage CreateBroadcastDataMessage(ref MessagePackReader reader, bool withMessageId = false)
         {
 
-            var messageId = ReadString(ref reader, "messageId");
+            var messageId = withMessageId ? ReadString(ref reader, "messageId") : null;
             var excludedList = ReadStringArray(ref reader, "excludedList");
             var payloads = ReadPayloads(ref reader);
-            
+
             return new BroadcastDataMessage(excludedList, payloads, messageId);
         }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -25,5 +25,6 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int JoinGroupWithAckMessageType = 18;
         public const int LeaveGroupWithAckMessageType = 19;
         public const int AckMessageType = 20;
+        public const int BroadcastDataMessageWithMessageIdType = 110;
     }
 }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.SignalR
             }
 
             return ServiceConnectionContainer.WriteAsync(
-                new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args)));
+                new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args), MessageIdGenerator.Generate()));
         }
 
         public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds, CancellationToken cancellationToken = default)
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.SignalR
             }
 
             return ServiceConnectionContainer.WriteAsync(
-                new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args)));
+                new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args), null)); // todo: wanl
         }
 
         public override Task SendConnectionAsync(string connectionId, string methodName, object[] args, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.SignalR
             }
 
             return ServiceConnectionContainer.WriteAsync(
-                new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args), MessageIdGenerator.Generate()));
+                new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args), ServiceMessageHelper.GenerateMessageId()));
         }
 
         public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.SignalR
                                  ServiceConnectionType connectionType = ServiceConnectionType.Default,
                                  ServerConnectionMigrationLevel migrationLevel = ServerConnectionMigrationLevel.Off,
                                  int closeTimeOutMilliseconds = DefaultCloseTimeoutMilliseconds
-            ): base(serviceProtocol, serverId, connectionId, endpoint, serviceMessageHandler, connectionType, migrationLevel, loggerFactory?.CreateLogger<ServiceConnection>())
+            ): base(serviceProtocol, serverId, connectionId, endpoint, serviceMessageHandler, connectionType, migrationLevel, loggerFactory)
         {
             _clientConnectionManager = clientConnectionManager;
             _connectionFactory = connectionFactory;

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -171,8 +171,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 {
                     ["json"] = new byte[] {4, 5, 6, 7, 1, 2, 3},
                     ["messagepack"] = new byte[] {5, 6, 7, 1, 2, 3, 4}
-                }),
-                binary: "kwqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgME"),
+                }, "59f9f481-4a18-4ef5-ab4e-8d3ad372062a"),
+                binary: "kwrZJDU5ZjlmNDgxLTRhMTgtNGVmNS1hYjRlLThkM2FkMzcyMDYyYZCCpGpzb27EBwQFBgcBAgOrbWVzc2FnZXBhY2vEBwUGBwECAwQ="),
             new ProtocolTestData(
                 name: "BroadcastExcept",
                 message: new BroadcastDataMessage(new[] {"conn7", "conn8", "conn9"},
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     {
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
-                    }),
+                    }, Guid.NewGuid().ToString()),
                 binary: "kwqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
             new ProtocolTestData(
                 name: "JoinGroup",


### PR DESCRIPTION
Sample of new service protocol: 

1. Add Message ID to `BroadcastDataMessage`
2. Change logger category name make customer easy to filter message log
3. Log message ID on success / failure of message delivering from server to service. 