### PR TITLE
Add more options to emulator and make the upstream hot reload

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -57,6 +57,7 @@
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>3.1.5</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
     <MicrosoftAspNetCoreMvcNewtonsoftJsonPackageVersion>3.1.5</MicrosoftAspNetCoreMvcNewtonsoftJsonPackageVersion>
     <MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>3.1.5</MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsPackageVersion>1.1.1</MicrosoftExtensionsCommandLineUtilsPackageVersion>
 
     <!--Testing -->
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackTestPackageVersion>3.0.0-preview6.19307.2</MicrosoftAspNetCoreSignalRProtocolsMessagePackTestPackageVersion>

--- a/src/Microsoft.Azure.SignalR.Emulator/Microsoft.Azure.SignalR.Emulator.csproj
+++ b/src/Microsoft.Azure.SignalR.Emulator/Microsoft.Azure.SignalR.Emulator.csproj
@@ -15,5 +15,6 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCoreMvcNewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="$(MicrosoftExtensionsCommandLineUtilsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.SignalR.Emulator/Program.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Program.cs
@@ -1,35 +1,137 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
-
+using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Emulator
 {
     public class Program
     {
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions {
+            WriteIndented = true,
+        };
+
+        private static readonly string SettingsFile = "settings.json";
+        private static readonly string ProgramDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location);
+        private static readonly string ProgramDefaultSettingsFile = Path.Combine(ProgramDirectory, SettingsFile);
+
         public static void Main(string[] args)
         {
             // todo: "upstream init" to generate the default setting.json file
             // todo: "upstream list" to list the settings file
             // todo: "start" to run the emulator
             // todo: "help" to explain the upstream and pattern rules
-            CreateHostBuilder(args).Build().Run();
+
+            var host = CreateHostBuilder(args).Build();
+
+            var app = new CommandLineApplication();
+            app.Name = "Azure SignalR Local Emulator";
+            app.Description = "The local emulator for Azure SignalR Serverless features.";
+            app.HelpOption("-?|-h|--help");
+            
+            app.Command("upstream", command =>
+            {
+                command.Description = "To init/list/update the upstream options";
+                command.HelpOption("-?|-h|--help");
+                command.Command("init", c =>
+                {
+                    c.Description = "Init the default upstream options into a settings.json config";
+                    c.OnExecute(() =>
+                    {
+                        if (File.Exists(SettingsFile))
+                        {
+                            Console.WriteLine($"Already contains {SettingsFile}, still want to override it with the default one? (N/y)");
+                            if (Console.ReadKey().Key != ConsoleKey.Y)
+                            {
+                                return 0;
+                            }
+                        }
+
+                        File.Copy(ProgramDefaultSettingsFile, SettingsFile, true);
+                        Console.WriteLine($"Exported default settings to {Path.GetFullPath(SettingsFile)}.");
+                        return 0;
+                    });
+                });
+                command.Command("list", c =>
+                {
+                    c.Description = "List current upstream options.";
+                    c.OnExecute(() =>
+                    {
+                        var option = host.Services.GetRequiredService<IOptions<UpstreamOptions>>();
+                        option.Value.Print();
+                        return 0;
+                    });
+                });
+            });
+
+            app.Command("start", command =>
+            {
+                command.Description = "To start the emulator.";
+                var portOptions = command.Option("-p|--port", "Specify the port to use.", CommandOptionType.SingleValue);
+                command.OnExecute(() =>
+                {
+                    if (portOptions.HasValue())
+                    {
+                        var val = portOptions.Value();
+
+                        if (int.TryParse(val, out var port))
+                        {
+                            host = CreateHostBuilder(args, port).Build();
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Invalid port value: {val}.");
+                            return 1;
+                        }
+                    }
+
+                    host.Run();
+                    return 0;
+                });
+            });
+
+            app.OnExecute(() =>
+            {
+                app.ShowHelp();
+                return 0;
+            });
+
+            try
+            {
+                app.Execute(args);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error starting emulator: {e.Message}.");
+            }
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args)
+        public static IHostBuilder CreateHostBuilder(string[] args, int? port = null)
         {
-            var settingsFile = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "appsettings.json");
+            var appSettingsFile = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "appsettings.json");
             return Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
+
+                    if (port.HasValue)
+                    {
+                        webBuilder.UseKestrel(o => o.ListenLocalhost(port.Value));
+                    }
                 })
-                .ConfigureAppConfiguration(s => s.AddJsonFile(settingsFile, optional: true, reloadOnChange: true))
-                .ConfigureAppConfiguration(s => s.AddJsonFile("settings.json", optional: true, reloadOnChange: true));
+                .ConfigureAppConfiguration(s =>
+                {
+                    s.AddJsonFile(appSettingsFile, optional: true, reloadOnChange: true);
+                    s.AddJsonFile(SettingsFile, optional: true, reloadOnChange: true);
+                });
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Emulator/Properties/launchSettings.json
+++ b/src/Microsoft.Azure.SignalR.Emulator/Properties/launchSettings.json
@@ -11,12 +11,14 @@
   "profiles": {
     "IIS Express": {
       "commandName": "Project",
+      "commandLineArgs": "start",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "Microsoft.Azure.SignalR.Emulator": {
       "commandName": "Project",
+      "commandLineArgs": "start -p 8111",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Microsoft.Azure.SignalR.Emulator/Startup.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Emulator
 {
@@ -42,9 +43,7 @@ namespace Microsoft.Azure.SignalR.Emulator
                 manager.FeatureProviders.Add(new CustomControllerFeatureProvider());
             });
 
-            var upstreamOptions = new UpstreamOptions();
-            Configuration.GetSection("UpstreamSettings").Bind(upstreamOptions);
-            services.Configure<UpstreamOptions>(s => s.Templates = upstreamOptions.Templates);
+            services.Configure<UpstreamOptions>(Configuration.GetSection("UpstreamSettings"));
 
             services.AddSignalREmulator();
             services.AddLogging(services =>
@@ -60,6 +59,11 @@ namespace Microsoft.Azure.SignalR.Emulator
             lifetime.ApplicationStarted.Register(() =>
                {
                    var address = new Uri(app.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First());
+                   var optionChanged = app.ApplicationServices.GetRequiredService<IOptionsMonitor<UpstreamOptions>>();
+                   optionChanged.OnChange(s =>
+                   {
+                       s.Print();
+                   });
                    Console.WriteLine(@$"
 ===================================================
 The Azure SignalR Emulator was successfully started.
@@ -72,6 +76,7 @@ Endpoint={address.Scheme}://{address.Host};Port={address.Port};AccessKey={AppBui
 
 ===================================================
 ");
+                   optionChanged.CurrentValue.Print();
                });
             app.UseRouting();
             app.UseWebSockets();

--- a/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamOptions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Microsoft.Azure.SignalR.Emulator
+{
+    internal class UpstreamOptions
+    {
+        public UpstreamTemplateItem[] Templates { get; set; }
+
+        public override string ToString()
+        {
+            if (Templates?.Length > 0)
+            {
+                var sb = new StringBuilder();
+                for (var i = 0; i < Templates.Length; i++)
+                {
+                    sb.AppendLine($"\t[{i}]{Templates[i]}");
+                }
+                return sb.ToString();
+            }
+
+            return "No upstream is set yet. Use 'upstream init' to create default upstreams.";
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamOptionsExtension.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamOptionsExtension.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.SignalR.Emulator
+{
+    internal static class UpstreamOptionsExtension
+    {
+        public static void Print(this UpstreamOptions options)
+        {
+            Console.WriteLine($"Current Upstream Settings:\n{options}");
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamTemplateItem.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Upstreams/UpstreamTemplateItem.cs
@@ -4,16 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Microsoft.Azure.SignalR.Common;
 
 namespace Microsoft.Azure.SignalR.Emulator
 {
-    internal class UpstreamOptions
-    {
-        public UpstreamTemplateItem[] Templates { get; set; }
-    }
-
     internal class UpstreamTemplateItem : IEquatable<UpstreamTemplateItem>
     {
         private static readonly HashSet<string> MatchAllPattern = new HashSet<string>(new[] { Constants.Asterisk });
@@ -84,6 +78,11 @@ namespace Microsoft.Azure.SignalR.Emulator
         public override bool Equals(object obj) => Equals(obj as UpstreamTemplateItem);
 
         public override int GetHashCode() => HashCode.Combine(UrlTemplate, EventPattern, HubPattern, CategoryPattern);
+
+        public override string ToString()
+        {
+            return $"{UrlTemplate}(event:'{EventPattern}',hub:'{HubPattern}',category:'{CategoryPattern}')";
+        }
 
         private void SetPattern(string pattern, ref string field, ref HashSet<string> store)
         {


### PR DESCRIPTION
Usage: asrs-emulator [options] [command]

Options:
  -?|-h|--help  Show help information

Commands:
  start     To start the emulator.
  upstream  To init/list/update the upstream options

Use "asrs-emulator [command] --help" for more information about a command.

