### PR TITLE
Add hooks for Graceful shutdown

### DIFF
--- a/samples/ChatSample/ChatSample/Startup.cs
+++ b/samples/ChatSample/ChatSample/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,6 +20,11 @@ namespace ChatSample.CoreApp3
                 {
                     option.GracefulShutdown.Mode = GracefulShutdownMode.WaitForClientsClose;
                     option.GracefulShutdown.Timeout = TimeSpan.FromSeconds(30);
+
+                    option.GracefulShutdown.Add<Chat>(async (c) =>
+                    {
+                        await c.Clients.All.SendAsync("exit");
+                    });
                 })
                 .AddMessagePackProtocol();
         }

--- a/samples/ChatSample/ChatSample/wwwroot/index.html
+++ b/samples/ChatSample/ChatSample/wwwroot/index.html
@@ -28,7 +28,17 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <div>Connection Error...</div>
-                    <div><strong style="font-size: 1.5em;">Hit Refresh/F5</strong> to rejoin. ;)</div>
+                    <div><strong style="font-size: 1.5em;">Hit Refresh/F5</strong> to rejoin. :)</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal alert alert-success fade" id="closeModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <div>Connection Closed</div>
+                    <div><strong style="font-size: 1.5em;">Hit Refresh/F5</strong> to rejoin. :)</div>
                 </div>
             </div>
         </div>
@@ -97,9 +107,15 @@
                     messageBox.appendChild(messageEntry);
                     messageBox.scrollTop = messageBox.scrollHeight;
                 };
+
+                var close = function (name, message) {
+                    setTimeout(() => connection.stop(), 3000);
+                }
+
                 // Create a function that the hub can call to broadcast messages.
                 connection.on('broadcastMessage', messageCallback);
                 connection.on('echo', messageCallback);
+                connection.on('exit', close);
                 connection.onclose(onConnectionError);
             }
 
@@ -138,8 +154,10 @@
             function onConnectionError(error) {
                 if (error && error.message) {
                     console.error(error.message);
+                    var modal = document.getElementById('myModal');
+                } else {
+                    var modal = document.getElementById('closeModal');
                 }
-                var modal = document.getElementById('myModal');
                 modal.classList.add('in');
                 modal.style = 'display: block;';
             }

--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceHubDispatcher.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Microsoft.Azure.SignalR/GracefulShutdownOptions.cs
+++ b/src/Microsoft.Azure.SignalR/GracefulShutdownOptions.cs
@@ -1,17 +1,88 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.Azure.SignalR
 {
     public class GracefulShutdownOptions
     {
-        /// <summary>
-        /// Define the maximum waiting time to do the graceful shutdown process.
-        /// </summary>
-        public TimeSpan Timeout { get; set; } = Constants.Periods.DefaultShutdownTimeout;
+        private readonly Dictionary<string, List<object>> _dict = new Dictionary<string, List<object>>();
 
         /// <summary>
         /// This mode defines the server's behavior after receiving a `Ctrl+C` (SIGINT).
         /// </summary>
         public GracefulShutdownMode Mode { get; set; } = GracefulShutdownMode.Off;
+
+        /// <summary>
+        /// Specifies the timeout of a graceful shutdown process (in seconds). 
+        /// Default value is 30 seconds.
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = Constants.Periods.DefaultShutdownTimeout;
+
+        public void Add<THub>(Func<IHubContext<THub>, Task> func) where THub : Hub
+        {
+            AddMethod<THub>(func);
+        }
+
+        public void Add<THub>(Action<IHubContext<THub>> action) where THub : Hub
+        {
+            AddMethod<THub>(action);
+        }
+
+        public void Add<THub>(Func<Task> func)
+        {
+            AddMethod<THub>(func);
+        }
+
+        public void Add<THub>(Action action)
+        {
+            AddMethod<THub>(action);
+        }
+
+        internal async Task OnShutdown<THub>(IHubContext<THub> context) where THub : Hub
+        {
+            var name = typeof(THub).Name;
+            if (_dict.TryGetValue(name, out var methods))
+            {
+                foreach (var method in methods)
+                {
+                    if (method is Action<IHubContext<THub>> action)
+                    {
+                        action(context);
+                    }
+                    else if (method is Action action2)
+                    {
+                        action2();
+                    }
+                    else if (method is Func<IHubContext<THub>, Task> func)
+                    {
+                        await func(context);
+                    }
+                    else if (method is Func<Task> func2)
+                    {
+                        await func2();
+                    }
+                }
+            }
+        }
+
+        private void AddMethod<THub>(object method)
+        {
+            if (method == null)
+            {
+                return;
+            }
+
+            var name = typeof(THub).Name;
+            if (_dict.TryGetValue(name, out var list))
+            {
+                list.Add(method);
+            }
+            else
+            {
+                _dict.Add(name, new List<object>() { method });
+            }
+        }
     }
 }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceHubDispatcher.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceHubDispatcher.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
 
         public MockServiceHubDispatcher(
             IServiceProtocol serviceProtocol,
+            IHubContext<THub> context,
             IServiceConnectionManager<THub> serviceConnectionManager,
             IClientConnectionManager clientConnectionManager,
             IServiceEndpointManager serviceEndpointManager,
@@ -32,6 +33,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
             ServerLifetimeManager serverLifetimeManager,
             IClientConnectionFactory clientConnectionFactory) : base(
                 serviceProtocol,
+                context,
                 serviceConnectionManager,
                 clientConnectionManager,
                 serviceEndpointManager,

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
             var dispatcher = new ServiceHubDispatcher<Hub>(
                 null,
+                TestHubContext<Hub>.GetInstance(),
                 serviceManager,
                 clientManager,
                 null,

--- a/test/Microsoft.Azure.SignalR.Tests/TestHubContext.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestHubContext.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    internal sealed class TestHubContext<THub> : IHubContext<THub> where THub : Hub
+    {
+        public IHubClients Clients => throw new NotImplementedException();
+
+        public IGroupManager Groups => throw new NotImplementedException();
+
+        public static TestHubContext<THub> GetInstance()
+        {
+            return new TestHubContext<THub>();
+        }
+    }
+}


### PR DESCRIPTION
Add a new step for **graceful shutdown** feature.

Now the graceful shutdown works in the following order.

1. Set the server offline from ASRS.
2. **(New) Trigger OnShutdown hooks.**
3. Wait until all client connections have finished, depends on the mode (Wait/Migrate) you choose.
4. Stop server connections.

As well as fixed a bug that will cause `OperationCancelledException` when the given endpoint is not accessible.