### PR TITLE
Updated the healthcheck url.

### DIFF
--- a/docs/howto-tsg.md
+++ b/docs/howto-tsg.md
@@ -151,7 +151,7 @@ Troubleshooting `classic` mode connectivity and message delivary issues are simi
 
 You can check the health api for service health.
 
-* Request: GET `https://{instance_name}.service.signalr.net/v1/api/health`
+* Request: GET `https://{instance_name}.service.signalr.net/api/v1/health`
 * Response status code:
   * 200: healthy.
   * 503: your service is unhealthy.


### PR DESCRIPTION
The original Url does not appear to work. It was returning 404 for the free tier Azure SignalR instances and 403 for standard tier ones. 
I believe I found the one that works, the updated url returns 200 for all of the SignalR instances that I was able to test, and during an Azure SignalR restart it would switch to 502s.

### Summary of the changes (Less than 80 chars)
Changed the health check url in the documentation.
