### PR TITLE
Fix reload endpoints

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.SignalR
             return groupedEndpoints;
         }
 
-        protected async virtual Task ReloadServiceEndpointsAsync(ServiceEndpoint[] serviceEndpoints, TimeSpan scaleTimeout)
+        protected async virtual Task ReloadServiceEndpointsAsync(IEnumerable<ServiceEndpoint> serviceEndpoints, TimeSpan scaleTimeout)
         {
             try
             {

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointManager.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -51,10 +52,10 @@ namespace Microsoft.Azure.SignalR
         {
             Log.DetectConfigurationChanges(_logger);
 
-            ReloadServiceEndpointsAsync(options.Endpoints);
+            ReloadServiceEndpointsAsync(GetEndpoints(options));
         }
 
-        private Task ReloadServiceEndpointsAsync(ServiceEndpoint[] serviceEndpoints)
+        private Task ReloadServiceEndpointsAsync(IEnumerable<ServiceEndpoint> serviceEndpoints)
         {
             return ReloadServiceEndpointsAsync(serviceEndpoints, _scaleTimeout);
         }

--- a/test/Microsoft.Azure.SignalR.Tests/testappsettings.json
+++ b/test/Microsoft.Azure.SignalR.Tests/testappsettings.json
@@ -1,0 +1,21 @@
+{
+  "Azure": {
+    "SignalR": {
+      "ConnectionString": [
+        {
+          "EP1:Primary": "Endpoint=https://primaryconnectionstring;AccessKey=1"
+        },
+        {
+          "EP2:Secondary": "Endpoint=https://secondaryconnectionstring;AccessKey=1"
+        }
+      ]
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - Use `GetEndpoints` when reload to apply all available settings.

Fixes #1048
