### PR TITLE
Release V1.4.3

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Azure.SignalR
 
         public virtual string Name { get; internal set; }
 
-        /// <summary>
-        /// Initial status as Online so that when the app server first starts, it can accept incoming negotiate requests, as for backward compatability
-        /// </summary>
-        public bool Online { get; internal set; } = true;
-
         public string Endpoint { get; }
 
         internal string Version { get; }
@@ -25,6 +20,22 @@ namespace Microsoft.Azure.SignalR
         internal AccessKey AccessKey { get; private set; }
 
         internal int? Port { get; }
+
+        /// <summary>
+        /// When current app server instance has server connections connected to the target endpoint for current hub, it can deliver messages to that endpoint.
+        /// The endpoint is then considered as *Online*; otherwise, *Offline*.
+        /// Messages are not able to be delivered to an *Offline* endpoint.
+        /// </summary>
+        public bool Online { get; internal set; } = true;
+
+        /// <summary>
+        /// When the target endpoint has hub clients connected, the endpoint is considered as an *Active* endpoint.
+        /// When the target endpoint has no hub clients connected for 10 minutes, the endpoint is considered as an *Inactive* one.
+        /// User can choose to not send messages to an *Inactive* endpoint to save network traffic.
+        /// But please note that as the *Active* status is reported to the server from remote service, there can be some delay when status changes.
+        /// Don't rely on this status if you don't expect any message lose once a client is connected.
+        /// </summary>
+        public bool IsActive { get; internal set; } = true;
 
         public ServiceEndpoint(string key, string connectionString) : this(connectionString)
         {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Azure.SignalR
 {
     internal abstract class ServiceConnectionContainerBase : IServiceConnectionContainer, IServiceMessageHandler, IDisposable
     {
+        private const int CheckWindow = 5;
+        private static readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
+
         // Give interval(5s) * 24 = 2min window for retry considering abnormal case.
         private const int MaxRetryRemoveSeverConnection = 24;
 
@@ -34,6 +37,8 @@ namespace Microsoft.Azure.SignalR
         private readonly object _lock = new object();
 
         private readonly object _statusLock = new object();
+
+        private (int count, DateTime? last) _inactiveInfo;
 
         private readonly AckHandler _ackHandler;
 
@@ -173,6 +178,7 @@ namespace Microsoft.Azure.SignalR
             {
                 Log.ReceivedServiceStatusPing(Logger, status, Endpoint);
                 _hasClients = status;
+                Endpoint.IsActive = GetServiceStatus(status, CheckWindow, CheckTimeSpan);
             }
             else if (RuntimeServicePingMessage.TryGetServersTag(pingMessage, out var serversTag, out var updatedTime))
             {
@@ -343,6 +349,27 @@ namespace Microsoft.Azure.SignalR
                 retry++;
             }
             Log.TimeoutWaitingForFinAck(Logger, retry);
+        }
+
+        internal bool GetServiceStatus(bool active, int checkWindow, TimeSpan checkTimeSpan)
+        {
+            if (active)
+            {
+                _inactiveInfo = (0, null);
+                return true;
+            }
+            else
+            {
+                var info = _inactiveInfo;
+                var last = info.last ?? DateTime.UtcNow;
+                var count = info.count;
+                count++;
+                _inactiveInfo = (count, last);
+
+                // Inactive it only when it checks over 5 times and elapsed for over 10 minutes
+                var inactive = count >= checkWindow && DateTime.UtcNow - last >= checkTimeSpan;
+                return !inactive;
+            }
         }
 
         internal static TimeSpan GetRetryDelay(int retryCount)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/WeakServiceConnectionContainer.cs
@@ -3,23 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.Common
 {
     internal class WeakServiceConnectionContainer : ServiceConnectionContainerBase
     {
-        private const int CheckWindow = 5;
-        private static readonly TimeSpan CheckTimeSpan = TimeSpan.FromMinutes(10);
-
-        private readonly object _lock = new object();
-        private int _inactiveCount;
-        private DateTime? _firstInactiveTime;
-
-        // active ones are those whose client connections connected to the whole endpoint
-        private volatile bool _active = true;
-
         protected override ServiceConnectionType InitialConnectionType => ServiceConnectionType.Weak;
 
         public WeakServiceConnectionContainer(IServiceConnectionFactory serviceConnectionFactory,
@@ -28,62 +17,9 @@ namespace Microsoft.Azure.SignalR.Common
         {
         }
 
-        public override Task HandlePingAsync(PingMessage pingMessage)
-        {
-            base.HandlePingAsync(pingMessage);
-            var active = HasClients;
-            _active = GetServiceStatus(active, CheckWindow, CheckTimeSpan);
-
-            return Task.CompletedTask;
-        }
-
-        public override Task WriteAsync(ServiceMessage serviceMessage)
-        {
-            if (!_active && !(serviceMessage is PingMessage))
-            {
-                // If the endpoint is inactive, there is no need to send messages to it
-                Log.IgnoreSendingMessageToInactiveEndpoint(Logger, serviceMessage.GetType(), Endpoint);
-                return Task.CompletedTask;
-            }
-
-            return base.WriteAsync(serviceMessage);
-        }
-
         public override Task OfflineAsync(bool migratable)
         {
             return Task.CompletedTask;
-        }
-
-        internal bool GetServiceStatus(bool active, int checkWindow, TimeSpan checkTimeSpan)
-        {
-            lock (_lock)
-            {
-                if (active)
-                {
-                    _firstInactiveTime = null;
-                    _inactiveCount = 0;
-                    return true;
-                }
-                else
-                {
-                    if (_firstInactiveTime == null)
-                    {
-                        _firstInactiveTime = DateTime.UtcNow;
-                    }
-
-                    _inactiveCount++;
-
-                    // Inactive it only when it checks over 5 times and elapsed for over 10 minutes
-                    if (_inactiveCount >= checkWindow && DateTime.UtcNow - _firstInactiveTime >= checkTimeSpan)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
-                }
-            }
         }
 
         private static class Log

--- a/src/Microsoft.Azure.SignalR.Management/IServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// <param name="claims">The claim list to be put into access token.</param>
         /// <param name="lifeTime">The lifetime of the token. The default value is one hour.</param>
         /// <returns>Client access token to Azure SignalR Service.</returns>
-        Task<string> GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null);
+        string GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null);
 
         /// <summary>
         /// Creates an client endpoint for SignalR hub connections to connect to Azure SignalR Service

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.SignalR.Management
             }
         }
 
-        public Task<string> GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null)
+        public string GenerateClientAccessToken(string hubName, string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null)
         {
             var claimsWithUserId = new List<Claim>();
             if (userId != null)
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.SignalR.Management
             {
                 claimsWithUserId.AddRange(claims);
             }
-            return _endpointProvider.GenerateClientAccessTokenAsync(hubName, claimsWithUserId, lifeTime);
+            return _endpointProvider.GenerateClientAccessTokenAsync(hubName, claimsWithUserId, lifeTime).Result;
         }
 
         public string GetClientEndpoint(string hubName) => _endpointProvider.GetClientEndpoint(hubName, null, null);

--- a/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
@@ -331,16 +331,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 var serviceHubContext = await serviceManager.CreateHubContextAsync(HubName, loggerFactory);
 
                 var clientEndpoint = serviceManager.GetClientEndpoint(HubName);
-                var tasks = from userName in _userNames
+                var tokens = from userName in _userNames
                                          select serviceManager.GenerateClientAccessToken(HubName, userName);
-
-                await Task.WhenAll(tasks);
-
-                var tokens = new List<string>();
-                foreach (var task in tasks)
-                {
-                    tokens.Add(task.Result);
-                }
                 return (clientEndpoint, tokens, serviceHubContext);
             }
         }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
@@ -24,30 +24,23 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
         [Theory]
         [MemberData(nameof(GetTestData))]
-        public void RestApiTest(string audience, string tokenString, string expectedAudience)
+        internal void RestApiTest(RestApiEndpoint api, string expectedAudience)
         {
-            var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
+            var token = JwtTokenHelper.JwtHandler.ReadJwtToken(api.Token);
             string expectedTokenString = JwtTokenHelper.GenerateExpectedAccessToken(token, expectedAudience, _accessKey);
 
-            Assert.Equal(expectedAudience, audience);
-            Assert.Equal(expectedTokenString, tokenString);
+            Assert.Equal(expectedAudience, api.Audience);
+            Assert.Equal(expectedTokenString, api.Token);
         }
 
         public static IEnumerable<object[]> GetTestData()
         {
-            var broadcastApi = _restApiProvider.GetBroadcastEndpoint();
-            var sendToUserApi = _restApiProvider.GetSendToUserEndpoint(_userId);
-            var sendToGroupApi = _restApiProvider.GetSendToGroupEndpoint(_groupName);
-            var groupManagementApi = _restApiProvider.GetUserGroupManagementEndpoint(_userId, _groupName);
-            var sendToConnctionsApi = _restApiProvider.GetSendToConnectionEndpoint(_connectionId);
-            var connectionGroupManagementApi = _restApiProvider.GetConnectionGroupManagementEndpoint(_connectionId, _groupName);
-
-            yield return new object[] { broadcastApi.Audience, broadcastApi.Token, _commonEndpoint };
-            yield return new object[] { sendToUserApi.Audience, sendToUserApi.Token,  $"{_commonEndpoint}/users/{_userId}"};
-            yield return new object[] { sendToGroupApi.Audience, sendToGroupApi.Token, $"{_commonEndpoint}/groups/{_groupName}"};
-            yield return new object[] { groupManagementApi.Audience, groupManagementApi.Token, $"{_commonEndpoint}/groups/{_groupName}/users/{_userId}"};
-            yield return new object[] { sendToConnctionsApi.Audience, sendToConnctionsApi.Token, $"{_commonEndpoint}/connections/{_connectionId}" };
-            yield return new object[] { connectionGroupManagementApi.Audience, connectionGroupManagementApi.Token, $"{_commonEndpoint}/groups/{_groupName}/connections/{_connectionId}" };
+            yield return new object[]{_restApiProvider.GetBroadcastEndpoint(), _commonEndpoint };
+            yield return new object[] { _restApiProvider.GetSendToUserEndpoint(_userId), $"{_commonEndpoint}/users/{_userId}" };
+            yield return new object[] { _restApiProvider.GetSendToGroupEndpoint(_groupName), $"{_commonEndpoint}/groups/{_groupName}" };
+            yield return new object[] { _restApiProvider.GetUserGroupManagementEndpoint(_userId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/users/{_userId}" };
+            yield return new object[] { _restApiProvider.GetSendToConnectionEndpoint(_connectionId), $"{_commonEndpoint}/connections/{_connectionId}" };
+            yield return new object[] { _restApiProvider.GetConnectionGroupManagementEndpoint(_connectionId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/connections/{_connectionId}" };
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
         [Theory]
         [MemberData(nameof(TestGenerateAccessTokenData))]
-        internal async Task GenerateClientAccessTokenTest(string userId, Claim[] claims, string appName)
+        internal void GenerateClientAccessTokenTest(string userId, Claim[] claims, string appName)
         {
             var manager = new ServiceManager(new ServiceManagerOptions() { ConnectionString = _testConnectionString, ApplicationName = appName }, null);
-            var tokenString = await manager.GenerateClientAccessToken(HubName, userId, claims, _tokenLifeTime);
+            var tokenString =  manager.GenerateClientAccessToken(HubName, userId, claims, _tokenLifeTime);
             var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 
             string expectedToken = JwtTokenHelper.GenerateExpectedAccessToken(token, GetExpectedClientEndpoint(appName), AccessKey, claims);

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -26,12 +26,15 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public Task ConnectionCreated => _created.Task;
 
-        public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected, bool throws = false, ILogger logger = null) : base(
+        public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected, bool throws = false,
+            ILogger logger = null,
+            IServiceMessageHandler serviceMessageHandler = null
+            ) : base(
             new ServiceProtocol(),
             "serverId",
             Guid.NewGuid().ToString(),
             new HubServiceEndpoint(),
-            null, // TODO replace it with a NullMessageHandler
+            serviceMessageHandler,
             ServiceConnectionType.Default,
             ServerConnectionMigrationLevel.Off,
             logger ?? NullLogger.Instance

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionFactory.cs
@@ -2,12 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Azure.SignalR.Tests.Common
 {
     internal sealed class TestServiceConnectionFactory : IServiceConnectionFactory
     {
         private readonly Func<ServiceEndpoint, IServiceConnection> _generator;
+
+        public ConcurrentQueue<IServiceConnection> CreatedConnections { get; } = new ConcurrentQueue<IServiceConnection>();
+        
         public TestServiceConnectionFactory(Func<ServiceEndpoint, IServiceConnection> generator = null)
         {
             _generator = generator;
@@ -15,7 +19,9 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, ServiceConnectionType type)
         {
-            return _generator?.Invoke(endpoint) ?? new TestServiceConnection();
+            var conn = _generator?.Invoke(endpoint) ?? new TestServiceConnection(serviceMessageHandler: serviceMessageHandler);
+            CreatedConnections.Enqueue(conn);
+            return conn;
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -33,6 +33,76 @@ namespace Microsoft.Azure.SignalR.Tests
         {
         }
 
+        [Fact(Skip = "Enable when custom interval is supported")]
+        public async Task TestStatusPingChangesEndpointStatus()
+        {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Trace))
+            {
+                var endpoints = new[]
+                {
+                    new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "strong"),
+                    new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "weak"),
+                };
+
+                var sem = new TestServiceEndpointManager(endpoints);
+
+                var router = new TestEndpointRouter();
+
+                var connectionFactory1 = new TestServiceConnectionFactory();
+                var connectionFactory2 = new TestServiceConnectionFactory();
+
+                var hub1 = new MultiEndpointServiceConnectionContainer(connectionFactory1, "hub1", 2, sem, router,
+                    loggerFactory);
+                var hub2 = new MultiEndpointServiceConnectionContainer(connectionFactory2, "hub2", 2, sem, router,
+                    loggerFactory);
+
+                var connections = connectionFactory1.CreatedConnections.ToArray();
+                Assert.Equal(4, connections.Length);
+
+                var connection1 = connections[0] as TestServiceConnection;
+                var connection2 = connections[2] as TestServiceConnection;
+
+                Assert.NotNull(connection1);
+                Assert.NotNull(connection2);
+
+                // All the connections started
+                _ = hub1.StartAsync();
+                await hub1.ConnectionInitializedTask;
+                _ = hub2.StartAsync();
+                await hub2.ConnectionInitializedTask;
+
+                var protocol = new ServiceProtocol();
+                for (var i = 0; i < 5; i++)
+                {
+                    protocol.WriteMessage(RuntimeServicePingMessage.GetStatusPingMessage(false), connection1.Application.Output);
+                    await connection1.Application.Output.FlushAsync();
+                    await Task.Delay(100);
+                }
+
+                await Task.Delay(100);
+
+                var active = hub1.GetOnlineEndpoints().Where(s => s.IsActive).Count();
+                Assert.Equal(1, active);
+
+                active = hub2.GetOnlineEndpoints().Where(s => s.IsActive).Count();
+                Assert.Equal(2, active);
+
+                for (var i = 0; i < 5; i++)
+                {
+                    protocol.WriteMessage(RuntimeServicePingMessage.GetStatusPingMessage(false), connection2.Application.Output);
+                    await connection2.Application.Output.FlushAsync();
+                    await Task.Delay(100);
+                }
+
+                active = hub1.GetOnlineEndpoints().Where(s => s.IsActive).Count();
+                Assert.Equal(0, active);
+
+                // the original endpoints are not impacted
+                active = sem.Endpoints.Where(s => s.Value.IsActive).Count();
+                Assert.Equal(2, active);
+            }
+        }
+
         [Fact]
         public void TestGetRoutedEndpointsReturnDistinctResultForMultiMessages()
         {

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.4.2</VersionPrefix>
+    <VersionPrefix>1.4.3</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>


### PR DESCRIPTION
1. Revert the interface breaking change in Management SDK (#876)
2. Add a `IsActive` property to `ServiceEndpoint` so that user can decide if sending message to an endpoint having no client connections. (#879)