### PR TITLE
add extensible members in protocol.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// Base class of connection-specific messages between Azure SignalR Service and SDK.
     /// </summary>
-    public abstract class ConnectionMessage : ServiceMessage
+    public abstract class ConnectionMessage : ExtensibleServiceMessage
     {
         protected ConnectionMessage(string connectionId)
         {
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A connection data message.
     /// </summary>
-    public class ConnectionDataMessage : ConnectionMessage
+    public class ConnectionDataMessage : ConnectionMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionDataMessage"/> class.
@@ -136,5 +136,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the binary payload.
         /// </summary>
         public ReadOnlySequence<byte> Payload { get; set; }
+
+        public string TracingId { get; set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A join-group message.
     /// </summary>
-    public class JoinGroupMessage : ServiceMessage
+    public class JoinGroupMessage : ExtensibleServiceMessage
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A leave-group message.
     /// </summary>
-    public class LeaveGroupMessage : ServiceMessage
+    public class LeaveGroupMessage : ExtensibleServiceMessage
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A user-join-group message.
     /// </summary>
-    public class UserJoinGroupMessage : ServiceMessage
+    public class UserJoinGroupMessage : ExtensibleServiceMessage
     {
         /// <summary>
         /// Gets or sets the user Id.
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A user-leave-group message.
     /// </summary>
-    public class UserLeaveGroupMessage : ServiceMessage
+    public class UserLeaveGroupMessage : ExtensibleServiceMessage
     {
         /// <summary>
         /// Gets or sets the user Id.
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A waiting for ack join-group message.
     /// </summary>
-    public class JoinGroupWithAckMessage : ServiceMessage, IAckableMessage
+    public class JoinGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A waiting for ack leave-group message.
     /// </summary>
-    public class LeaveGroupWithAckMessage : ServiceMessage, IAckableMessage
+    public class LeaveGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage
     {
         /// <summary>
         /// Gets or sets the connection Id.

--- a/src/Microsoft.Azure.SignalR.Protocols/IMessageWithTracingId.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/IMessageWithTracingId.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Azure.SignalR.Protocol
+{
+    public interface IMessageWithTracingId
+    {
+        string TracingId { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// Base class for multicast data messages between Azure SignalR Service and SDK.
     /// </summary>
-    public abstract class MulticastDataMessage : ServiceMessage
+    public abstract class MulticastDataMessage : ExtensibleServiceMessage
     {
         protected MulticastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads)
         {

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -29,17 +29,19 @@ namespace Microsoft.Azure.SignalR.Protocol
             {
                 count++;
             }
-            writer.WriteArrayHeader(count * 2);
+            // todo : count more optional fields.
+            writer.WriteMapHeader(count);
             if (!string.IsNullOrEmpty(tracingId))
             {
                 writer.Write(TracingId);
                 writer.Write(tracingId);
             }
+            // todo : write more optional fields.
         }
 
         internal void ReadExtensionMembers(ref MessagePackReader reader)
         {
-            int count = reader.ReadArrayHeader() / 2;
+            int count = reader.ReadMapHeader();
             for (int i = 0; i < count; i++)
             {
                 switch (reader.ReadInt32())
@@ -50,6 +52,7 @@ namespace Microsoft.Azure.SignalR.Protocol
                             withTracingId.TracingId = reader.ReadString();
                         }
                         break;
+                        // todo : more optional fields
                     default:
                         break;
                 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.SignalR.Protocol
                 case ServiceProtocolConstants.HandshakeRequestType:
                     return CreateHandshakeRequestMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.HandshakeResponseType:
-                    return CreateHandshakeResponseMessage(ref reader);
+                    return CreateHandshakeResponseMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.PingMessageType:
                     return CreatePingMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.OpenConnectionMessageType:
@@ -56,35 +56,35 @@ namespace Microsoft.Azure.SignalR.Protocol
                 case ServiceProtocolConstants.CloseConnectionMessageType:
                     return CreateCloseConnectionMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.ConnectionDataMessageType:
-                    return CreateConnectionDataMessage(ref reader);
+                    return CreateConnectionDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.MultiConnectionDataMessageType:
-                    return CreateMultiConnectionDataMessage(ref reader);
+                    return CreateMultiConnectionDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.UserDataMessageType:
-                    return CreateUserDataMessage(ref reader);
+                    return CreateUserDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.MultiUserDataMessageType:
-                    return CreateMultiUserDataMessage(ref reader);
+                    return CreateMultiUserDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.BroadcastDataMessageType:
-                    return CreateBroadcastDataMessage(ref reader);
+                    return CreateBroadcastDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.JoinGroupMessageType:
-                    return CreateJoinGroupMessage(ref reader);
+                    return CreateJoinGroupMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.LeaveGroupMessageType:
-                    return CreateLeaveGroupMessage(ref reader);
+                    return CreateLeaveGroupMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.UserJoinGroupMessageType:
-                    return CreateUserJoinGroupMessage(ref reader);
+                    return CreateUserJoinGroupMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.UserLeaveGroupMessageType:
-                    return CreateUserLeaveGroupMessage(ref reader);
+                    return CreateUserLeaveGroupMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.GroupBroadcastDataMessageType:
-                    return CreateGroupBroadcastDataMessage(ref reader);
+                    return CreateGroupBroadcastDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.MultiGroupBroadcastDataMessageType:
-                    return CreateMultiGroupBroadcastDataMessage(ref reader);
+                    return CreateMultiGroupBroadcastDataMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.ServiceErrorMessageType:
                     return CreateServiceErrorMessage(ref reader);
                 case ServiceProtocolConstants.JoinGroupWithAckMessageType:
-                    return CreateJoinGroupWithAckMessage(ref reader);
+                    return CreateJoinGroupWithAckMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.LeaveGroupWithAckMessageType:
-                    return CreateLeaveGroupWithAckMessage(ref reader);
+                    return CreateLeaveGroupWithAckMessage(ref reader, arrayLength);
                 case ServiceProtocolConstants.AckMessageType:
-                    return CreateAckMessage(ref reader);
+                    return CreateAckMessage(ref reader, arrayLength);
                 default:
                     // Future protocol changes can add message types, old clients can ignore them
                     return null;
@@ -217,19 +217,21 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         private static void WriteHandshakeRequestMessage(ref MessagePackWriter writer, HandshakeRequestMessage message)
         {
-            writer.WriteArrayHeader(5);
+            writer.WriteArrayHeader(6);
             writer.Write(ServiceProtocolConstants.HandshakeRequestType);
             writer.Write(message.Version);
             writer.Write(message.ConnectionType);
             writer.Write(message.ConnectionType == 0 ? "" : message.Target ?? string.Empty);
             writer.Write((int)message.MigrationLevel);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteHandshakeResponseMessage(ref MessagePackWriter writer, HandshakeResponseMessage message)
         {
-            writer.WriteArrayHeader(2);
+            writer.WriteArrayHeader(3);
             writer.Write(ServiceProtocolConstants.HandshakeResponseType);
             writer.Write(message.ErrorMessage);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WritePingMessage(ref MessagePackWriter writer, PingMessage message)
@@ -244,7 +246,7 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         private static void WriteOpenConnectionMessage(ref MessagePackWriter writer, OpenConnectionMessage message)
         {
-            writer.WriteArrayHeader(5);
+            writer.WriteArrayHeader(6);
             writer.Write(ServiceProtocolConstants.OpenConnectionMessageType);
             writer.Write(message.ConnectionId);
 
@@ -264,107 +266,120 @@ namespace Microsoft.Azure.SignalR.Protocol
             WriteHeaders(ref writer, message.Headers);
 
             writer.Write(message.QueryString);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteCloseConnectionMessage(ref MessagePackWriter writer, CloseConnectionMessage message)
         {
-            writer.WriteArrayHeader(4);
+            writer.WriteArrayHeader(5);
             writer.Write(ServiceProtocolConstants.CloseConnectionMessageType);
             writer.Write(message.ConnectionId);
             writer.Write(message.ErrorMessage);
             WriteHeaders(ref writer, message.Headers);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteConnectionDataMessage(ref MessagePackWriter writer, ConnectionDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.ConnectionDataMessageType);
             writer.Write(message.ConnectionId);
 
             /************ REVIEW ************/
             // REVIEW : PREVIOUS CODE WAS writing every bytes manualy, not sure if this is the strict equivalent in term of serialization
             writer.Write(message.Payload);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteMultiConnectionDataMessage(ref MessagePackWriter writer, MultiConnectionDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.MultiConnectionDataMessageType);
             WriteStringArray(ref writer, message.ConnectionList);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteUserDataMessage(ref MessagePackWriter writer, UserDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.UserDataMessageType);
             writer.Write(message.UserId);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteMultiUserDataMessage(ref MessagePackWriter writer, MultiUserDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.MultiUserDataMessageType);
             WriteStringArray(ref writer, message.UserList);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteBroadcastDataMessage(ref MessagePackWriter writer, BroadcastDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.BroadcastDataMessageType);
             WriteStringArray(ref writer, message.ExcludedList);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteJoinGroupMessage(ref MessagePackWriter writer, JoinGroupMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.JoinGroupMessageType);
             writer.Write(message.ConnectionId);
             writer.Write(message.GroupName);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteLeaveGroupMessage(ref MessagePackWriter writer, LeaveGroupMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.LeaveGroupMessageType);
             writer.Write(message.ConnectionId);
             writer.Write(message.GroupName);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteUserJoinGroupMessage(ref MessagePackWriter writer, UserJoinGroupMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.UserJoinGroupMessageType);
             writer.Write(message.UserId);
             writer.Write(message.GroupName);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteUserLeaveGroupMessage(ref MessagePackWriter writer, UserLeaveGroupMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.UserLeaveGroupMessageType);
             writer.Write(message.UserId);
             writer.Write(message.GroupName);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteGroupBroadcastDataMessage(ref MessagePackWriter writer, GroupBroadcastDataMessage message)
         {
-            writer.WriteArrayHeader(4);
+            writer.WriteArrayHeader(5);
             writer.Write(ServiceProtocolConstants.GroupBroadcastDataMessageType);
             writer.Write(message.GroupName);
             WriteStringArray(ref writer, message.ExcludedList);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteMultiGroupBroadcastDataMessage(ref MessagePackWriter writer, MultiGroupBroadcastDataMessage message)
         {
-            writer.WriteArrayHeader(3);
+            writer.WriteArrayHeader(4);
             writer.Write(ServiceProtocolConstants.MultiGroupBroadcastDataMessageType);
             WriteStringArray(ref writer, message.GroupList);
             WritePayloads(ref writer, message.Payloads);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteServiceErrorMessage(ref MessagePackWriter writer, ServiceErrorMessage message)
@@ -376,29 +391,32 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         private static void WriteJoinGroupWithAckMessage(ref MessagePackWriter writer, JoinGroupWithAckMessage message)
         {
-            writer.WriteArrayHeader(4);
+            writer.WriteArrayHeader(5);
             writer.Write(ServiceProtocolConstants.JoinGroupWithAckMessageType);
             writer.Write(message.ConnectionId);
             writer.Write(message.GroupName);
             writer.Write(message.AckId);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteLeaveGroupWithAckMessage(ref MessagePackWriter writer, LeaveGroupWithAckMessage message)
         {
-            writer.WriteArrayHeader(4);
+            writer.WriteArrayHeader(5);
             writer.Write(ServiceProtocolConstants.LeaveGroupWithAckMessageType);
             writer.Write(message.ConnectionId);
             writer.Write(message.GroupName);
             writer.Write(message.AckId);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteAckMessage(ref MessagePackWriter writer, AckMessage message)
         {
-            writer.WriteArrayHeader(4);
+            writer.WriteArrayHeader(5);
             writer.Write(ServiceProtocolConstants.AckMessageType);
             writer.Write(message.AckId);
             writer.Write(message.Status);
             writer.Write(message.Message);
+            message.WriteExtensionMembers(ref writer);
         }
 
         private static void WriteStringArray(ref MessagePackWriter writer, IReadOnlyList<string> array)
@@ -474,14 +492,22 @@ namespace Microsoft.Azure.SignalR.Protocol
                 result.Target = ReadString(ref reader, "target");
             }
             result.MigrationLevel = arrayLength >= 5 ? ReadInt32(ref reader, "migratableStatus") : 0;
+            if (arrayLength >= 6)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
             return result;
         }
 
-        private static HandshakeResponseMessage CreateHandshakeResponseMessage(ref MessagePackReader reader)
+        private static HandshakeResponseMessage CreateHandshakeResponseMessage(ref MessagePackReader reader, int arrayLength)
         {
             var errorMessage = ReadString(ref reader, "errorMessage");
-
-            return new HandshakeResponseMessage(errorMessage);
+            var result = new HandshakeResponseMessage(errorMessage);
+            if (arrayLength >= 3)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
         private static PingMessage CreatePingMessage(ref MessagePackReader reader, int arrayLength)
@@ -506,11 +532,16 @@ namespace Microsoft.Azure.SignalR.Protocol
             var claims = ReadClaims(ref reader);
 
             // Backward compatible with old versions
-            if (arrayLength > 3)
+            if (arrayLength >= 5)
             {
                 var headers = ReadHeaders(ref reader);
                 var queryString = ReadString(ref reader, "queryString");
-                return new OpenConnectionMessage(connectionId, claims, headers, queryString);
+                var result = new OpenConnectionMessage(connectionId, claims, headers, queryString);
+                if (arrayLength >= 6)
+                {
+                    result.ReadExtensionMembers(ref reader);
+                }
+                return result;
             }
             else
             {
@@ -522,97 +553,157 @@ namespace Microsoft.Azure.SignalR.Protocol
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var errorMessage = ReadString(ref reader, "errorMessage");
-            var headers = arrayLength > 3 ? ReadHeaders(ref reader) : new Dictionary<string, StringValues>();
-            return new CloseConnectionMessage(connectionId, errorMessage, headers);
+            var headers = arrayLength >= 4 ? ReadHeaders(ref reader) : new Dictionary<string, StringValues>();
+            var result = new CloseConnectionMessage(connectionId, errorMessage, headers);
+            if (arrayLength >= 5)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static ConnectionDataMessage CreateConnectionDataMessage(ref MessagePackReader reader)
+        private static ConnectionDataMessage CreateConnectionDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var payload = ReadBytes(ref reader, "payload");
 
-            return new ConnectionDataMessage(connectionId, payload);
+            var result = new ConnectionDataMessage(connectionId, payload);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static MultiConnectionDataMessage CreateMultiConnectionDataMessage(ref MessagePackReader reader)
+        private static MultiConnectionDataMessage CreateMultiConnectionDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionList = ReadStringArray(ref reader, "connectionList");
             var payloads = ReadPayloads(ref reader);
 
-            return new MultiConnectionDataMessage(connectionList, payloads);
+            var result = new MultiConnectionDataMessage(connectionList, payloads);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static ServiceMessage CreateUserDataMessage(ref MessagePackReader reader)
+        private static ServiceMessage CreateUserDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var userId = ReadString(ref reader, "userId");
             var payloads = ReadPayloads(ref reader);
 
-            return new UserDataMessage(userId, payloads);
+            var result = new UserDataMessage(userId, payloads);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static MultiUserDataMessage CreateMultiUserDataMessage(ref MessagePackReader reader)
+        private static MultiUserDataMessage CreateMultiUserDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var userList = ReadStringArray(ref reader, "userList");
             var payloads = ReadPayloads(ref reader);
 
-            return new MultiUserDataMessage(userList, payloads);
+            var result = new MultiUserDataMessage(userList, payloads);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static BroadcastDataMessage CreateBroadcastDataMessage(ref MessagePackReader reader)
+        private static BroadcastDataMessage CreateBroadcastDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var excludedList = ReadStringArray(ref reader, "excludedList");
             var payloads = ReadPayloads(ref reader);
 
-            return new BroadcastDataMessage(excludedList, payloads);
+            var result = new BroadcastDataMessage(excludedList, payloads);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static JoinGroupMessage CreateJoinGroupMessage(ref MessagePackReader reader)
+        private static JoinGroupMessage CreateJoinGroupMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var groupName = ReadString(ref reader, "groupName");
 
-            return new JoinGroupMessage(connectionId, groupName);
+            var result = new JoinGroupMessage(connectionId, groupName);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static LeaveGroupMessage CreateLeaveGroupMessage(ref MessagePackReader reader)
+        private static LeaveGroupMessage CreateLeaveGroupMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var groupName = ReadString(ref reader, "groupName");
 
-            return new LeaveGroupMessage(connectionId, groupName);
+            var result = new LeaveGroupMessage(connectionId, groupName);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static UserJoinGroupMessage CreateUserJoinGroupMessage(ref MessagePackReader reader)
+        private static UserJoinGroupMessage CreateUserJoinGroupMessage(ref MessagePackReader reader, int arrayLength)
         {
             var userId = ReadString(ref reader, "userId");
             var groupName = ReadString(ref reader, "groupName");
 
-            return new UserJoinGroupMessage(userId, groupName);
+            var result = new UserJoinGroupMessage(userId, groupName);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static UserLeaveGroupMessage CreateUserLeaveGroupMessage(ref MessagePackReader reader)
+        private static UserLeaveGroupMessage CreateUserLeaveGroupMessage(ref MessagePackReader reader, int arrayLength)
         {
             var userId = ReadString(ref reader, "userId");
             var groupName = ReadString(ref reader, "groupName");
 
-            return new UserLeaveGroupMessage(userId, groupName);
+            var result = new UserLeaveGroupMessage(userId, groupName);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static GroupBroadcastDataMessage CreateGroupBroadcastDataMessage(ref MessagePackReader reader)
+        private static GroupBroadcastDataMessage CreateGroupBroadcastDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var groupName = ReadString(ref reader, "groupName");
             var excludedList = ReadStringArray(ref reader, "excludedList");
             var payloads = ReadPayloads(ref reader);
 
-            return new GroupBroadcastDataMessage(groupName, excludedList, payloads);
+            var result = new GroupBroadcastDataMessage(groupName, excludedList, payloads);
+            if (arrayLength >= 5)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static MultiGroupBroadcastDataMessage CreateMultiGroupBroadcastDataMessage(ref MessagePackReader reader)
+        private static MultiGroupBroadcastDataMessage CreateMultiGroupBroadcastDataMessage(ref MessagePackReader reader, int arrayLength)
         {
             var groupList = ReadStringArray(ref reader, "groupList");
             var payloads = ReadPayloads(ref reader);
 
-            return new MultiGroupBroadcastDataMessage(groupList, payloads);
+            var result = new MultiGroupBroadcastDataMessage(groupList, payloads);
+            if (arrayLength >= 4)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
         private static ServiceErrorMessage CreateServiceErrorMessage(ref MessagePackReader reader)
@@ -622,31 +713,46 @@ namespace Microsoft.Azure.SignalR.Protocol
             return new ServiceErrorMessage(errorMessage);
         }
 
-        private static JoinGroupWithAckMessage CreateJoinGroupWithAckMessage(ref MessagePackReader reader)
+        private static JoinGroupWithAckMessage CreateJoinGroupWithAckMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var groupName = ReadString(ref reader, "groupName");
             var ackId = ReadInt32(ref reader, "ackId");
 
-            return new JoinGroupWithAckMessage(connectionId, groupName, ackId);
+            var result = new JoinGroupWithAckMessage(connectionId, groupName, ackId);
+            if (arrayLength >= 5)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static LeaveGroupWithAckMessage CreateLeaveGroupWithAckMessage(ref MessagePackReader reader)
+        private static LeaveGroupWithAckMessage CreateLeaveGroupWithAckMessage(ref MessagePackReader reader, int arrayLength)
         {
             var connectionId = ReadString(ref reader, "connectionId");
             var groupName = ReadString(ref reader, "groupName");
             var ackId = ReadInt32(ref reader, "ackId");
 
-            return new LeaveGroupWithAckMessage(connectionId, groupName, ackId);
+            var result = new LeaveGroupWithAckMessage(connectionId, groupName, ackId);
+            if (arrayLength >= 5)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
-        private static AckMessage CreateAckMessage(ref MessagePackReader reader)
+        private static AckMessage CreateAckMessage(ref MessagePackReader reader, int arrayLength)
         {
             var ackId = ReadInt32(ref reader, "ackId");
             var status = ReadInt32(ref reader, "status");
             var message = ReadString(ref reader, "message");
 
-            return new AckMessage(ackId, status, message);
+            var result = new AckMessage(ackId, status, message);
+            if (arrayLength >= 5)
+            {
+                result.ReadExtensionMembers(ref reader);
+            }
+            return result;
         }
 
         private static Claim[] ReadClaims(ref MessagePackReader reader)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -100,7 +100,9 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
 
         private bool ConnectionDataMessagesEqual(ConnectionDataMessage x, ConnectionDataMessage y)
         {
-            return StringEqual(x.ConnectionId, y.ConnectionId) && SequenceEqual(x.Payload.ToArray(), y.Payload.ToArray());
+            return StringEqual(x.ConnectionId, y.ConnectionId) &&
+                SequenceEqual(x.Payload.ToArray(), y.Payload.ToArray()) &&
+                StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool MultiConnectionDataMessagesEqual(MultiConnectionDataMessage x, MultiConnectionDataMessage y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -80,23 +80,23 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "HandshakeRequest",
                 message: new HandshakeRequestMessage(1),
-                binary: "lgEBAKAAkA=="),
+                binary: "lgEBAKAAgA=="),
             new ProtocolTestData(
                 name: "HandshakeRequestWithProperty",
                 message: new HandshakeRequestMessage(1) { ConnectionType = 1, Target = "abc" },
-                binary: "lgEBAaNhYmMAkA=="),
+                binary: "lgEBAaNhYmMAgA=="),
             new ProtocolTestData(
                 name: "HandshakeRequestWithMigratableStatus",
                 message: new HandshakeRequestMessage(1) { MigrationLevel = 1},
-                binary: "lgEBAKABkA=="),
+                binary: "lgEBAKABgA=="),
             new ProtocolTestData(
                 name: "HandshakeResponse",
                 message: new HandshakeResponseMessage(),
-                binary: "kwKgkA=="),
+                binary: "kwKggA=="),
             new ProtocolTestData(
                 name: "HandshakeResponseWithError",
                 message: new HandshakeResponseMessage("Version mismatch."),
-                binary: "kwKxVmVyc2lvbiBtaXNtYXRjaC6Q"),
+                binary: "kwKxVmVyc2lvbiBtaXNtYXRjaC6A"),
             new ProtocolTestData(
                 name: "Ping",
                 message: PingMessage.Instance,
@@ -108,11 +108,11 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "OpenConnection",
                 message: new OpenConnectionMessage("conn1", null),
-                binary: "lgSlY29ubjGAgKCQ"),
+                binary: "lgSlY29ubjGAgKCA"),
             new ProtocolTestData(
                 name: "OpenConnectionWithClaims",
                 message: new OpenConnectionMessage("conn2", new [] {new Claim(ClaimTypes.NameIdentifier, "user1")}),
-                binary: "lgSlY29ubjKB2URodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllcqV1c2VyMYCgkA=="),
+                binary: "lgSlY29ubjKB2URodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllcqV1c2VyMYCggA=="),
             new ProtocolTestData(
                 name: "OpenConnectionWithHeaders",
                 message: new OpenConnectionMessage("conn3", null, new Dictionary<string, StringValues>
@@ -121,31 +121,31 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     {"header-key-2", new[] {"heaer-value-2a", "header-value-2b"}},
                     {"header-key-3", new[] {"heaer-value-3a", "header-value-3b", "header-value-3c"}}
                 }, string.Empty),
-                binary: "lgSlY29ubjOAg6xoZWFkZXIta2V5LTGRrmhlYWRlci12YWx1ZS0xrGhlYWRlci1rZXktMpKuaGVhZXItdmFsdWUtMmGvaGVhZGVyLXZhbHVlLTJirGhlYWRlci1rZXktM5OuaGVhZXItdmFsdWUtM2GvaGVhZGVyLXZhbHVlLTNir2hlYWRlci12YWx1ZS0zY6CQ"),
+                binary: "lgSlY29ubjOAg6xoZWFkZXIta2V5LTGRrmhlYWRlci12YWx1ZS0xrGhlYWRlci1rZXktMpKuaGVhZXItdmFsdWUtMmGvaGVhZGVyLXZhbHVlLTJirGhlYWRlci1rZXktM5OuaGVhZXItdmFsdWUtM2GvaGVhZGVyLXZhbHVlLTNir2hlYWRlci12YWx1ZS0zY6CA"),
             new ProtocolTestData(
                 name: "OpenConnectionWithQueryString1",
                 message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1"),
-                binary: "lgSlY29ubjSAgK1xdWVyeTE9dmFsdWUxkA=="),
+                binary: "lgSlY29ubjSAgK1xdWVyeTE9dmFsdWUxgA=="),
             new ProtocolTestData(
                 name: "OpenConnectionWithQueryString2",
                 message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1&query2=query2&query3=value3"),
-                binary: "lgSlY29ubjSAgNkpcXVlcnkxPXZhbHVlMSZxdWVyeTI9cXVlcnkyJnF1ZXJ5Mz12YWx1ZTOQ"),
+                binary: "lgSlY29ubjSAgNkpcXVlcnkxPXZhbHVlMSZxdWVyeTI9cXVlcnkyJnF1ZXJ5Mz12YWx1ZTOA"),
             new ProtocolTestData(
                 name: "CloseConnection",
                 message: new CloseConnectionMessage("conn3"),
-                binary: "lQWlY29ubjOggJA="),
+                binary: "lQWlY29ubjOggIA="),
             new ProtocolTestData(
                 name: "CloseConnectionWithError",
                 message: new CloseConnectionMessage("conn4", "Error message."),
-                binary: "lQWlY29ubjSuRXJyb3IgbWVzc2FnZS6AkA=="),
+                binary: "lQWlY29ubjSuRXJyb3IgbWVzc2FnZS6AgA=="),
             new ProtocolTestData(
                 name: "ConnectionData",
                 message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}),
-                binary: "lAalY29ubjXEBwECAwQFBgeQ"),
+                binary: "lAalY29ubjXEBwECAwQFBgeA"),
             new ProtocolTestData(
                 name: "ConnectionDataWithTracingId",
                 message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}) { TracingId = "test" },
-                binary: "lAalY29ubjXEBwECAwQFBgeSAaR0ZXN0"),
+                binary: "lAalY29ubjXEBwECAwQFBgeBAaR0ZXN0"),
             new ProtocolTestData(
                 name: "MultiConnectionData",
                 message: new MultiConnectionDataMessage(new [] {"conn6", "conn7"}, new Dictionary<string, ReadOnlyMemory<byte>>
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     ["json"] = new byte[] {2, 3, 4, 5, 6, 7, 1},
                     ["messagepack"] = new byte[] {3, 4, 5, 6, 7, 1, 2}
                 }),
-                binary: "lAeSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwECkA=="),
+                binary: "lAeSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwECgA=="),
             new ProtocolTestData(
                 name: "UserData",
                 message: new UserDataMessage("user1",
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lAildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQaQ"),
+                binary: "lAildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQaA"),
             new ProtocolTestData(
                 name: "MultiUserData",
                 message: new MultiUserDataMessage(new [] {"user1", "user2"},
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lAmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
+                binary: "lAmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgA=="),
             new ProtocolTestData(
                 name: "Broadcast",
                 message: new BroadcastDataMessage(new Dictionary<string, ReadOnlyMemory<byte>>
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     ["json"] = new byte[] {4, 5, 6, 7, 1, 2, 3},
                     ["messagepack"] = new byte[] {5, 6, 7, 1, 2, 3, 4}
                 }),
-                binary: "lAqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgMEkA=="),
+                binary: "lAqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgMEgA=="),
             new ProtocolTestData(
                 name: "BroadcastExcept",
                 message: new BroadcastDataMessage(new[] {"conn7", "conn8", "conn9"},
@@ -188,23 +188,23 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lAqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
+                binary: "lAqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgA=="),
             new ProtocolTestData(
                 name: "JoinGroup",
                 message: new JoinGroupMessage("conn10", "group1"),
-                binary: "lAumY29ubjEwpmdyb3VwMZA="),
+                binary: "lAumY29ubjEwpmdyb3VwMYA="),
             new ProtocolTestData(
                 name: "LeaveGroup",
                 message: new LeaveGroupMessage("conn11", "group2"),
-                binary: "lAymY29ubjExpmdyb3VwMpA="),
+                binary: "lAymY29ubjExpmdyb3VwMoA="),
             new ProtocolTestData(
                 name: "UserJoinGroup",
                 message: new UserJoinGroupMessage("conn10", "group1"),
-                binary: "lBCmY29ubjEwpmdyb3VwMZA="),
+                binary: "lBCmY29ubjEwpmdyb3VwMYA="),
             new ProtocolTestData(
                 name: "UserLeaveGroup",
                 message: new UserLeaveGroupMessage("conn11", "group2"),
-                binary: "lBGmY29ubjExpmdyb3VwMpA="),
+                binary: "lBGmY29ubjExpmdyb3VwMoA="),
             new ProtocolTestData(
                 name: "GroupBroadcast",
                 message: new GroupBroadcastDataMessage("group3",
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBpA="),
+                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoA="),
             new ProtocolTestData(
                 name: "GroupBroadcastExcept",
                 message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lQ2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
+                binary: "lQ2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgA=="),
             new ProtocolTestData(
                 name: "MultiGroupBroadcast",
                 message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {1, 2, 3, 4, 5, 6, 7, 8},
                         ["messagepack"] = new byte[] {7, 8, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lA6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBpA="),
+                binary: "lA6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBoA="),
             new ProtocolTestData(
                 name: "ServiceError",
                 message: new ServiceErrorMessage("Maximum message count limit reached: 100000"),
@@ -239,19 +239,19 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "JoinGroupWithAck",
                 message: new JoinGroupWithAckMessage("conn14", "group1", 1), 
-                binary: "lRKmY29ubjE0pmdyb3VwMQGQ"),
+                binary: "lRKmY29ubjE0pmdyb3VwMQGA"),
             new ProtocolTestData(
                 name: "LeaveGroupWithAck",
                 message: new LeaveGroupWithAckMessage("conn15", "group2", 1), 
-                binary: "lROmY29ubjE1pmdyb3VwMgGQ"),
+                binary: "lROmY29ubjE1pmdyb3VwMgGA"),
             new ProtocolTestData(
                 name: "Ack",
                 message: new AckMessage(1, 100), 
-                binary: "lRQBZKCQ"),
+                binary: "lRQBZKCA"),
             new ProtocolTestData(
                 name: "AckWithMessage",
                 message: new AckMessage(2, 101, "Joined group successfully"),
-                binary: "lRQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5kA=="),
+                binary: "lRQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5gA=="),
         }.ToDictionary(t => t.Name);
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 }
             }
         }
+
         public static IDictionary<string, ProtocolTestData> TestCompatibilityData => new[] {
             new ProtocolTestData(
                 name: "CloseConnection",
@@ -78,23 +80,23 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "HandshakeRequest",
                 message: new HandshakeRequestMessage(1),
-                binary: "lQEBAKAA"),
+                binary: "lgEBAKAAkA=="),
             new ProtocolTestData(
                 name: "HandshakeRequestWithProperty",
                 message: new HandshakeRequestMessage(1) { ConnectionType = 1, Target = "abc" },
-                binary: "lQEBAaNhYmMA"),
+                binary: "lgEBAaNhYmMAkA=="),
             new ProtocolTestData(
                 name: "HandshakeRequestWithMigratableStatus",
                 message: new HandshakeRequestMessage(1) { MigrationLevel = 1},
-                binary: "lQEBAKAB"),
+                binary: "lgEBAKABkA=="),
             new ProtocolTestData(
                 name: "HandshakeResponse",
                 message: new HandshakeResponseMessage(),
-                binary: "kgKg"),
+                binary: "kwKgkA=="),
             new ProtocolTestData(
                 name: "HandshakeResponseWithError",
                 message: new HandshakeResponseMessage("Version mismatch."),
-                binary: "kgKxVmVyc2lvbiBtaXNtYXRjaC4="),
+                binary: "kwKxVmVyc2lvbiBtaXNtYXRjaC6Q"),
             new ProtocolTestData(
                 name: "Ping",
                 message: PingMessage.Instance,
@@ -106,11 +108,11 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "OpenConnection",
                 message: new OpenConnectionMessage("conn1", null),
-                binary: "lQSlY29ubjGAgKA="),
+                binary: "lgSlY29ubjGAgKCQ"),
             new ProtocolTestData(
                 name: "OpenConnectionWithClaims",
                 message: new OpenConnectionMessage("conn2", new [] {new Claim(ClaimTypes.NameIdentifier, "user1")}),
-                binary: "lQSlY29ubjKB2URodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllcqV1c2VyMYCg"),
+                binary: "lgSlY29ubjKB2URodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllcqV1c2VyMYCgkA=="),
             new ProtocolTestData(
                 name: "OpenConnectionWithHeaders",
                 message: new OpenConnectionMessage("conn3", null, new Dictionary<string, StringValues>
@@ -119,27 +121,31 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     {"header-key-2", new[] {"heaer-value-2a", "header-value-2b"}},
                     {"header-key-3", new[] {"heaer-value-3a", "header-value-3b", "header-value-3c"}}
                 }, string.Empty),
-                binary: "lQSlY29ubjOAg6xoZWFkZXIta2V5LTGRrmhlYWRlci12YWx1ZS0xrGhlYWRlci1rZXktMpKuaGVhZXItdmFsdWUtMmGvaGVhZGVyLXZhbHVlLTJirGhlYWRlci1rZXktM5OuaGVhZXItdmFsdWUtM2GvaGVhZGVyLXZhbHVlLTNir2hlYWRlci12YWx1ZS0zY6A="),
+                binary: "lgSlY29ubjOAg6xoZWFkZXIta2V5LTGRrmhlYWRlci12YWx1ZS0xrGhlYWRlci1rZXktMpKuaGVhZXItdmFsdWUtMmGvaGVhZGVyLXZhbHVlLTJirGhlYWRlci1rZXktM5OuaGVhZXItdmFsdWUtM2GvaGVhZGVyLXZhbHVlLTNir2hlYWRlci12YWx1ZS0zY6CQ"),
             new ProtocolTestData(
                 name: "OpenConnectionWithQueryString1",
                 message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1"),
-                binary: "lQSlY29ubjSAgK1xdWVyeTE9dmFsdWUx"),
+                binary: "lgSlY29ubjSAgK1xdWVyeTE9dmFsdWUxkA=="),
             new ProtocolTestData(
                 name: "OpenConnectionWithQueryString2",
                 message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1&query2=query2&query3=value3"),
-                binary: "lQSlY29ubjSAgNkpcXVlcnkxPXZhbHVlMSZxdWVyeTI9cXVlcnkyJnF1ZXJ5Mz12YWx1ZTM="),
+                binary: "lgSlY29ubjSAgNkpcXVlcnkxPXZhbHVlMSZxdWVyeTI9cXVlcnkyJnF1ZXJ5Mz12YWx1ZTOQ"),
             new ProtocolTestData(
                 name: "CloseConnection",
                 message: new CloseConnectionMessage("conn3"),
-                binary: "lAWlY29ubjOggA=="),
+                binary: "lQWlY29ubjOggJA="),
             new ProtocolTestData(
                 name: "CloseConnectionWithError",
                 message: new CloseConnectionMessage("conn4", "Error message."),
-                binary: "lAWlY29ubjSuRXJyb3IgbWVzc2FnZS6A"),
+                binary: "lQWlY29ubjSuRXJyb3IgbWVzc2FnZS6AkA=="),
             new ProtocolTestData(
                 name: "ConnectionData",
                 message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}),
-                binary: "kwalY29ubjXEBwECAwQFBgc="),
+                binary: "lAalY29ubjXEBwECAwQFBgeQ"),
+            new ProtocolTestData(
+                name: "ConnectionDataWithTracingId",
+                message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}) { TracingId = "test" },
+                binary: "lAalY29ubjXEBwECAwQFBgeSAaR0ZXN0"),
             new ProtocolTestData(
                 name: "MultiConnectionData",
                 message: new MultiConnectionDataMessage(new [] {"conn6", "conn7"}, new Dictionary<string, ReadOnlyMemory<byte>>
@@ -147,7 +153,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     ["json"] = new byte[] {2, 3, 4, 5, 6, 7, 1},
                     ["messagepack"] = new byte[] {3, 4, 5, 6, 7, 1, 2}
                 }),
-                binary: "kweSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwEC"),
+                binary: "lAeSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwECkA=="),
             new ProtocolTestData(
                 name: "UserData",
                 message: new UserDataMessage("user1",
@@ -156,7 +162,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "kwildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQY="),
+                binary: "lAildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQaQ"),
             new ProtocolTestData(
                 name: "MultiUserData",
                 message: new MultiUserDataMessage(new [] {"user1", "user2"},
@@ -165,7 +171,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "kwmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+                binary: "lAmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
             new ProtocolTestData(
                 name: "Broadcast",
                 message: new BroadcastDataMessage(new Dictionary<string, ReadOnlyMemory<byte>>
@@ -173,7 +179,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     ["json"] = new byte[] {4, 5, 6, 7, 1, 2, 3},
                     ["messagepack"] = new byte[] {5, 6, 7, 1, 2, 3, 4}
                 }),
-                binary: "kwqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgME"),
+                binary: "lAqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgMEkA=="),
             new ProtocolTestData(
                 name: "BroadcastExcept",
                 message: new BroadcastDataMessage(new[] {"conn7", "conn8", "conn9"},
@@ -182,23 +188,23 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "kwqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+                binary: "lAqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
             new ProtocolTestData(
                 name: "JoinGroup",
                 message: new JoinGroupMessage("conn10", "group1"),
-                binary: "kwumY29ubjEwpmdyb3VwMQ=="),
+                binary: "lAumY29ubjEwpmdyb3VwMZA="),
             new ProtocolTestData(
                 name: "LeaveGroup",
                 message: new LeaveGroupMessage("conn11", "group2"),
-                binary: "kwymY29ubjExpmdyb3VwMg=="),
+                binary: "lAymY29ubjExpmdyb3VwMpA="),
             new ProtocolTestData(
                 name: "UserJoinGroup",
                 message: new UserJoinGroupMessage("conn10", "group1"),
-                binary: "kxCmY29ubjEwpmdyb3VwMQ=="),
+                binary: "lBCmY29ubjEwpmdyb3VwMZA="),
             new ProtocolTestData(
                 name: "UserLeaveGroup",
                 message: new UserLeaveGroupMessage("conn11", "group2"),
-                binary: "kxGmY29ubjExpmdyb3VwMg=="),
+                binary: "lBGmY29ubjExpmdyb3VwMpA="),
             new ProtocolTestData(
                 name: "GroupBroadcast",
                 message: new GroupBroadcastDataMessage("group3",
@@ -207,7 +213,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lA2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBg=="),
+                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBpA="),
             new ProtocolTestData(
                 name: "GroupBroadcastExcept",
                 message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
@@ -216,7 +222,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lA2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+                binary: "lQ2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGkA=="),
             new ProtocolTestData(
                 name: "MultiGroupBroadcast",
                 message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},
@@ -225,7 +231,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {1, 2, 3, 4, 5, 6, 7, 8},
                         ["messagepack"] = new byte[] {7, 8, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "kw6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBg=="),
+                binary: "lA6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBpA="),
             new ProtocolTestData(
                 name: "ServiceError",
                 message: new ServiceErrorMessage("Maximum message count limit reached: 100000"),
@@ -233,19 +239,19 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             new ProtocolTestData(
                 name: "JoinGroupWithAck",
                 message: new JoinGroupWithAckMessage("conn14", "group1", 1), 
-                binary: "lBKmY29ubjE0pmdyb3VwMQE="),
+                binary: "lRKmY29ubjE0pmdyb3VwMQGQ"),
             new ProtocolTestData(
                 name: "LeaveGroupWithAck",
                 message: new LeaveGroupWithAckMessage("conn15", "group2", 1), 
-                binary: "lBOmY29ubjE1pmdyb3VwMgE="),
+                binary: "lROmY29ubjE1pmdyb3VwMgGQ"),
             new ProtocolTestData(
                 name: "Ack",
                 message: new AckMessage(1, 100), 
-                binary: "lBQBZKA="),
+                binary: "lRQBZKCQ"),
             new ProtocolTestData(
                 name: "AckWithMessage",
                 message: new AckMessage(2, 101, "Joined group successfully"),
-                binary: "lBQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5"),
+                binary: "lRQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5kA=="),
         }.ToDictionary(t => t.Name);
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -73,6 +73,165 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "HandshakeRequestWithProperty",
                 message: new HandshakeRequestMessage(1) { ConnectionType = 1, Target = "abc" },
                 binary: "lAEBAaNhYmM="),
+            new ProtocolTestData(
+                name: "HandshakeRequest_NoOptionalField",
+                message: new HandshakeRequestMessage(1),
+                binary: "lQEBAKAA"),
+            new ProtocolTestData(
+                name: "HandshakeRequestWithProperty_NoOptionalField",
+                message: new HandshakeRequestMessage(1) { ConnectionType = 1, Target = "abc" },
+                binary: "lQEBAaNhYmMA"),
+            new ProtocolTestData(
+                name: "HandshakeRequestWithMigratableStatus_NoOptionalField",
+                message: new HandshakeRequestMessage(1) { MigrationLevel = 1},
+                binary: "lQEBAKAB"),
+            new ProtocolTestData(
+                name: "HandshakeResponse_NoOptionalField",
+                message: new HandshakeResponseMessage(),
+                binary: "kgKg"),
+            new ProtocolTestData(
+                name: "HandshakeResponseWithError_NoOptionalField",
+                message: new HandshakeResponseMessage("Version mismatch."),
+                binary: "kgKxVmVyc2lvbiBtaXNtYXRjaC4="),
+            new ProtocolTestData(
+                name: "OpenConnection_NoOptionalField",
+                message: new OpenConnectionMessage("conn1", null),
+                binary: "lQSlY29ubjGAgKA="),
+            new ProtocolTestData(
+                name: "OpenConnectionWithClaims_NoOptionalField",
+                message: new OpenConnectionMessage("conn2", new [] {new Claim(ClaimTypes.NameIdentifier, "user1")}),
+                binary: "lQSlY29ubjKB2URodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllcqV1c2VyMYCg"),
+            new ProtocolTestData(
+                name: "OpenConnectionWithHeaders_NoOptionalField",
+                message: new OpenConnectionMessage("conn3", null, new Dictionary<string, StringValues>
+                {
+                    {"header-key-1", "header-value-1"},
+                    {"header-key-2", new[] {"heaer-value-2a", "header-value-2b"}},
+                    {"header-key-3", new[] {"heaer-value-3a", "header-value-3b", "header-value-3c"}}
+                }, string.Empty),
+                binary: "lQSlY29ubjOAg6xoZWFkZXIta2V5LTGRrmhlYWRlci12YWx1ZS0xrGhlYWRlci1rZXktMpKuaGVhZXItdmFsdWUtMmGvaGVhZGVyLXZhbHVlLTJirGhlYWRlci1rZXktM5OuaGVhZXItdmFsdWUtM2GvaGVhZGVyLXZhbHVlLTNir2hlYWRlci12YWx1ZS0zY6A="),
+            new ProtocolTestData(
+                name: "OpenConnectionWithQueryString1_NoOptionalField",
+                message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1"),
+                binary: "lQSlY29ubjSAgK1xdWVyeTE9dmFsdWUx"),
+            new ProtocolTestData(
+                name: "OpenConnectionWithQueryString2_NoOptionalField",
+                message: new OpenConnectionMessage("conn4", null, new Dictionary<string, StringValues>(), "query1=value1&query2=query2&query3=value3"),
+                binary: "lQSlY29ubjSAgNkpcXVlcnkxPXZhbHVlMSZxdWVyeTI9cXVlcnkyJnF1ZXJ5Mz12YWx1ZTM="),
+            new ProtocolTestData(
+                name: "CloseConnection_NoOptionalField",
+                message: new CloseConnectionMessage("conn3"),
+                binary: "lAWlY29ubjOggA=="),
+            new ProtocolTestData(
+                name: "CloseConnectionWithError_NoOptionalField",
+                message: new CloseConnectionMessage("conn4", "Error message."),
+                binary: "lAWlY29ubjSuRXJyb3IgbWVzc2FnZS6A"),
+            new ProtocolTestData(
+                name: "ConnectionData_NoOptionalField",
+                message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}),
+                binary: "kwalY29ubjXEBwECAwQFBgc="),
+            new ProtocolTestData(
+                name: "MultiConnectionData_NoOptionalField",
+                message: new MultiConnectionDataMessage(new [] {"conn6", "conn7"}, new Dictionary<string, ReadOnlyMemory<byte>>
+                {
+                    ["json"] = new byte[] {2, 3, 4, 5, 6, 7, 1},
+                    ["messagepack"] = new byte[] {3, 4, 5, 6, 7, 1, 2}
+                }),
+                binary: "kweSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwEC"),
+            new ProtocolTestData(
+                name: "UserData_NoOptionalField",
+                message: new UserDataMessage("user1",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "kwildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQY="),
+            new ProtocolTestData(
+                name: "MultiUserData_NoOptionalField",
+                message: new MultiUserDataMessage(new [] {"user1", "user2"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "kwmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+            new ProtocolTestData(
+                name: "Broadcast_NoOptionalField",
+                message: new BroadcastDataMessage(new Dictionary<string, ReadOnlyMemory<byte>>
+                {
+                    ["json"] = new byte[] {4, 5, 6, 7, 1, 2, 3},
+                    ["messagepack"] = new byte[] {5, 6, 7, 1, 2, 3, 4}
+                }),
+                binary: "kwqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgME"),
+            new ProtocolTestData(
+                name: "BroadcastExcept_NoOptionalField",
+                message: new BroadcastDataMessage(new[] {"conn7", "conn8", "conn9"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "kwqTpWNvbm43pWNvbm44pWNvbm45gqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+            new ProtocolTestData(
+                name: "JoinGroup_NoOptionalField",
+                message: new JoinGroupMessage("conn10", "group1"),
+                binary: "kwumY29ubjEwpmdyb3VwMQ=="),
+            new ProtocolTestData(
+                name: "LeaveGroup_NoOptionalField",
+                message: new LeaveGroupMessage("conn11", "group2"),
+                binary: "kwymY29ubjExpmdyb3VwMg=="),
+            new ProtocolTestData(
+                name: "UserJoinGroup_NoOptionalField",
+                message: new UserJoinGroupMessage("conn10", "group1"),
+                binary: "kxCmY29ubjEwpmdyb3VwMQ=="),
+            new ProtocolTestData(
+                name: "UserLeaveGroup_NoOptionalField",
+                message: new UserLeaveGroupMessage("conn11", "group2"),
+                binary: "kxGmY29ubjExpmdyb3VwMg=="),
+            new ProtocolTestData(
+                name: "GroupBroadcast_NoOptionalField",
+                message: new GroupBroadcastDataMessage("group3",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "lA2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBg=="),
+            new ProtocolTestData(
+                name: "GroupBroadcastExcept_NoOptionalField",
+                message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "lA2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUG"),
+            new ProtocolTestData(
+                name: "MultiGroupBroadcast_NoOptionalField",
+                message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {1, 2, 3, 4, 5, 6, 7, 8},
+                        ["messagepack"] = new byte[] {7, 8, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "kw6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBg=="),
+            new ProtocolTestData(
+                name: "JoinGroupWithAck_NoOptionalField",
+                message: new JoinGroupWithAckMessage("conn14", "group1", 1),
+                binary: "lBKmY29ubjE0pmdyb3VwMQE="),
+            new ProtocolTestData(
+                name: "LeaveGroupWithAck_NoOptionalField",
+                message: new LeaveGroupWithAckMessage("conn15", "group2", 1),
+                binary: "lBOmY29ubjE1pmdyb3VwMgE="),
+            new ProtocolTestData(
+                name: "Ack_NoOptionalField",
+                message: new AckMessage(1, 100),
+                binary: "lBQBZKA="),
+            new ProtocolTestData(
+                name: "AckWithMessage_NoOptionalField",
+                message: new AckMessage(2, 101, "Joined group successfully"),
+                binary: "lBQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5"),
         }.ToDictionary(t => t.Name);
 
         public static IDictionary<string, ProtocolTestData> TestData => new[]
@@ -238,15 +397,15 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 binary: "kg/ZK01heGltdW0gbWVzc2FnZSBjb3VudCBsaW1pdCByZWFjaGVkOiAxMDAwMDA="),
             new ProtocolTestData(
                 name: "JoinGroupWithAck",
-                message: new JoinGroupWithAckMessage("conn14", "group1", 1), 
+                message: new JoinGroupWithAckMessage("conn14", "group1", 1),
                 binary: "lRKmY29ubjE0pmdyb3VwMQGA"),
             new ProtocolTestData(
                 name: "LeaveGroupWithAck",
-                message: new LeaveGroupWithAckMessage("conn15", "group2", 1), 
+                message: new LeaveGroupWithAckMessage("conn15", "group2", 1),
                 binary: "lROmY29ubjE1pmdyb3VwMgGA"),
             new ProtocolTestData(
                 name: "Ack",
-                message: new AckMessage(1, 100), 
+                message: new AckMessage(1, 100),
                 binary: "lRQBZKCA"),
             new ProtocolTestData(
                 name: "AckWithMessage",
@@ -360,17 +519,17 @@ Please verify the MsgPack output and update the baseline");
 
         private static byte ArrayBytes(int size)
         {
-            return (byte) (0x90 | size);
+            return (byte)(0x90 | size);
         }
 
         private static byte StringBytes(int size)
         {
-            return (byte) (0xa0 | size);
+            return (byte)(0xa0 | size);
         }
 
         private static byte MapBytes(int size)
         {
-            return (byte) (0x80 | size);
+            return (byte)(0x80 | size);
         }
 
         private static byte[] Frame(byte[] input)


### PR DESCRIPTION
Allow adding more optional members in future.

## Issue

Serialize and deserialize optional members.

## Scenario

We will have more optional members in near future.

* Tracing Id -  for diagnosis
* Sequence Id - for ordering in some special time (client connection switch to another server connection in the same server).

We cannot use current length based deserializing to detect which field occurred.

## Solution
Add a map field represent all optional fields in the binary.

* All of optional fields should write in this field.
* Non-optional fields are not recommended in this field.
* Key is field hint for identifying the optional field (e.g.: tracing id is 1).
* Value is the real value for the optional field.

### Sample
The original format for `ConnectionDataMessage` is:
```
[(type)6, (ConnectionId) "abc", (payload) binary]
```
Updated format is:
```
[(type)6, (ConnectionId) "abc", (payload) binary, (optional fields) { }]
```
And with tracing id `id123`:
```
[(type)6, (ConnectionId) "abc", (payload) binary, (optional fields) { (hint)1: (value)"id123" }]
```

## About this PR

This PR just want to standardize the optional fields serializing/deserializing.
Define optional fields or implement them is out of scope.