### PR TITLE
Add ClientEndpoint support to ConnectionString to customize client negotiate target

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.SignalR.AspNet
         private const string ServerPath = "aspnetserver";
 
         private readonly string _endpoint;
+        private readonly string _clientEndpoint;
         private readonly AccessKey _accessKey;
         private readonly string _appName;
         private readonly int? _port;
@@ -37,13 +38,13 @@ namespace Microsoft.Azure.SignalR.AspNet
 
             // Version is ignored for aspnet signalr case
             _endpoint = endpoint.Endpoint;
+            _clientEndpoint = endpoint.ClientEndpoint ?? endpoint.Endpoint;
             _accessKey = endpoint.AccessKey;
             _appName = options.ApplicationName;
             _port = endpoint.Port;
             _algorithm = options.AccessTokenAlgorithm;
 
             _provider = provider;
-
             Proxy = options.Proxy;
         }
 
@@ -108,8 +109,8 @@ namespace Microsoft.Azure.SignalR.AspNet
             }
 
             return _port.HasValue ?
-                $"{_endpoint}:{_port}/{ClientPath}{queryBuilder}" :
-                $"{_endpoint}/{ClientPath}{queryBuilder}";
+                $"{_clientEndpoint}:{_port}/{ClientPath}{queryBuilder}" :
+                $"{_clientEndpoint}/{ClientPath}{queryBuilder}";
         }
 
         public string GetServerEndpoint(string hubName)

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Azure.SignalR
 
         public string Endpoint { get; }
 
+        /// <summary>
+        /// The customized endpoint that the client will be redirected to
+        /// </summary>
+        internal string ClientEndpoint { get; }
+
         internal string Version { get; }
 
         internal AccessKey AccessKey { get; private set; }
@@ -70,7 +75,7 @@ namespace Microsoft.Azure.SignalR
             }
 
             string key;
-            (Endpoint, key, Version, Port) = ConnectionStringParser.Parse(connectionString);
+            (Endpoint, key, Version, Port, ClientEndpoint) = ConnectionStringParser.Parse(connectionString);
             AccessKey = new AccessKey(key);
 
             EndpointType = type;

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/DefaultServiceEndpointGenerator.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/DefaultServiceEndpointGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Net;
 using System.Text;
 
@@ -10,18 +11,20 @@ namespace Microsoft.Azure.SignalR
     {
         private const string ClientPath = "client";
         private const string ServerPath = "server";
-
         public string Endpoint { get; }
 
         public string Version { get; }
 
         public int? Port { get; }
 
-        public DefaultServiceEndpointGenerator(string endpoint, string version, int? port)
+        public string ClientEndpoint { get; }
+
+        public DefaultServiceEndpointGenerator(ServiceEndpoint endpoint)
         {
-            Endpoint = endpoint;
-            Version = version;
-            Port = port;
+            Endpoint = endpoint.Endpoint;
+            Version = endpoint.Version;
+            Port = endpoint.Port;
+            ClientEndpoint = endpoint.ClientEndpoint;
         }
 
         public string GetClientAudience(string hubName, string applicationName) =>
@@ -60,9 +63,10 @@ namespace Microsoft.Azure.SignalR
 
         private string InternalGetEndpoint(string path, string hubName, string applicationName)
         {
+            var target = ClientEndpoint ?? Endpoint;
             return Port.HasValue ?
-                $"{Endpoint}:{Port}/{path}/?hub={GetPrefixedHubName(applicationName, hubName)}" :
-                $"{Endpoint}/{path}/?hub={GetPrefixedHubName(applicationName, hubName)}";
+                $"{target}:{Port}/{path}/?hub={GetPrefixedHubName(applicationName, hubName)}" :
+                $"{target}/{path}/?hub={GetPrefixedHubName(applicationName, hubName)}";
         }
 
         private string InternalGetAudience(string path, string hubName, string applicationName)

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
@@ -51,10 +51,7 @@ namespace Microsoft.Azure.SignalR
 
             Proxy = serviceOptions.Proxy;
 
-            var port = endpoint.Port;
-            var version = endpoint.Version;
-
-            _generator = new DefaultServiceEndpointGenerator(endpoint.Endpoint, version, port);
+            _generator = new DefaultServiceEndpointGenerator(endpoint);
 
             _ = UpdateAccessKeyAsync(provider, endpoint, loggerFactory ?? NullLoggerFactory.Instance);
         }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ConnectionStringParserFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ConnectionStringParserFacts.cs
@@ -15,12 +15,13 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         [InlineData("http://aaa", "ENDPOINT=http://aaa/;ACCESSKEY=bbb;")]
         public void ValidPreviewConnectionString(string expectedEndpoint, string connectionString)
         {
-            var (endpoint, accessKey, version, port) = ConnectionStringParser.Parse(connectionString);
+            var (endpoint, accessKey, version, port, clientEndpoint) = ConnectionStringParser.Parse(connectionString);
 
             Assert.Equal(expectedEndpoint, endpoint);
             Assert.Equal("bbb", accessKey);
             Assert.Null(version);
             Assert.Null(port);
+            Assert.Null(clientEndpoint);
         }
 
         [Theory]
@@ -30,12 +31,13 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         [InlineData("http://aaa", "1.1-beta2", 1234, "ENDPOINT=http://aaa/;ACCESSKEY=bbb;Version=1.1-beta2;Port=1234")]
         public void ValidConnectionString(string expectedEndpoint, string expectedVersion, int? expectedPort, string connectionString)
         {
-            var (endpoint, accessKey, version, port) = ConnectionStringParser.Parse(connectionString);
+            var (endpoint, accessKey, version, port, clientEndpoint) = ConnectionStringParser.Parse(connectionString);
 
             Assert.Equal(expectedEndpoint, endpoint);
             Assert.Equal("bbb", accessKey);
             Assert.Equal(expectedVersion, version);
             Assert.Equal(expectedPort, port);
+            Assert.Null(clientEndpoint);
         }
 
         [Theory]
@@ -58,6 +60,16 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             var exception = Assert.Throws<ArgumentException>(() => ConnectionStringParser.Parse(connectionString));
 
             Assert.Contains("Endpoint property in connection string is not a valid URI", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("endpoint=https://aaa;clientEndpoint=aaa;AccessKey=bbb;")]
+        [InlineData("endpoint=https://aaa;ClientEndpoint=endpoint=aaa;AccessKey=bbb;")]
+        public void InvalidClientEndpoint(string connectionString)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => ConnectionStringParser.Parse(connectionString));
+
+            Assert.Contains("ClientEndpoint property in connection string is not a valid URI", exception.Message);
         }
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -83,7 +83,14 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         [Fact]
         internal void GenerateClientEndpointTestWithClientEndpoint()
         {
-            var manager = new ServiceManager(new ServiceManagerOptions() { ConnectionString = $"Endpoint=http://localhost;AccessKey=ABC;Version=1.0;ClientEndpoint=https://remote"}, null, new RestClientFactory(UserAgent));
+            var options = new ServiceManagerOptions
+            {
+                ConnectionString = $"Endpoint=http://localhost;AccessKey=ABC;Version=1.0;ClientEndpoint=https://remote"
+            };
+
+            var context = new ServiceManagerContext();
+            context.SetValueFromOptions(options);
+            var manager = new ServiceManager(context, new RestClientFactory(UserAgent));
             var clientEndpoint = manager.GetClientEndpoint(HubName);
 
             Assert.Equal("https://remote/client/?hub=signalrbench", clientEndpoint);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -80,7 +80,16 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             Assert.Equal(expectedClientEndpoint, clientEndpoint);
         }
 
-        [Theory/*(Skip = "Reenable when it is ready")*/]
+        [Fact]
+        internal void GenerateClientEndpointTestWithClientEndpoint()
+        {
+            var manager = new ServiceManager(new ServiceManagerOptions() { ConnectionString = $"Endpoint=http://localhost;AccessKey=ABC;Version=1.0;ClientEndpoint=https://remote"}, null, new RestClientFactory(UserAgent));
+            var clientEndpoint = manager.GetClientEndpoint(HubName);
+
+            Assert.Equal("https://remote/client/?hub=signalrbench", clientEndpoint);
+        }
+
+        [Theory]
         [MemberData(nameof(TestServiceManagerOptionData))]
         internal async Task CreateServiceHubContextTest(ServiceTransportType serviceTransportType, bool useLoggerFacory, string appName, int connectionCount)
         {


### PR DESCRIPTION
User can add `ClientEndpoint={url}` in connectionstring to customize the target endpoint for client to redirect to.