### PR TITLE
Extract rest client

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/RestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestClient.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Common;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class RestClient
+    {
+        public async Task SendAsync(RestApiEndpoint api, HttpMethod httpMethod, string productInfo, string methodName = null, object[] args = null, CancellationToken cancellationToken = default)
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            var request = BuildRequest(api, httpMethod, productInfo, methodName, args);
+            HttpResponseMessage response = null;
+            var detail = "";
+
+            try
+            {
+                response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new AzureSignalRInaccessibleEndpointException(request.RequestUri.ToString(), ex);
+            }
+
+            try
+            {
+                detail = await response.Content.ReadAsStringAsync();
+                response.EnsureSuccessStatusCode();
+            }
+            catch (HttpRequestException ex)
+            {
+                ThrowExceptionOnResponseFailure(ex, response.StatusCode, request.RequestUri.ToString(), detail);
+            }
+            finally
+            {
+                response.Dispose();
+            }
+        }
+
+        private HttpRequestMessage BuildRequest(RestApiEndpoint api, HttpMethod httpMethod, string productInfo, string methodName = null, object[] args = null)
+        {
+            var payload = httpMethod == HttpMethod.Post ? new PayloadMessage { Target = methodName, Arguments = args } : null;
+            return GenerateHttpRequest(api.Audience, httpMethod, payload, api.Token,  productInfo);
+        }
+
+        private HttpRequestMessage GenerateHttpRequest(string url, HttpMethod httpMethod, PayloadMessage payload, string tokenString, string productInfo)
+        {
+            var request = new HttpRequestMessage(httpMethod, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenString);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Add(Constants.AsrsUserAgent, productInfo);
+            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+            return request;
+        }
+
+        private static void ThrowExceptionOnResponseFailure(Exception innerException, HttpStatusCode? statusCode, string requestUri, string detail = null)
+        {
+            switch (statusCode)
+            {
+                case HttpStatusCode.BadRequest:
+                {
+                    throw new AzureSignalRInvalidArgumentException(requestUri, innerException, detail);
+                }
+                case HttpStatusCode.Unauthorized:
+                {
+                    throw new AzureSignalRUnauthorizedException(requestUri, innerException);
+                }
+                case HttpStatusCode.NotFound:
+                {
+                    throw new AzureSignalRInaccessibleEndpointException(requestUri, innerException);
+                }
+                default:
+                {
+                    throw new AzureSignalRRuntimeException(requestUri, innerException);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -4,28 +4,28 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Azure.SignalR.Common;
-using Newtonsoft.Json;
 
 namespace Microsoft.Azure.SignalR.Management
 {
     internal class RestHubLifetimeManager : HubLifetimeManager<Hub>, IHubLifetimeManagerForUserGroup
     {
-        private readonly RestApiProvider _restApiProvider;
         private const string NullOrEmptyStringErrorMessage = "Argument cannot be null or empty.";
+        private static readonly RestClient _restClient = new RestClient();
+        private readonly RestApiProvider _restApiProvider;
         private readonly string _productInfo;
+        private readonly string _hubName;
+        private readonly string _appName;
 
         public RestHubLifetimeManager(ServiceManagerOptions serviceManagerOptions, string hubName, string productInfo)
         {
-            _restApiProvider = new RestApiProvider(serviceManagerOptions.ConnectionString, hubName, serviceManagerOptions.ApplicationName);
+            _restApiProvider = new RestApiProvider(serviceManagerOptions.ConnectionString);
             _productInfo = productInfo;
+            _appName = serviceManagerOptions.ApplicationName;
+            _hubName = hubName;
         }
 
         public override Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
@@ -40,9 +40,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(groupName));
             }
 
-            var api = _restApiProvider.GetConnectionGroupManagementEndpoint(connectionId, groupName);
-            var request = BuildRequest(api, HttpMethod.Put, null, null);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetConnectionGroupManagementEndpoint(_appName, _hubName, connectionId, groupName);
+            return _restClient.SendAsync(api, HttpMethod.Put, _productInfo, cancellationToken: cancellationToken);
         }
 
         public override Task OnConnectedAsync(HubConnectionContext connection)
@@ -67,9 +66,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(groupName));
             }
 
-            var api = _restApiProvider.GetConnectionGroupManagementEndpoint(connectionId, groupName);
-            var request = BuildRequest(api, HttpMethod.Delete, null, null);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetConnectionGroupManagementEndpoint(_appName, _hubName, connectionId, groupName);
+            return _restClient.SendAsync(api, HttpMethod.Delete, _productInfo, cancellationToken: cancellationToken);
         }
 
         public override Task SendAllAsync(string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -79,9 +77,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
             }
 
-            var api = _restApiProvider.GetBroadcastEndpoint();
-            var request = BuildRequest(api, HttpMethod.Post, methodName, args);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetBroadcastEndpoint(_appName, _hubName);
+            return _restClient.SendAsync(api, HttpMethod.Post, _productInfo, methodName, args, cancellationToken: cancellationToken);
         }
 
         public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds, CancellationToken cancellationToken = default)
@@ -101,9 +98,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionId));
             }
 
-            var api = _restApiProvider.GetSendToConnectionEndpoint(connectionId);
-            var request = BuildRequest(api, HttpMethod.Post, methodName, args);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetSendToConnectionEndpoint(_appName, _hubName, connectionId);
+            return _restClient.SendAsync(api, HttpMethod.Post, _productInfo, methodName, args, cancellationToken: cancellationToken);
         }
 
         public override async Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -123,9 +119,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(groupName));
             }
 
-            var api = _restApiProvider.GetSendToGroupEndpoint(groupName);
-            var request = BuildRequest(api, HttpMethod.Post, methodName, args);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetSendToGroupEndpoint(_appName, _hubName, groupName);
+            return _restClient.SendAsync(api, HttpMethod.Post, _productInfo, methodName, args, cancellationToken: cancellationToken);
         }
 
         public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds, CancellationToken cancellationToken = default)
@@ -160,9 +155,8 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(userId));
             }
 
-            var api = _restApiProvider.GetSendToUserEndpoint(userId);
-            var request = BuildRequest(api, HttpMethod.Post, methodName, args);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetSendToUserEndpoint(_appName, _hubName, userId);
+            return _restClient.SendAsync(api, HttpMethod.Post, _productInfo, methodName, args, cancellationToken: cancellationToken);
         }
 
         public override async Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -184,94 +178,22 @@ namespace Microsoft.Azure.SignalR.Management
         {
             ValidateUserIdAndGroupName(userId, groupName);
 
-            var api = _restApiProvider.GetUserGroupManagementEndpoint(userId, groupName);
-            var request = BuildRequest(api, HttpMethod.Put, null, null);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetUserGroupManagementEndpoint(_appName, _hubName, userId, groupName);
+            return _restClient.SendAsync(api, HttpMethod.Put, _productInfo, cancellationToken: cancellationToken);
         }
 
         public Task UserRemoveFromGroupAsync(string userId, string groupName, CancellationToken cancellationToken = default)
         {
             ValidateUserIdAndGroupName(userId, groupName);
 
-            var api = _restApiProvider.GetUserGroupManagementEndpoint(userId, groupName);
-            var request = BuildRequest(api, HttpMethod.Delete, null, null);
-            return CallRestApiAsync(request, cancellationToken);
+            var api = _restApiProvider.GetUserGroupManagementEndpoint(_appName, _hubName, userId, groupName);
+            return _restClient.SendAsync(api, HttpMethod.Delete, _productInfo, cancellationToken: cancellationToken);
         }
 
         public Task UserRemoveFromAllGroupsAsync(string userId, CancellationToken cancellationToken = default)
         {
-            var api = _restApiProvider.GetRemoveUserFromAllGroups(userId);
-            var request = BuildRequest(api, HttpMethod.Delete);
-            return CallRestApiAsync(request, cancellationToken);
-        }
-
-        private HttpRequestMessage GenerateHttpRequest(string url, PayloadMessage payload, string tokenString, HttpMethod httpMethod)
-        {
-            var request = new HttpRequestMessage(httpMethod, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenString);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Headers.Add(Constants.AsrsUserAgent, _productInfo);
-            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
-            return request;
-        }
-
-        private static void ThrowExceptionOnResponseFailure(Exception innerException, HttpStatusCode? statusCode, string requestUri, string detail = null)
-        {
-            switch (statusCode)
-            {
-                case HttpStatusCode.BadRequest:
-                    {
-                        throw new AzureSignalRInvalidArgumentException(requestUri, innerException, detail);
-                    }
-                case HttpStatusCode.Unauthorized:
-                    {
-                        throw new AzureSignalRUnauthorizedException(requestUri, innerException);
-                    }
-                case HttpStatusCode.NotFound:
-                    {
-                        throw new AzureSignalRInaccessibleEndpointException(requestUri, innerException);
-                    }
-                default:
-                    {
-                        throw new AzureSignalRRuntimeException(requestUri, innerException);
-                    }
-            }
-        }
-
-        private HttpRequestMessage BuildRequest(RestApiEndpoint endpoint, HttpMethod httpMethod, string methodName = null, object[] args = null)
-        {
-            var payload = httpMethod == HttpMethod.Post ? new PayloadMessage { Target = methodName, Arguments = args } : null;
-            return GenerateHttpRequest(endpoint.Audience, payload, endpoint.Token, httpMethod);
-        }
-
-        private static async Task CallRestApiAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
-        {
-            var httpClient = HttpClientFactory.CreateClient();
-            HttpResponseMessage response = null;
-            var detail = "";
-
-            try
-            {
-                response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            }
-            catch (HttpRequestException ex)
-            {
-                throw new AzureSignalRInaccessibleEndpointException(request.RequestUri.ToString(), ex);
-            }
-
-            try
-            {
-                detail = await response.Content.ReadAsStringAsync();
-                response.EnsureSuccessStatusCode();
-            }
-            catch (HttpRequestException ex)
-            {
-                ThrowExceptionOnResponseFailure(ex, response.StatusCode, request.RequestUri.ToString(), detail);
-            }
-            finally
-            {
-                response.Dispose();
-            }
+            var api = _restApiProvider.GetRemoveUserFromAllGroups(_appName, _hubName, userId);
+            return _restClient.SendAsync(api, HttpMethod.Delete, _productInfo, cancellationToken: cancellationToken);
         }
 
         private static void ValidateUserIdAndGroupName(string userId, string groupName)

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         private const string _connectionId = "ConnectionA";
         private static readonly string _commonEndpoint = $"{_endpoint}/api/v1/hubs/{_appName.ToLower()}_{_hubName}";
 
-        private static readonly RestApiProvider _restApiProvider = new RestApiProvider(_connectionString, _hubName, _appName);
+        private static readonly RestApiProvider _restApiProvider = new RestApiProvider(_connectionString);
 
         [Theory]
         [MemberData(nameof(GetTestData))]
@@ -35,12 +35,12 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
         public static IEnumerable<object[]> GetTestData()
         {
-            yield return new object[]{_restApiProvider.GetBroadcastEndpoint(), _commonEndpoint };
-            yield return new object[] { _restApiProvider.GetSendToUserEndpoint(_userId), $"{_commonEndpoint}/users/{_userId}" };
-            yield return new object[] { _restApiProvider.GetSendToGroupEndpoint(_groupName), $"{_commonEndpoint}/groups/{_groupName}" };
-            yield return new object[] { _restApiProvider.GetUserGroupManagementEndpoint(_userId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/users/{_userId}" };
-            yield return new object[] { _restApiProvider.GetSendToConnectionEndpoint(_connectionId), $"{_commonEndpoint}/connections/{_connectionId}" };
-            yield return new object[] { _restApiProvider.GetConnectionGroupManagementEndpoint(_connectionId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/connections/{_connectionId}" };
+            yield return new object[]{_restApiProvider.GetBroadcastEndpoint(_appName, _hubName), _commonEndpoint };
+            yield return new object[] { _restApiProvider.GetSendToUserEndpoint(_appName, _hubName, _userId), $"{_commonEndpoint}/users/{_userId}" };
+            yield return new object[] { _restApiProvider.GetSendToGroupEndpoint(_appName, _hubName, _groupName), $"{_commonEndpoint}/groups/{_groupName}" };
+            yield return new object[] { _restApiProvider.GetUserGroupManagementEndpoint(_appName, _hubName, _userId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/users/{_userId}" };
+            yield return new object[] { _restApiProvider.GetSendToConnectionEndpoint(_appName, _hubName, _connectionId), $"{_commonEndpoint}/connections/{_connectionId}" };
+            yield return new object[] { _restApiProvider.GetConnectionGroupManagementEndpoint(_appName, _hubName, _connectionId, _groupName), $"{_commonEndpoint}/groups/{_groupName}/connections/{_connectionId}" };
         }
     }
 }


### PR DESCRIPTION
Plan to add more REST APIs in Management SDK.
Plan to add check-service-health API to IServiceManager, so:
1. extract the `RestClient` from `RestHubLifetimeManager` for better reuse.
2. refactor `RestApiProvider` make it support APIs without hub name.
