### PR TITLE
Add ConfigureAwait false

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/OwinExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/OwinExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.Azure.SignalR.AspNet;
 using Microsoft.Azure.SignalR.Common;
@@ -203,7 +204,7 @@ namespace Owin
             if (dispatcher != null)
             {
                 // Start the server->service connection asynchronously 
-                _ = dispatcher.StartAsync();
+                Task.Run(() => dispatcher.StartAsync());
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.SignalR
 
         public async Task WriteAsync(ServiceMessage serviceMessage)
         {
-            if (!await SafeWriteAsync(serviceMessage))
+            if (!await SafeWriteAsync(serviceMessage).ConfigureAwait(false))
             {
                 throw new ServiceConnectionNotActiveException(_errorMessage);
             }
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.SignalR
                 return false;
             }
 
-            await _writeLock.WaitAsync();
+            await _writeLock.WaitAsync().ConfigureAwait(false);
 
             if (Status != ServiceConnectionStatus.Connected)
             {
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.SignalR
             {
                 // Write the service protocol message
                 ServiceProtocol.WriteMessage(serviceMessage, _connectionContext.Transport.Output);
-                await _connectionContext.Transport.Output.FlushAsync();
+                await _connectionContext.Transport.Output.FlushAsync().ConfigureAwait(false);
                 return true;
             }
             catch (Exception ex)


### PR DESCRIPTION
For `ASP.NET MVC`, users can call hub methods using `GlobalHost.ConnectionManager.GetHubContext<Hub>()` in it's Controller with `AspNetSynchronizationContext`. Adding `ConfigureAwait(false)` to prevent message send from relying on this context.