### PR TITLE
mark ServiceEndpoint in ServiceManagerOptions as internal 

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// <summary>
         /// Gets or sets a service endpoint of Azure SignalR Service.
         /// </summary>
-        public ServiceEndpoint ServiceEndpoint { get; set; }
+        internal ServiceEndpoint ServiceEndpoint { get; set; }
 
         /// <summary>
         /// Sets multiple service endpoints of Azure SignalR Service.
@@ -45,7 +45,6 @@ namespace Microsoft.Azure.SignalR.Management
         /// Gets or sets the transport type to Azure SignalR Service. Default value is Transient.
         /// </summary>
         public ServiceTransportType ServiceTransportType { get; set; } = ServiceTransportType.Transient;
-
 
         /// <summary>
         /// Method called by management SDK to validate options.


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - change `ServiceEndpoint` in `ServiceManagerOptions` accesibility to internal as AAD service endpoint will be configured as connection string . It will be deleted later.