### PR TITLE
Wrapping IServiceConnection in WeakReference 

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ClientConnectionScope.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ClientConnectionScope.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
                             {
                                 Properties = new ClientConnectionScopeProperties()
                                 {
-                                    OutboundServiceConnection = outboundConnection,
+                                    OutboundServiceConnection = new WeakReference<IServiceConnection>(outboundConnection),
                                     IsDiagnosticClient = isDiagnosticClient
                                 }
                             };
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
 
         internal static bool IsScopeEstablished => ScopePropertiesAccessor<ClientConnectionScopeProperties>.Current != null;
 
-        internal static IServiceConnection OutboundServiceConnection
+        internal static WeakReference<IServiceConnection> OutboundServiceConnection
         {
             get => ScopePropertiesAccessor<ClientConnectionScopeProperties>.Current?.Properties?.OutboundServiceConnection;
             set 
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.SignalR.Common.ServiceConnections
 
         private class ClientConnectionScopeProperties
         {
-            public IServiceConnection OutboundServiceConnection { get; set; }
+            public WeakReference<IServiceConnection> OutboundServiceConnection { get; set; }
 
             public bool IsDiagnosticClient { get; set; }
         }


### PR DESCRIPTION
...before storing it in async local to prevent memory leaks.

Execution contexts may keep ServiceConnection alive for much longer than the actual service connection lifetime. So we wrap it in a weak reference before storing in async local.