### PR TITLE
Update service protocal for message's tracing id

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -117,9 +117,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="payload">Binary data to be delivered.</param>
-        public ConnectionDataMessage(string connectionId, ReadOnlyMemory<byte> payload) : base(connectionId)
+        /// <param name="tracingId">The tracing Id of the message</param>
+        public ConnectionDataMessage(string connectionId, ReadOnlyMemory<byte> payload, string tracingId = null) : base(connectionId)
         {
             Payload = new ReadOnlySequence<byte>(payload);
+            TracingId = tracingId;
         }
 
         /// <summary>
@@ -127,9 +129,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="payload">Binary data to be delivered.</param>
-        public ConnectionDataMessage(string connectionId, ReadOnlySequence<byte> payload) : base(connectionId)
+        /// <param name="tracingId">The tracing Id of the message</param>
+        public ConnectionDataMessage(string connectionId, ReadOnlySequence<byte> payload, string tracingId = null) : base(connectionId)
         {
             Payload = payload;
+            TracingId = tracingId;
         }
 
         /// <summary>
@@ -137,6 +141,10 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         public ReadOnlySequence<byte> Payload { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets the message ID
+        /// </summary>
         public string TracingId { get; set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A join-group message.
     /// </summary>
-    public class JoinGroupMessage : ExtensibleServiceMessage
+    public class JoinGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -17,23 +17,30 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the group name.
         /// </summary>
         public string GroupName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JoinGroupMessage"/> class.
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, to which the connection will join.</param>
-        public JoinGroupMessage(string connectionId, string groupName)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public JoinGroupMessage(string connectionId, string groupName, string tracingId = null)
         {
             ConnectionId = connectionId;
             GroupName = groupName;
+            TracingId = tracingId;
         }
     }
 
     /// <summary>
     /// A leave-group message.
     /// </summary>
-    public class LeaveGroupMessage : ExtensibleServiceMessage
+    public class LeaveGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -44,23 +51,30 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the group name.
         /// </summary>
         public string GroupName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LeaveGroupMessage"/> class.
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, from which the connection will leave.</param>
-        public LeaveGroupMessage(string connectionId, string groupName)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public LeaveGroupMessage(string connectionId, string groupName, string tracingId = null)
         {
             ConnectionId = connectionId;
             GroupName = groupName;
+            TracingId = tracingId;
         }
     }
 
     /// <summary>
     /// A user-join-group message.
     /// </summary>
-    public class UserJoinGroupMessage : ExtensibleServiceMessage
+    public class UserJoinGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the user Id.
@@ -71,23 +85,30 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the group name.
         /// </summary>
         public string GroupName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserJoinGroupMessage"/> class.
         /// </summary>
         /// <param name="userId">The user Id.</param>
         /// <param name="groupName">The group name, to which the user will join.</param>
-        public UserJoinGroupMessage(string userId, string groupName)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public UserJoinGroupMessage(string userId, string groupName, string tracingId = null)
         {
             UserId = userId;
             GroupName = groupName;
+            TracingId = tracingId;
         }
     }
 
     /// <summary>
     /// A user-leave-group message.
     /// </summary>
-    public class UserLeaveGroupMessage : ExtensibleServiceMessage
+    public class UserLeaveGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the user Id.
@@ -98,23 +119,30 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the group name.
         /// </summary>
         public string GroupName { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserLeaveGroupMessage"/> class.
         /// </summary>
         /// <param name="userId">The user Id.</param>
         /// <param name="groupName">The group name, from which the user will leave.</param>
-        public UserLeaveGroupMessage(string userId, string groupName)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public UserLeaveGroupMessage(string userId, string groupName, string tracingId = null)
         {
             UserId = userId;
             GroupName = groupName;
+            TracingId = tracingId;
         }
     }
 
     /// <summary>
     /// A waiting for ack join-group message.
     /// </summary>
-    public class JoinGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage
+    public class JoinGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -132,12 +160,19 @@ namespace Microsoft.Azure.SignalR.Protocol
         public int AckId { get; set; }
 
         /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JoinGroupWithAckMessage"/> class.
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, to which the connection will join.</param>
-        public JoinGroupWithAckMessage(string connectionId, string groupName): this(connectionId, groupName, 0)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public JoinGroupWithAckMessage(string connectionId, string groupName, string tracingId = null): this(connectionId, groupName, 0, tracingId)
         {
+            TracingId = tracingId;
         }
 
         /// <summary>
@@ -146,18 +181,20 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, to which the connection will join.</param>
         /// <param name="ackId">The ack Id</param>
-        public JoinGroupWithAckMessage(string connectionId, string groupName, int ackId)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public JoinGroupWithAckMessage(string connectionId, string groupName, int ackId, string tracingId = null)
         {
             ConnectionId = connectionId;
             GroupName = groupName;
             AckId = ackId;
+            TracingId = tracingId;
         }
     }
 
     /// <summary>
     /// A waiting for ack leave-group message.
     /// </summary>
-    public class LeaveGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage
+    public class LeaveGroupWithAckMessage : ExtensibleServiceMessage, IAckableMessage, IMessageWithTracingId
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -175,12 +212,19 @@ namespace Microsoft.Azure.SignalR.Protocol
         public int AckId { get; set; }
 
         /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LeaveGroupWithAckMessage"/> class.
         /// </summary>
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, from which the connection will leave.</param>
-        public LeaveGroupWithAckMessage(string connectionId, string groupName): this(connectionId, groupName, 0)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public LeaveGroupWithAckMessage(string connectionId, string groupName, string tracingId = null): this(connectionId, groupName, 0, tracingId)
         {
+            TracingId = tracingId;
         }
 
         /// <summary>
@@ -189,11 +233,13 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="connectionId">The connection Id.</param>
         /// <param name="groupName">The group name, from which the connection will leave.</param>
         /// <param name="ackId">The ack Id</param>
-        public LeaveGroupWithAckMessage(string connectionId, string groupName, int ackId)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public LeaveGroupWithAckMessage(string connectionId, string groupName, int ackId, string tracingId = null)
         {
             ConnectionId = connectionId;
             GroupName = groupName;
             AckId = ackId;
+            TracingId = tracingId;
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -9,17 +9,23 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// Base class for multicast data messages between Azure SignalR Service and SDK.
     /// </summary>
-    public abstract class MulticastDataMessage : ExtensibleServiceMessage
+    public abstract class MulticastDataMessage : ExtensibleServiceMessage, IMessageWithTracingId
     {
-        protected MulticastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads)
+        protected MulticastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null)
         {
             Payloads = payloads;
+            TracingId = tracingId;
         }
 
         /// <summary>
         /// Gets or sets the payload dictionary which contains binary payload of multiple protocols.
         /// </summary>
         public IDictionary<string, ReadOnlyMemory<byte>> Payloads { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracing Id
+        /// </summary>
+        public string TracingId { get; set; }
     }
 
     /// <summary>
@@ -32,8 +38,9 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="connectionList">The list of connection Ids.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
+        /// <param name="tracingId">The tracing Id of the message.</param>
         public MultiConnectionDataMessage(IReadOnlyList<string> connectionList,
-            IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+            IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : base(payloads, tracingId)
         {
             ConnectionList = connectionList;
         }
@@ -59,7 +66,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="userId">The user Id.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public UserDataMessage(string userId, IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public UserDataMessage(string userId, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : base(payloads, tracingId)
         {
             UserId = userId;
         }
@@ -75,7 +83,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="userList">The list of user Ids.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public MultiUserDataMessage(IReadOnlyList<string> userList, IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public MultiUserDataMessage(IReadOnlyList<string> userList, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : base(payloads, tracingId)
         {
             UserList = userList;
         }
@@ -100,7 +109,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Initializes a new instance of the <see cref="BroadcastDataMessage"/> class.
         /// </summary>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public BroadcastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads) : this(null, payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public BroadcastDataMessage(IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : this(null, payloads, tracingId)
         {
         }
 
@@ -109,7 +119,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="excludedList">The list of excluded connection Ids.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public BroadcastDataMessage(IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public BroadcastDataMessage(IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : base(payloads, tracingId)
         {
             ExcludedList = excludedList;
         }
@@ -135,8 +146,9 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="groupName">The group name.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public GroupBroadcastDataMessage(string groupName, IDictionary<string, ReadOnlyMemory<byte>> payloads)
-            : this(groupName, null, payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public GroupBroadcastDataMessage(string groupName, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null)
+            : this(groupName, null, payloads, tracingId)
         {
         }
 
@@ -146,8 +158,9 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="groupName">The group name.</param>
         /// <param name="excludedList">The list of excluded connection Ids.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public GroupBroadcastDataMessage(string groupName, IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads)
-            : base(payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public GroupBroadcastDataMessage(string groupName, IReadOnlyList<string> excludedList, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null)
+            : base(payloads, tracingId)
         {
             GroupName = groupName;
             ExcludedList = excludedList;
@@ -169,7 +182,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         /// <param name="groupList">The list of group names.</param>
         /// <param name="payloads">The payload dictionary which contains binary payload of multiple protocols.</param>
-        public MultiGroupBroadcastDataMessage(IReadOnlyList<string> groupList, IDictionary<string, ReadOnlyMemory<byte>> payloads) : base(payloads)
+        /// <param name="tracingId">The tracing Id of the message.</param>
+        public MultiGroupBroadcastDataMessage(IReadOnlyList<string> groupList, IDictionary<string, ReadOnlyMemory<byte>> payloads, string tracingId = null) : base(payloads, tracingId)
         {
             GroupList = groupList;
         }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
 
         private bool OpenConnectionMessagesEqual(OpenConnectionMessage x, OpenConnectionMessage y)
         {
-            return StringEqual(x.ConnectionId, y.ConnectionId) && 
+            return StringEqual(x.ConnectionId, y.ConnectionId) &&
                    ClaimsEqual(x.Claims, y.Claims) &&
                    HeadersEqual(x.Headers, y.Headers) &&
                    StringEqual(x.QueryString, y.QueryString);
@@ -107,55 +107,73 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
 
         private bool MultiConnectionDataMessagesEqual(MultiConnectionDataMessage x, MultiConnectionDataMessage y)
         {
-            return SequenceEqual(x.ConnectionList, y.ConnectionList) && PayloadsEqual(x.Payloads, y.Payloads);
+            return SequenceEqual(x.ConnectionList, y.ConnectionList) &&
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool UserDataMessagesEqual(UserDataMessage x, UserDataMessage y)
         {
-            return StringEqual(x.UserId, y.UserId) && PayloadsEqual(x.Payloads, y.Payloads);
+            return StringEqual(x.UserId, y.UserId) &&
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool MultiUserDataMessagesEqual(MultiUserDataMessage x, MultiUserDataMessage y)
         {
-            return SequenceEqual(x.UserList, y.UserList) && PayloadsEqual(x.Payloads, y.Payloads);
+            return SequenceEqual(x.UserList, y.UserList) &&
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool BroadcastDataMessagesEqual(BroadcastDataMessage x, BroadcastDataMessage y)
         {
             return SequenceEqual(x.ExcludedList, y.ExcludedList) &&
-                   PayloadsEqual(x.Payloads, y.Payloads);
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool JoinGroupMessagesEqual(JoinGroupMessage x, JoinGroupMessage y)
         {
-            return StringEqual(x.ConnectionId, y.ConnectionId) && StringEqual(x.GroupName, y.GroupName);
+            return StringEqual(x.ConnectionId, y.ConnectionId) && 
+                   StringEqual(x.GroupName, y.GroupName) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool LeaveGroupMessagesEqual(LeaveGroupMessage x, LeaveGroupMessage y)
         {
-            return StringEqual(x.ConnectionId, y.ConnectionId) && StringEqual(x.GroupName, y.GroupName);
+            return StringEqual(x.ConnectionId, y.ConnectionId) && 
+                   StringEqual(x.GroupName, y.GroupName) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool UserJoinGroupMessagesEqual(UserJoinGroupMessage x, UserJoinGroupMessage y)
         {
-            return StringEqual(x.UserId, y.UserId) && StringEqual(x.GroupName, y.GroupName);
+            return StringEqual(x.UserId, y.UserId) && 
+                   StringEqual(x.GroupName, y.GroupName) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool UserLeaveGroupMessagesEqual(UserLeaveGroupMessage x, UserLeaveGroupMessage y)
         {
-            return StringEqual(x.UserId, y.UserId) && StringEqual(x.GroupName, y.GroupName);
+            return StringEqual(x.UserId, y.UserId) && 
+                   StringEqual(x.GroupName, y.GroupName) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
         private bool GroupBroadcastDataMessagesEqual(GroupBroadcastDataMessage x, GroupBroadcastDataMessage y)
         {
             return StringEqual(x.GroupName, y.GroupName) &&
                    SequenceEqual(x.ExcludedList, y.ExcludedList) &&
-                   PayloadsEqual(x.Payloads, y.Payloads);
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool MultiGroupBroadcastDataMessagesEqual(MultiGroupBroadcastDataMessage x,
             MultiGroupBroadcastDataMessage y)
         {
-            return SequenceEqual(x.GroupList, y.GroupList) && PayloadsEqual(x.Payloads, y.Payloads);
+            return SequenceEqual(x.GroupList, y.GroupList) && 
+                   PayloadsEqual(x.Payloads, y.Payloads) &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool ServiceErrorMessageEqual(ServiceErrorMessage x, ServiceErrorMessage y)
@@ -167,14 +185,16 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         {
             return StringEqual(x.ConnectionId, y.ConnectionId) &&
                    StringEqual(x.GroupName, y.GroupName) &&
-                   x.AckId == y.AckId;
+                   x.AckId == y.AckId &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool LeaveGroupWithAckMessageEqual(LeaveGroupWithAckMessage x, LeaveGroupWithAckMessage y)
         {
             return StringEqual(x.ConnectionId, y.ConnectionId) &&
                    StringEqual(x.GroupName, y.GroupName) &&
-                   x.AckId == y.AckId;
+                   x.AckId == y.AckId &&
+                   StringEqual(x.TracingId, y.TracingId);
         }
 
         private bool AckMessageEqual(AckMessage x, AckMessage y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -302,10 +302,6 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}),
                 binary: "lAalY29ubjXEBwECAwQFBgeA"),
             new ProtocolTestData(
-                name: "ConnectionDataWithTracingId",
-                message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}) { TracingId = "test" },
-                binary: "lAalY29ubjXEBwECAwQFBgeBAaR0ZXN0"),
-            new ProtocolTestData(
                 name: "MultiConnectionData",
                 message: new MultiConnectionDataMessage(new [] {"conn6", "conn7"}, new Dictionary<string, ReadOnlyMemory<byte>>
                 {
@@ -411,6 +407,88 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "AckWithMessage",
                 message: new AckMessage(2, 101, "Joined group successfully"),
                 binary: "lRQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5gA=="),
+
+            // messages with tracing id
+            new ProtocolTestData(
+                name: "ConnectionDataWithTracingId",
+                message: new ConnectionDataMessage("conn5", new byte[] {1, 2, 3, 4, 5, 6, 7}, tracingId: "test"),
+                binary: "lAalY29ubjXEBwECAwQFBgeBAaR0ZXN0"),
+            new ProtocolTestData(
+                name: "MultiConnectionDataWithTracingId",
+                message: new MultiConnectionDataMessage(new [] {"conn6", "conn7"}, new Dictionary<string, ReadOnlyMemory<byte>>
+                {
+                    ["json"] = new byte[] {2, 3, 4, 5, 6, 7, 1},
+                    ["messagepack"] = new byte[] {3, 4, 5, 6, 7, 1, 2}
+                }, tracingId: "test"),
+                binary: "lAeSpWNvbm42pWNvbm43gqRqc29uxAcCAwQFBgcBq21lc3NhZ2VwYWNrxAcDBAUGBwECgQGkdGVzdA=="),
+            new ProtocolTestData(
+                name: "UserDataWithTracingId",
+                message: new UserDataMessage("user1",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: "test"),
+                binary: "lAildXNlcjGCpGpzb27EBwYHAQIDBAWrbWVzc2FnZXBhY2vEBwcBAgMEBQaBAaR0ZXN0"),
+            new ProtocolTestData(
+                name: "MultiUserDataWithTracingId",
+                message: new MultiUserDataMessage(new [] {"user1", "user2"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: "test"),
+                binary: "lAmSpXVzZXIxpXVzZXIygqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgQGkdGVzdA=="),
+            new ProtocolTestData(
+                name: "BroadcastWithTracingId",
+                message: new BroadcastDataMessage(new Dictionary<string, ReadOnlyMemory<byte>>
+                {
+                    ["json"] = new byte[] {4, 5, 6, 7, 1, 2, 3},
+                    ["messagepack"] = new byte[] {5, 6, 7, 1, 2, 3, 4}
+                }, tracingId: "test"),
+                binary: "lAqQgqRqc29uxAcEBQYHAQIDq21lc3NhZ2VwYWNrxAcFBgcBAgMEgQGkdGVzdA=="),
+            new ProtocolTestData(
+                name: "JoinGroupWithTracingId",
+                message: new JoinGroupMessage("conn10", "group1", tracingId: "test"),
+                binary: "lAumY29ubjEwpmdyb3VwMYEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "LeaveGroupWithTracingId",
+                message: new LeaveGroupMessage("conn11", "group2", tracingId: "test"),
+                binary: "lAymY29ubjExpmdyb3VwMoEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "UserJoinGroupWithTracingId",
+                message: new UserJoinGroupMessage("conn10", "group1", tracingId: "test"),
+                binary: "lBCmY29ubjEwpmdyb3VwMYEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "UserLeaveGroupWithTracingId",
+                message: new UserLeaveGroupMessage("conn11", "group2", tracingId: "test"),
+                binary: "lBGmY29ubjExpmdyb3VwMoEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "GroupBroadcastWithTracingId",
+                message: new GroupBroadcastDataMessage("group3",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: "test"),
+                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "MultiGroupBroadcastWithTracingId",
+                message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {1, 2, 3, 4, 5, 6, 7, 8},
+                        ["messagepack"] = new byte[] {7, 8, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: "test"),
+                binary: "lA6Spmdyb3VwNKZncm91cDWCpGpzb27ECAECAwQFBgcIq21lc3NhZ2VwYWNrxAgHCAECAwQFBoEBpHRlc3Q="),
+            new ProtocolTestData(
+                name: "JoinGroupWithAckWithTracingId",
+                message: new JoinGroupWithAckMessage("conn14", "group1", 1, tracingId: "test"),
+                binary: "lRKmY29ubjE0pmdyb3VwMQGBAaR0ZXN0"),
+            new ProtocolTestData(
+                name: "LeaveGroupWithAckWithTracingId",
+                message: new LeaveGroupWithAckMessage("conn15", "group2", 1, tracingId: "test"),
+                binary: "lROmY29ubjE1pmdyb3VwMgGBAaR0ZXN0"),
         }.ToDictionary(t => t.Name);
 
         [Theory]


### PR DESCRIPTION
Tracing id is only used for message that contains customer's data, includes group action messages, connection data message and multicast messages, and _excludes_ ping/handshake/ack message.