### PR TITLE
rename

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceMessageBus.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceMessageBus.cs
@@ -105,14 +105,14 @@ namespace Microsoft.Azure.SignalR.AspNet
 
                 if (message is IMessageWithTracingId msg && msg.TracingId != null)
                 {
-                    AzureSignalRLog.SucceededToSendMessage(_logger, msg);
+                    MessageLog.SucceededToSendMessage(_logger, msg);
                 }
             }
             catch (Exception ex)
             {
                 if (message is IMessageWithTracingId msg && msg.TracingId != null)
                 {
-                    AzureSignalRLog.FailedToSendMessage(_logger, msg, ex);
+                    MessageLog.FailedToSendMessage(_logger, msg, ex);
                 }
                 throw;
             }

--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                             var joinGroupWithAckMessage = new JoinGroupWithAckMessage(connectionId, groupName).WithTracingId();
                             if (joinGroupWithAckMessage.TracingId != null)
                             { 
-                                AzureSignalRLog.StartToAddConnectionToGroup(_logger, joinGroupWithAckMessage);
+                                MessageLog.StartToAddConnectionToGroup(_logger, joinGroupWithAckMessage);
                             }
 
                             // go through the app connection
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                             var leaveGroupWithAckMessage = new LeaveGroupWithAckMessage(connectionId, groupName).WithTracingId();
                             if (leaveGroupWithAckMessage.TracingId != null)
                             {
-                                AzureSignalRLog.StartToRemoveConnectionFromGroup(_logger, leaveGroupWithAckMessage);
+                                MessageLog.StartToRemoveConnectionFromGroup(_logger, leaveGroupWithAckMessage);
                             }
 
                             // go through the app connection
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 var broadcastDataMessage = new BroadcastDataMessage(excludedList: GetExcludedIds(message.Filter), payloads: GetPayloads(segment)).WithTracingId();
                 if (broadcastDataMessage.TracingId != null)
                 {
-                    AzureSignalRLog.StartToBroadcastMessage(_logger, broadcastDataMessage);
+                    MessageLog.StartToBroadcastMessage(_logger, broadcastDataMessage);
                 }
                 yield return new HubMessage(hubName, broadcastDataMessage, message);
             }
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 var connectionDataMessage = new ConnectionDataMessage(connectionId, segment).WithTracingId();
                 if (connectionDataMessage.TracingId != null)
                 {
-                    AzureSignalRLog.StartToSendMessageToConnection(_logger, connectionDataMessage);
+                    MessageLog.StartToSendMessageToConnection(_logger, connectionDataMessage);
                 }
 
                 // Go through the app connection
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 var groupBroadcastDataMessage = new GroupBroadcastDataMessage(groupName, excludedList: GetExcludedIds(message.Filter), payloads: GetPayloads(segment)).WithTracingId();
                 if (groupBroadcastDataMessage.TracingId != null)
                 {
-                    AzureSignalRLog.StartToBroadcastMessageToGroup(_logger, groupBroadcastDataMessage);
+                    MessageLog.StartToBroadcastMessageToGroup(_logger, groupBroadcastDataMessage);
                 }
                 yield return new AppMessage(groupBroadcastDataMessage, message);
             }
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                     var userDataMessage = new UserDataMessage(user, GetPayloads(segment)).WithTracingId();
                     if (userDataMessage.TracingId != null)
                     {
-                        AzureSignalRLog.StartToSendMessageToUser(_logger, userDataMessage);
+                        MessageLog.StartToSendMessageToUser(_logger, userDataMessage);
                     }
                     // For old protocol, it is always single user per message https://github.com/SignalR/SignalR/blob/dev/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs#L162
                     yield return new HubMessage(hub, userDataMessage, message);

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         {
             if (connectionDataMessage.TracingId != null)
             {
-                AzureSignalRLog.ReceiveMessageFromService(Logger, connectionDataMessage);
+                MessageLog.ReceiveMessageFromService(Logger, connectionDataMessage);
             }
             return ForwardMessageToApplication(connectionDataMessage.ConnectionId, connectionDataMessage);
         }

--- a/src/Microsoft.Azure.SignalR.Common/Logging/MessageLog.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Logging/MessageLog.cs
@@ -7,10 +7,8 @@ using System;
 
 namespace Microsoft.Azure.SignalR
 {
-    internal static class AzureSignalRLog
+    internal static class MessageLog
     {
-        #region MessageLog
-
         public const string StartToBroadcastMessageTemplate = "Start to broadcast message {0}.";
         public const string StartToBroadcastMessageWithExcludedConnectionTemplate = "Start to broadcast message {0} except for {1} connections {2}.";
         public const string StartToSendMessageToConnectionsTemplate = "Start to send message {0} to {1} connections {2}.";
@@ -250,7 +248,5 @@ namespace Microsoft.Azure.SignalR
                 _startToRemoveUserFromGroup(logger, message.TracingId, message.UserId, message.GroupName, null);
             }
         }
-
-        #endregion
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR.Management
             var message = new UserJoinGroupMessage(userId, groupName).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToAddUserToGroup(Logger, message);
+                MessageLog.StartToAddUserToGroup(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.SignalR.Management
             var message = new UserJoinGroupMessage(userId, groupName) { Ttl = (int)ttl.TotalSeconds }.WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToAddUserToGroup(Logger, message);
+                MessageLog.StartToAddUserToGroup(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.SignalR.Management
             var message = new UserLeaveGroupMessage(userId, groupName).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToRemoveUserFromGroup(Logger, message);
+                MessageLog.StartToRemoveUserFromGroup(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.SignalR.Management
             var message = new UserLeaveGroupMessage(userId, null).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToRemoveUserFromGroup(Logger, message);
+                MessageLog.StartToRemoveUserFromGroup(Logger, message);
             }
             return WriteAsync(message);
         }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.SignalR
                 var message = new MultiConnectionDataMessage(new[] { connectionId }, SerializeAllProtocols(methodName, args)).WithTracingId();
                 if (message.TracingId != null)
                 {
-                    AzureSignalRLog.StartToSendMessageToConnections(Logger, message);
+                    MessageLog.StartToSendMessageToConnections(Logger, message);
                 }
 
                 try
@@ -76,13 +76,13 @@ namespace Microsoft.Azure.SignalR
                     
                     if (message.TracingId != null)
                     {
-                        AzureSignalRLog.SucceededToSendMessage(Logger, message);
+                        MessageLog.SucceededToSendMessage(Logger, message);
                     }
                     return;
                 }
                 catch (Exception ex)
                 {
-                    AzureSignalRLog.FailedToSendMessage(Logger, message, ex);
+                    MessageLog.FailedToSendMessage(Logger, message, ex);
                     throw;
                 }
             }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.SignalR
             var message = new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToBroadcastMessage(Logger, message);
+                MessageLog.StartToBroadcastMessage(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.SignalR
             var message = new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToBroadcastMessage(Logger, message);
+                MessageLog.StartToBroadcastMessage(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.SignalR
             var message = new MultiConnectionDataMessage(new[] { connectionId }, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToSendMessageToConnections(Logger, message);
+                MessageLog.StartToSendMessageToConnections(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR
             var message = new MultiConnectionDataMessage(connectionIds, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToSendMessageToConnections(Logger, message);
+                MessageLog.StartToSendMessageToConnections(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.SignalR
             var message = new GroupBroadcastDataMessage(groupName, null, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToBroadcastMessageToGroup(Logger, message);
+                MessageLog.StartToBroadcastMessageToGroup(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.SignalR
             var message = new MultiGroupBroadcastDataMessage(groupNames, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToBroadcastMessageToGroups(Logger, message);
+                MessageLog.StartToBroadcastMessageToGroups(Logger, message);
             }
             // Send this message from a random service connection because this message involves of multiple groups.
             // Unless we send message for each group one by one, we can not guarantee the message order for all groups.
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.SignalR
             var message = new GroupBroadcastDataMessage(groupName, excludedIds, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToBroadcastMessageToGroup(Logger, message);
+                MessageLog.StartToBroadcastMessageToGroup(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.SignalR
             var message = new UserDataMessage(userId, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToSendMessageToUser(Logger, message);
+                MessageLog.StartToSendMessageToUser(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.SignalR
             var message = new MultiUserDataMessage(userIds, SerializeAllProtocols(methodName, args)).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToSendMessageToUsers(Logger, message);
+                MessageLog.StartToSendMessageToUsers(Logger, message);
             }
             return WriteAsync(message);
         }
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.SignalR
             var message = new JoinGroupWithAckMessage(connectionId, groupName).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToAddConnectionToGroup(Logger, message);
+                MessageLog.StartToAddConnectionToGroup(Logger, message);
             }
             return WriteAckableMessageAsync(message);
         }
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.SignalR
             var message = new LeaveGroupWithAckMessage(connectionId, groupName).WithTracingId();
             if (message.TracingId != null)
             {
-                AzureSignalRLog.StartToRemoveConnectionFromGroup(Logger, message);
+                MessageLog.StartToRemoveConnectionFromGroup(Logger, message);
             }
             return WriteAckableMessageAsync(message);
         }
@@ -288,13 +288,13 @@ namespace Microsoft.Azure.SignalR
             }
             catch (Exception ex)
             {
-                AzureSignalRLog.FailedToSendMessage(Logger, message, ex);
+                MessageLog.FailedToSendMessage(Logger, message, ex);
                 throw;
             }
             
             if (message.TracingId != null)
             {
-                AzureSignalRLog.SucceededToSendMessage(Logger, message);
+                MessageLog.SucceededToSendMessage(Logger, message);
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.SignalR
         {
             if (connectionDataMessage.TracingId != null)
             {
-                AzureSignalRLog.ReceiveMessageFromService(Logger, connectionDataMessage);
+                MessageLog.ReceiveMessageFromService(Logger, connectionDataMessage);
             }
             if (_clientConnectionManager.ClientConnections.TryGetValue(connectionDataMessage.ConnectionId, out var connection))
             {

--- a/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
@@ -19,49 +19,49 @@ namespace Microsoft.Azure.SignalR.Tests
             using (var s = new ClientConnectionScope(null, true))
             {
                 // broadcast
-                AzureSignalRLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(null, 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
+                MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(null, 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
 
-                AzureSignalRLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(new[] { "x", "y" }, new Dictionary<string, ReadOnlyMemory<byte>>(), 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
+                MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(new[] { "x", "y" }, new Dictionary<string, ReadOnlyMemory<byte>>(), 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
 
                 // send to connections
-                AzureSignalRLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
+                MessageLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
 
                 // send to user/users
-                AzureSignalRLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
+                MessageLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
 
-                AzureSignalRLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
+                MessageLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
 
                 // send to group/groups
-                AzureSignalRLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
+                MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
 
-                AzureSignalRLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", new[] { "c1", "c2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
+                MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", new[] { "c1", "c2" }, null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
 
-                AzureSignalRLog.StartToBroadcastMessageToGroups(logger, new MultiGroupBroadcastDataMessage(new[] { "g1", "g2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
+                MessageLog.StartToBroadcastMessageToGroups(logger, new MultiGroupBroadcastDataMessage(new[] { "g1", "g2" }, null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
 
                 // connection join/leave group
-                AzureSignalRLog.StartToAddConnectionToGroup(logger, new JoinGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                MessageLog.StartToAddConnectionToGroup(logger, new JoinGroupWithAckMessage("c", "g", tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
-                AzureSignalRLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                MessageLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
                 // user join/leave group
-                AzureSignalRLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                MessageLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
-                AzureSignalRLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
-                AzureSignalRLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", null, tracingId: 123UL));
-                Assert.Equal(string.Format(AzureSignalRLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
+                MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
             }
         }
 


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
* rename `AzureSignalRLog` -> `MessageLog`

todo:
* wait for centralize logs, then use name `Log`. Cannot use it now since a lot of class have a peivate class `Log`.