### PR TITLE
fix the issue that when client exit app server reports tedious error

### DIFF
--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Azure.SignalR
                     // Since all user-created messages will be sent to `ServiceConnection` directly.
                     // We can simply ignore all messages came from the application pipe.
                 }
-                context.Application.Input.CancelPendingRead();
             }
+
             return PerformDisconnectAsyncCore(connectionId);
         }
 


### PR DESCRIPTION
When the connected client exits, app server always reports error like below:
```
fail: Microsoft.Azure.SignalR.ServiceConnection[8]
      Application task failed.
Microsoft.Azure.SignalR.Common.AzureSignalRException: Cancelled running application task, probably caused by time out.
   at Microsoft.Azure.SignalR.ServiceConnection.ProcessIncomingMessageAsync(ClientConnectionContext connection) in C:\repos\signalr-sdk\src\Microsoft.Azure.SignalR\ServerConnections\ServiceConnection.cs:line 391
   at Microsoft.Azure.SignalR.ServiceConnection.ProcessClientConnectionAsync(ClientConnectionContext connection) in C:\repos\signalr-sdk\src\Microsoft.Azure.SignalR\ServerConnections\ServiceConnection.cs:line 227
```

This is because when `OnClientDisconnectedAsync` it always cancel input read first. It does not sound right because the app should still process messages inside the pipe that are inserted before connection close. Remove this `CancelPendingRead` instead.
