### PR TITLE
Add TrackingClientFilter in ServiceOption

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         private readonly string _appName;
         private readonly Func<IOwinContext, IEnumerable<Claim>> _claimsProvider;
-        private readonly Func<IOwinContext, bool> _trackingClientFilter;
+        private readonly Func<IOwinContext, bool> _tracingClientFilter;
         private readonly ILogger _logger;
 
         private readonly IServiceEndpointManager _endpointManager;
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.SignalR.AspNet
             _provider = configuration.Resolver.Resolve<IUserIdProvider>();
             _appName = appName ?? throw new ArgumentNullException(nameof(appName));
             _claimsProvider = options?.ClaimsProvider;
-            _trackingClientFilter = options?.TrackingClientFilter;
+            _tracingClientFilter = options?.TracingClientFilter;
             _endpointManager = endpointManager ?? throw new ArgumentNullException(nameof(endpointManager));
             _router = router ?? throw new ArgumentNullException(nameof(router));
             _connectionRequestIdProvider = connectionRequestIdProvider ?? throw new ArgumentNullException(nameof(connectionRequestIdProvider));
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.SignalR.AspNet
             yield return new Claim(Constants.ClaimType.AppName, _appName);
             var user = owinContext.Authentication?.User;
             var userId = _provider?.GetUserId(request);
-            var claims = ClaimsUtility.BuildJwtClaims(user, userId, GetClaimsProvider(owinContext), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsTrackingClient(owinContext));
+            var claims = ClaimsUtility.BuildJwtClaims(user, userId, GetClaimsProvider(owinContext), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsTracingClient(owinContext));
 
             yield return new Claim(Constants.ClaimType.Version, AssemblyVersion);
 
@@ -230,9 +230,9 @@ namespace Microsoft.Azure.SignalR.AspNet
             return () => _claimsProvider.Invoke(context);
         }
 
-        private bool IsTrackingClient(IOwinContext context)
+        private bool IsTracingClient(IOwinContext context)
         {
-            return _trackingClientFilter != null && _trackingClientFilter(context);
+            return _tracingClientFilter != null && _tracingClientFilter(context);
         }
 
         private static string GetRedirectNegotiateResponse(string url, string token)

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.SignalR.AspNet
         public Func<IOwinContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the func to set tracking client filter from <see cref="IOwinContext" />.
-        /// The clients will be regarded as tracking client only if the function returns true.
+        /// Gets or sets the func to set diagnostic client filter from <see cref="IOwinContext" />.
+        /// The clients will be regarded as diagnostic client only if the function returns true.
         /// </summary>
-        public Func<IOwinContext, bool> TracingClientFilter { get; set; } = null;
+        public Func<IOwinContext, bool> DiagnosticClientFilter { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -39,6 +39,12 @@ namespace Microsoft.Azure.SignalR.AspNet
         public Func<IOwinContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the func to set tracking client filter from <see cref="IOwinContext" />.
+        /// The clients will be regarded as tracking client only if the function returns true.
+        /// </summary>
+        public Func<IOwinContext, bool> TrackingClientFilter { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
         /// Default value is one hour.
         /// </summary>

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         /// Gets or sets the func to set tracking client filter from <see cref="IOwinContext" />.
         /// The clients will be regarded as tracking client only if the function returns true.
         /// </summary>
-        public Func<IOwinContext, bool> TrackingClientFilter { get; set; } = null;
+        public Func<IOwinContext, bool> TracingClientFilter { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.SignalR
             public const string EnableDetailedErrors = AzureSignalRSysPrefix + "derror";
             public const string ServiceEndpointsCount = AzureSignalRSysPrefix + "secn";
             public const string MaxPollInterval = AzureSignalRSysPrefix + "ttl";
-            public const string TrackingClient = AzureSignalRSysPrefix + "tc";
+            public const string TracingClient = AzureSignalRSysPrefix + "tc";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.SignalR
             public const string EnableDetailedErrors = AzureSignalRSysPrefix + "derror";
             public const string ServiceEndpointsCount = AzureSignalRSysPrefix + "secn";
             public const string MaxPollInterval = AzureSignalRSysPrefix + "ttl";
-            public const string TracingClient = AzureSignalRSysPrefix + "tc";
+            public const string DiagnosticClient = AzureSignalRSysPrefix + "dc";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.SignalR
             public const string EnableDetailedErrors = AzureSignalRSysPrefix + "derror";
             public const string ServiceEndpointsCount = AzureSignalRSysPrefix + "secn";
             public const string MaxPollInterval = AzureSignalRSysPrefix + "ttl";
+            public const string TrackingClient = AzureSignalRSysPrefix + "tc";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR
             bool enableDetailedErrors = false, 
             int endpointsCount = 1,
             int? maxPollInterval = null,
-            bool isTracingClient = false)
+            bool isDiagnosticClient = false)
         {
             if (userId != null)
             {
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.SignalR
                 yield return new Claim(Constants.ClaimType.ServerStickyMode, mode.ToString());
             }
 
-            if (isTracingClient)
+            if (isDiagnosticClient)
             {
-                yield return new Claim(Constants.ClaimType.TracingClient, "true");
+                yield return new Claim(Constants.ClaimType.DiagnosticClient, "true");
             }
 
             var authenticationType = user?.Identity?.AuthenticationType;

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR
             bool enableDetailedErrors = false, 
             int endpointsCount = 1,
             int? maxPollInterval = null,
-            bool isTrackingClient = false)
+            bool isTracingClient = false)
         {
             if (userId != null)
             {
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.SignalR
                 yield return new Claim(Constants.ClaimType.ServerStickyMode, mode.ToString());
             }
 
-            if (isTrackingClient)
+            if (isTracingClient)
             {
-                yield return new Claim(Constants.ClaimType.TrackingClient, "true");
+                yield return new Claim(Constants.ClaimType.TracingClient, "true");
             }
 
             var authenticationType = user?.Identity?.AuthenticationType;

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.SignalR
             ServerStickyMode mode = ServerStickyMode.Disabled, 
             bool enableDetailedErrors = false, 
             int endpointsCount = 1,
-            int? maxPollInterval = null)
+            int? maxPollInterval = null,
+            bool isTrackingClient = false)
         {
             if (userId != null)
             {
@@ -44,6 +45,11 @@ namespace Microsoft.Azure.SignalR
             {
                 yield return new Claim(Constants.ClaimType.ServerName, serverName);
                 yield return new Claim(Constants.ClaimType.ServerStickyMode, mode.ToString());
+            }
+
+            if (isTrackingClient)
+            {
+                yield return new Claim(Constants.ClaimType.TrackingClient, "true");
             }
 
             var authenticationType = user?.Identity?.AuthenticationType;

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.SignalR
         private readonly IUserIdProvider _userIdProvider;
         private readonly IConnectionRequestIdProvider _connectionRequestIdProvider;
         private readonly Func<HttpContext, IEnumerable<Claim>> _claimsProvider;
-        private readonly Func<HttpContext, bool> _trackingClientFilter;
+        private readonly Func<HttpContext, bool> _tracingClientFilter;
         private readonly IServiceEndpointManager _endpointManager;
         private readonly IEndpointRouter _router;
         private readonly string _serverName;
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR
             _userIdProvider = userIdProvider ?? throw new ArgumentNullException(nameof(userIdProvider));
             _connectionRequestIdProvider = connectionRequestIdProvider ?? throw new ArgumentNullException(nameof(connectionRequestIdProvider));
             _claimsProvider = options?.Value?.ClaimsProvider;
-            _trackingClientFilter = options?.Value?.TrackingClientFilter;
+            _tracingClientFilter = options?.Value?.TracingClientFilter;
             _mode = options.Value.ServerStickyMode;
             _enableDetailedErrors = hubOptions.Value.EnableDetailedErrors == true;
             _endpointsCount = options.Value.Endpoints.Length;
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.SignalR
         private IEnumerable<Claim> BuildClaims(HttpContext context)
         {
             var userId = _userIdProvider.GetUserId(new ServiceHubConnectionContext(context));
-            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsTrackingClient(context)).ToList();
+            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsTracingClient(context)).ToList();
         }
 
         private Func<IEnumerable<Claim>> GetClaimsProvider(HttpContext context)
@@ -106,9 +106,9 @@ namespace Microsoft.Azure.SignalR
             return () => _claimsProvider.Invoke(context);
         }
 
-        private bool IsTrackingClient(HttpContext context)
+        private bool IsTracingClient(HttpContext context)
         {
-            return _trackingClientFilter != null && _trackingClientFilter(context);
+            return _tracingClientFilter != null && _tracingClientFilter(context);
         }
 
         private static string GetOriginalPath(string path)

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.SignalR
         private readonly IUserIdProvider _userIdProvider;
         private readonly IConnectionRequestIdProvider _connectionRequestIdProvider;
         private readonly Func<HttpContext, IEnumerable<Claim>> _claimsProvider;
-        private readonly Func<HttpContext, bool> _tracingClientFilter;
+        private readonly Func<HttpContext, bool> _diagnosticClientFilter;
         private readonly IServiceEndpointManager _endpointManager;
         private readonly IEndpointRouter _router;
         private readonly string _serverName;
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR
             _userIdProvider = userIdProvider ?? throw new ArgumentNullException(nameof(userIdProvider));
             _connectionRequestIdProvider = connectionRequestIdProvider ?? throw new ArgumentNullException(nameof(connectionRequestIdProvider));
             _claimsProvider = options?.Value?.ClaimsProvider;
-            _tracingClientFilter = options?.Value?.TracingClientFilter;
+            _diagnosticClientFilter = options?.Value?.DiagnosticClientFilter;
             _mode = options.Value.ServerStickyMode;
             _enableDetailedErrors = hubOptions.Value.EnableDetailedErrors == true;
             _endpointsCount = options.Value.Endpoints.Length;
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.SignalR
         private IEnumerable<Claim> BuildClaims(HttpContext context)
         {
             var userId = _userIdProvider.GetUserId(new ServiceHubConnectionContext(context));
-            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsTracingClient(context)).ToList();
+            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, _mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsDiagnosticClient(context)).ToList();
         }
 
         private Func<IEnumerable<Claim>> GetClaimsProvider(HttpContext context)
@@ -106,9 +106,9 @@ namespace Microsoft.Azure.SignalR
             return () => _claimsProvider.Invoke(context);
         }
 
-        private bool IsTracingClient(HttpContext context)
+        private bool IsDiagnosticClient(HttpContext context)
         {
-            return _tracingClientFilter != null && _tracingClientFilter(context);
+            return _diagnosticClientFilter != null && _diagnosticClientFilter(context);
         }
 
         private static string GetOriginalPath(string path)

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -37,6 +37,12 @@ namespace Microsoft.Azure.SignalR
         public Func<HttpContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the func to set tracking client filter from <see cref="HttpContext" />.
+        /// The clients will be regarded as tracking client only if the function returns true.
+        /// </summary>
+        public Func<HttpContext, bool> TrackingClientFilter { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
         /// Default value is one hour.
         /// </summary>

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Azure.SignalR
         public Func<HttpContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the func to set tracking client filter from <see cref="HttpContext" />.
-        /// The clients will be regarded as tracking client only if the function returns true.
+        /// Gets or sets the func to set tracing client filter from <see cref="HttpContext" />.
+        /// The clients will be regarded as tracing client only if the function returns true.
         /// </summary>
-        public Func<HttpContext, bool> TrackingClientFilter { get; set; } = null;
+        public Func<HttpContext, bool> TracingClientFilter { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Azure.SignalR
         public Func<HttpContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the func to set tracing client filter from <see cref="HttpContext" />.
-        /// The clients will be regarded as tracing client only if the function returns true.
+        /// Gets or sets the func to set diagnostic client filter from <see cref="HttpContext" />.
+        /// The clients will be regarded as diagnostic client only if the function returns true.
         /// </summary>
-        public Func<HttpContext, bool> TracingClientFilter { get; set; } = null;
+        public Func<HttpContext, bool> DiagnosticClientFilter { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -638,26 +638,26 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         }
 
         [Fact]
-        public async Task TestTracingClientProviderInServiceOptionsTakeEffect()
+        public async Task TestDiagnosticClientProviderInServiceOptionsTakeEffect()
         {
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
             {
-                Func<IOwinContext, bool> tracingClientFilter = context => context.Request.Query["tracing"] != null;
+                Func<IOwinContext, bool> diagnosticClientFilter = context => context.Request.Query["diag"] != null;
                 var hubConfiguration = Utility.GetTestHubConfig(loggerFactory);
                 hubConfiguration.EnableDetailedErrors = true;
                 using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
                 {
                     options.ConnectionString = ConnectionString;
-                    options.TracingClientFilter = tracingClientFilter;
+                    options.DiagnosticClientFilter = diagnosticClientFilter;
                 })))
                 {
                     var client = new HttpClient { BaseAddress = new Uri(ServiceUrl) };
-                    var response = await client.GetAsync("/negotiate?tracing=true");
+                    var response = await client.GetAsync("/negotiate?diag=true");
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     var message = await response.Content.ReadAsStringAsync();
                     var responseObject = JsonConvert.DeserializeObject<ResponseMessage>(message);
                     var token = JwtSecurityTokenHandler.ReadJwtToken(responseObject.AccessToken);
-                    Assert.Equal("true", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.TracingClient)?.Value);
+                    Assert.Equal("true", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.DiagnosticClient)?.Value);
                 }
             }
         }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Owin;
 using Microsoft.Owin.Hosting;
 using Newtonsoft.Json;
 using Owin;
@@ -632,6 +633,31 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
                     var enableDetailedErrors = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors);
                     Assert.Equal("True", enableDetailedErrors.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestTrackingClientProviderInServiceOptionsTakeEffect()
+        {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                Func<IOwinContext, bool> trackingClientFilter = context => context.Request.Query["track"] != null;
+                var hubConfiguration = Utility.GetTestHubConfig(loggerFactory);
+                hubConfiguration.EnableDetailedErrors = true;
+                using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
+                {
+                    options.ConnectionString = ConnectionString;
+                    options.TrackingClientFilter = trackingClientFilter;
+                })))
+                {
+                    var client = new HttpClient { BaseAddress = new Uri(ServiceUrl) };
+                    var response = await client.GetAsync("/negotiate?track=true");
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    var message = await response.Content.ReadAsStringAsync();
+                    var responseObject = JsonConvert.DeserializeObject<ResponseMessage>(message);
+                    var token = JwtSecurityTokenHandler.ReadJwtToken(responseObject.AccessToken);
+                    Assert.Equal("true", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.TrackingClient)?.Value);
                 }
             }
         }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -638,26 +638,26 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         }
 
         [Fact]
-        public async Task TestTrackingClientProviderInServiceOptionsTakeEffect()
+        public async Task TestTracingClientProviderInServiceOptionsTakeEffect()
         {
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
             {
-                Func<IOwinContext, bool> trackingClientFilter = context => context.Request.Query["track"] != null;
+                Func<IOwinContext, bool> tracingClientFilter = context => context.Request.Query["tracing"] != null;
                 var hubConfiguration = Utility.GetTestHubConfig(loggerFactory);
                 hubConfiguration.EnableDetailedErrors = true;
                 using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
                 {
                     options.ConnectionString = ConnectionString;
-                    options.TrackingClientFilter = trackingClientFilter;
+                    options.TracingClientFilter = tracingClientFilter;
                 })))
                 {
                     var client = new HttpClient { BaseAddress = new Uri(ServiceUrl) };
-                    var response = await client.GetAsync("/negotiate?track=true");
+                    var response = await client.GetAsync("/negotiate?tracing=true");
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     var message = await response.Content.ReadAsStringAsync();
                     var responseObject = JsonConvert.DeserializeObject<ResponseMessage>(message);
                     var token = JwtSecurityTokenHandler.ReadJwtToken(responseObject.AccessToken);
-                    Assert.Equal("true", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.TrackingClient)?.Value);
+                    Assert.Equal("true", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.TracingClient)?.Value);
                 }
             }
         }

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
@@ -90,6 +91,31 @@ namespace Microsoft.Azure.SignalR.Tests
                 Assert.Equal(1, options.ConnectionCount);
                 Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
                 Assert.Null(options.ClaimsProvider);
+                Assert.Null(options.TrackingClientFilter);
+            }
+        }
+
+        [Fact]
+        public void AddAzureWithTrackingClientRuleProvider()
+        {
+            using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
+            {
+                Func<HttpContext, bool> trackingClientFilter = context => context.Request.Query["track"][0] != null;
+                var services = new ServiceCollection();
+                var config = new ConfigurationBuilder().Build();
+                var serviceProvider = services.AddSignalR()
+                    .AddAzureSignalR(o =>
+                    {
+                        o.TrackingClientFilter = trackingClientFilter;
+                    })
+                    .Services
+                    .AddSingleton<IConfiguration>(config)
+                    .AddSingleton(loggerFactory)
+                    .BuildServiceProvider();
+
+                var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+
+                Assert.Equal(trackingClientFilter, options.TrackingClientFilter);
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -91,22 +91,22 @@ namespace Microsoft.Azure.SignalR.Tests
                 Assert.Equal(1, options.ConnectionCount);
                 Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
                 Assert.Null(options.ClaimsProvider);
-                Assert.Null(options.TrackingClientFilter);
+                Assert.Null(options.TracingClientFilter);
             }
         }
 
         [Fact]
-        public void AddAzureWithTrackingClientRuleProvider()
+        public void AddAzureWithTracingClientRuleProvider()
         {
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
             {
-                Func<HttpContext, bool> trackingClientFilter = context => context.Request.Query["track"][0] != null;
+                Func<HttpContext, bool> tracingClientFilter = context => context.Request.Query["tracing"][0] != null;
                 var services = new ServiceCollection();
                 var config = new ConfigurationBuilder().Build();
                 var serviceProvider = services.AddSignalR()
                     .AddAzureSignalR(o =>
                     {
-                        o.TrackingClientFilter = trackingClientFilter;
+                        o.TracingClientFilter = tracingClientFilter;
                     })
                     .Services
                     .AddSingleton<IConfiguration>(config)
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
                 var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-                Assert.Equal(trackingClientFilter, options.TrackingClientFilter);
+                Assert.Equal(tracingClientFilter, options.TracingClientFilter);
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -91,22 +91,22 @@ namespace Microsoft.Azure.SignalR.Tests
                 Assert.Equal(1, options.ConnectionCount);
                 Assert.Equal(TimeSpan.FromHours(1), options.AccessTokenLifetime);
                 Assert.Null(options.ClaimsProvider);
-                Assert.Null(options.TracingClientFilter);
+                Assert.Null(options.DiagnosticClientFilter);
             }
         }
 
         [Fact]
-        public void AddAzureWithTracingClientRuleProvider()
+        public void AddAzureWithDiagnosticClientRuleProvider()
         {
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
             {
-                Func<HttpContext, bool> tracingClientFilter = context => context.Request.Query["tracing"][0] != null;
+                Func<HttpContext, bool> diagnosticClientFilter = context => context.Request.Query["diag"][0] != null;
                 var services = new ServiceCollection();
                 var config = new ConfigurationBuilder().Build();
                 var serviceProvider = services.AddSignalR()
                     .AddAzureSignalR(o =>
                     {
-                        o.TracingClientFilter = tracingClientFilter;
+                        o.DiagnosticClientFilter = diagnosticClientFilter;
                     })
                     .Services
                     .AddSingleton<IConfiguration>(config)
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
                 var options = serviceProvider.GetRequiredService<IOptions<ServiceOptions>>().Value;
 
-                Assert.Equal(tracingClientFilter, options.TracingClientFilter);
+                Assert.Equal(diagnosticClientFilter, options.DiagnosticClientFilter);
             }
         }
 


### PR DESCRIPTION
 There is a scenario for [_message log feature_](https://microsoft.sharepoint.com/teams/IoTToolingTeam/_layouts/OneNote.aspx?id=%2Fteams%2FIoTToolingTeam%2FSiteAssets%2FAzure%20SignalR%20Service%20Notebook&wd=target%28SignalR%20Service%20-%20SignalR%20Service%20-Engineering%20Doc.one%7CCE337738-D146-4D4C-B03E-9FFF6F433FCD%2F-%20%5BWIP%5D%20Improve%20Customers%27%20Experience%3A%20Message%20Log%7C38C10298-91B4-4D6C-9B34-93B4B29C8E4C%2F%29) that customers only want to add message logs for some specific clients. i.e. _tracking clients_. To support this, app server sould need to support filter client connections to tell which clients are _tracking clients_.

This PR add a new option in `ServiceOption` to let customers determine which are _tracking client_ based on `HttpContext`. Server SDK add a internal claim internally and pass to SignalR service, then SignalR service will determine whether the clients are _tracking clients_ finally.