### PR TITLE
[Draft] Add diagnostic tag to notify the service whether the msg should be log

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/GroupMessage.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// <summary>
     /// A join-group message.
     /// </summary>
-    public class JoinGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId
+    public class JoinGroupMessage : ExtensibleServiceMessage, IMessageWithTracingId, IDiagTag
     {
         /// <summary>
         /// Gets or sets the connection Id.
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the tracing Id
         /// </summary>
         public string TracingId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the diagnostic tag.
+        /// </summary>
+        public bool DiagTag { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JoinGroupMessage"/> class.

--- a/src/Microsoft.Azure.SignalR.Protocols/IDiagTag.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/IDiagTag.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Protocol
+{
+    public interface IDiagTag
+    {
+        bool DiagTag { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -21,20 +21,27 @@ namespace Microsoft.Azure.SignalR.Protocol
     {
         private const int TracingId = 1;
         private const int Ttl = 2;
+        private const int DiagTag = 3;
 
         internal void WriteExtensionMembers(ref MessagePackWriter writer)
         {
             int count = 0;
+
             var tracingId = (this as IMessageWithTracingId)?.TracingId;
             if (!string.IsNullOrEmpty(tracingId))
             {
                 count++;
             }
+
             var ttl = (this as IHasTtl)?.Ttl;
             if (ttl != null)
             {
                 count++;
             }
+
+            var diagTag = (this as IDiagTag)?.DiagTag;
+            count += diagTag == null ? 0 : 1;
+
             // todo : count more optional fields.
             writer.WriteMapHeader(count);
             if (!string.IsNullOrEmpty(tracingId))
@@ -46,6 +53,11 @@ namespace Microsoft.Azure.SignalR.Protocol
             {
                 writer.Write(Ttl);
                 writer.Write(ttl.Value);
+            }
+            if (diagTag != null)
+            {
+                writer.Write(DiagTag);
+                writer.Write(diagTag.Value);
             }
             // todo : write more optional fields.
         }
@@ -67,6 +79,12 @@ namespace Microsoft.Azure.SignalR.Protocol
                         if (this is IHasTtl hasTtl)
                         {
                             hasTtl.Ttl = reader.ReadInt32();
+                        }
+                        break;
+                    case DiagTag:
+                        if (this is IDiagTag msgWithDiagTag)
+                        {
+                            msgWithDiagTag.DiagTag = reader.ReadBoolean();
                         }
                         break;
                     // todo : more optional fields


### PR DESCRIPTION
`DiagTag` is for the scenario default collecting rule for service is "only collect tracking client".
Message may be originated from client/server/Management SDK/REST API/Function binding.
It'll be used togethor with tracing scope in the future.
This PR is demo for only one message.
