### PR TITLE
Store global client connection from ping.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Azure.SignalR
 {
-    public class EndpointStat
+    public class EndpointMetrics
     {
         /// <summary>
         /// <see cref="ServiceEndpoint" /> global concurrent client connection count

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.SignalR
     public class EndpointMetrics
     {
         /// <summary>
-        /// <see cref="ServiceEndpoint" /> global concurrent client connection count
+        /// <see cref="ServiceEndpoint" /> total concurrent client connection count on all hubs.
         /// </summary>
         public int ClientConnectionCount { get; internal set; }
     }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointStat.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointStat.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Azure.SignalR
     public class EndpointStat
     {
         /// <summary>
-        /// <see cref="ServiceEndpoint" /> globally concurrent client connection count
+        /// <see cref="ServiceEndpoint" /> global concurrent client connection count
         /// </summary>
-        public int ClientCount { get; internal set; }
+        public int ClientConnectionCount { get; internal set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointStat.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointStat.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR
+{
+    public class EndpointStat
+    {
+        /// <summary>
+        /// <see cref="ServiceEndpoint" /> globally concurrent client connection count
+        /// </summary>
+        public int ClientCount { get; internal set; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR
         /// <summary>
         /// Enriched endpoint metrics for customized routing.
         /// </summary>
-        public EndpointMetrics EndpointStat { get; internal set; } = new EndpointMetrics();
+        public EndpointMetrics EndpointMetrics { get; internal set; } = new EndpointMetrics();
 
         internal ServiceEndpoint(string endpoint, AuthOptions authOptions, int port = 443)
         {

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Azure.SignalR
         public bool IsActive { get; internal set; } = true;
 
         /// <summary>
-        /// Enriched endpoint stat for customized routing.
+        /// Enriched endpoint metrics for customized routing.
         /// </summary>
-        public EndpointStat EndpointStat { get; internal set; } = new EndpointStat();
+        public EndpointMetrics EndpointStat { get; internal set; } = new EndpointMetrics();
 
         internal ServiceEndpoint(string endpoint, AuthOptions authOptions, int port = 443)
         {

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Azure.SignalR
         /// </summary>
         public bool IsActive { get; internal set; } = true;
 
+        /// <summary>
+        /// Enriched endpoint stat for customized routing.
+        /// </summary>
+        public EndpointStat EndpointStat { get; internal set; } = new EndpointStat();
+
         internal ServiceEndpoint(string endpoint, AuthOptions authOptions, int port = 443)
         {
             // Endpoint = string.Format("https://{0}.service.signalr.net", resourceName);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.SignalR
 
                 if (RuntimeServicePingMessage.TryGetClientCount(pingMessage, out var clientCount))
                 {
-                    Endpoint.EndpointStat.ClientCount = clientCount;
+                    Endpoint.EndpointStat.ClientConnectionCount = clientCount;
                 }
             }
             else if (RuntimeServicePingMessage.TryGetServersTag(pingMessage, out var serversTag, out var updatedTime))

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.SignalR
 
                 if (RuntimeServicePingMessage.TryGetClientCount(pingMessage, out var clientCount))
                 {
-                    Endpoint.EndpointStat.ClientConnectionCount = clientCount;
+                    Endpoint.EndpointMetrics.ClientConnectionCount = clientCount;
                 }
             }
             else if (RuntimeServicePingMessage.TryGetServersTag(pingMessage, out var serversTag, out var updatedTime))

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -187,16 +187,16 @@ namespace Microsoft.Azure.SignalR
 
         public virtual Task HandlePingAsync(PingMessage pingMessage)
         {
+            if (RuntimeServicePingMessage.TryGetClientCount(pingMessage, out var clientCount))
+            {
+                Endpoint.EndpointMetrics.ClientConnectionCount = clientCount;
+            }
+
             if (RuntimeServicePingMessage.TryGetStatus(pingMessage, out var status))
             {
                 Log.ReceivedServiceStatusPing(Logger, status, Endpoint);
                 _hasClients = status;
                 Endpoint.IsActive = GetServiceStatus(status, CheckWindow, CheckTimeSpan);
-
-                if (RuntimeServicePingMessage.TryGetClientCount(pingMessage, out var clientCount))
-                {
-                    Endpoint.EndpointMetrics.ClientConnectionCount = clientCount;
-                }
             }
             else if (RuntimeServicePingMessage.TryGetServersTag(pingMessage, out var serversTag, out var updatedTime))
             {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -192,6 +192,11 @@ namespace Microsoft.Azure.SignalR
                 Log.ReceivedServiceStatusPing(Logger, status, Endpoint);
                 _hasClients = status;
                 Endpoint.IsActive = GetServiceStatus(status, CheckWindow, CheckTimeSpan);
+
+                if (RuntimeServicePingMessage.TryGetClientCount(pingMessage, out var clientCount))
+                {
+                    Endpoint.EndpointStat.ClientCount = clientCount;
+                }
             }
             else if (RuntimeServicePingMessage.TryGetServersTag(pingMessage, out var serversTag, out var updatedTime))
             {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.SignalR
         private const string StatusKey = "status";
         private const string ShutdownKey = "shutdown";
         private const string ServersKey = "servers";
+        private const string ClientCountKey = "clientcount";
         private const string DiagnosticLogsMessagingTypeKey = "d-m";
 
         private const string MessagingLogEnableValue = "1";
@@ -78,6 +79,17 @@ namespace Microsoft.Azure.SignalR
                 return false;
             }
             isActive = value == StatusActiveValue;
+            return true;
+        }
+
+        public static bool TryGetClientCount(this ServicePingMessage ping, out int clientCount)
+        {
+            if (!TryGetValue(ping, ClientCountKey, out var value) || !int.TryParse(value, out var count))
+            {
+                clientCount = 0;
+                return false;
+            }
+            clientCount = count;
             return true;
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
@@ -71,6 +71,12 @@ namespace Microsoft.Azure.SignalR
         public static ServicePingMessage GetStatusPingMessage(bool isActive) =>
             isActive ? StatusActive : StatusInactive;
 
+        public static ServicePingMessage GetStatusPingMessage(bool isActive, int clientCount) =>
+            isActive
+            ? new ServicePingMessage { Messages = new[] { StatusKey, StatusActiveValue, ClientCountKey, clientCount.ToString() } }
+            : new ServicePingMessage { Messages = new[] { StatusKey, StatusInactiveValue, ClientCountKey, clientCount.ToString() } };
+
+
         public static bool TryGetStatus(this ServicePingMessage ping, out bool isActive)
         {
             if (!TryGetValue(ping, StatusKey, out var value))

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -1425,8 +1425,8 @@ namespace Microsoft.Azure.SignalR.Tests
             await Task.WhenAll(container1.MockReceivedStatusPing(true, c1));
             await Task.WhenAll(container2.MockReceivedStatusPing(true, c2));
 
-            Assert.Equal(c1, hubEndpoints[0].EndpointStat.ClientConnectionCount);
-            Assert.Equal(c2, hubEndpoints[1].EndpointStat.ClientConnectionCount);
+            Assert.Equal(c1, hubEndpoints[0].EndpointMetrics.ClientConnectionCount);
+            Assert.Equal(c2, hubEndpoints[1].EndpointMetrics.ClientConnectionCount);
         }
 
         public static IEnumerable<object[]> TestReloadEndpointsData = new object[][]

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -1389,6 +1389,46 @@ namespace Microsoft.Azure.SignalR.Tests
             }
         }
 
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(200, 5)]
+        [InlineData(5, 0)]
+        public async Task TestEndpointWithStatusPingPlusClientCount(int c1, int c2)
+        {
+            var sem = new TestServiceEndpointManager(
+                new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
+                new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "22")
+                );
+            var endpoints = sem.Endpoints.Keys.ToArray();
+            Assert.Equal(2, endpoints.Length);
+            Assert.Equal("1", endpoints[0].Name);
+            Assert.Equal("22", endpoints[1].Name);
+
+            var router = new TestEndpointRouter();
+            var writeTcs = new TaskCompletionSource<object>();
+            var container = new TestMultiEndpointServiceConnectionContainer("hub",
+                e => new TestServiceConnectionContainer(new List<IServiceConnection> {
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
+            }, e), sem, router, NullLoggerFactory.Instance);
+
+            var hubEndpoints = container.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, hubEndpoints.Length);
+            Assert.Equal("1", hubEndpoints[0].Name);
+            Assert.Equal("22", hubEndpoints[1].Name);
+
+            // mock client count ping and validate they won't messed.
+            var containers = container.GetTestOnlineContainers();
+            var container1 = containers.Where(x => x.Endpoint.Name == "1").FirstOrDefault();
+            var container2 = containers.Where(x => x.Endpoint.Name == "22").FirstOrDefault();
+            await Task.WhenAll(container1.MockReceivedStatusPing(true, c1));
+            await Task.WhenAll(container2.MockReceivedStatusPing(true, c2));
+
+            Assert.Equal(c1, hubEndpoints[0].EndpointStat.ClientConnectionCount);
+            Assert.Equal(c2, hubEndpoints[1].EndpointStat.ClientConnectionCount);
+        }
+
         public static IEnumerable<object[]> TestReloadEndpointsData = new object[][]
         {
             // no change

--- a/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestServiceConnectionContainer.cs
@@ -74,5 +74,11 @@ namespace Microsoft.Azure.SignalR.Tests
             var ping = new PingMessage { Messages = new[] { "status", isActive ? "1" : "0" } };
             return base.HandlePingAsync(ping);
         }
+
+        public Task MockReceivedStatusPing(bool isActive, int clientCount)
+        {
+            var ping = new PingMessage { Messages = new[] { "status", isActive ? "1" : "0" , "clientcount", clientCount.ToString()} };
+            return base.HandlePingAsync(ping);
+        }
     }
 }


### PR DESCRIPTION
Store global client connection count in ServiceEndpoint to enable server side do customized routing in sharding.