### PR TITLE
Fixed options variable name in one of code samples

### DIFF
--- a/docs/use-signalr-service.md
+++ b/docs/use-signalr-service.md
@@ -174,8 +174,8 @@ services.AddSignalR()
                 options.AccessTokenLifetime = TimeSpan.FromDays(1);
                 options.ClaimsProvider = context => context.User.Claims;
 
-                option.GracefulShutdown.Mode = GracefulShutdownMode.WaitForClientsClose;
-                option.GracefulShutdown.Timeout = TimeSpan.FromSeconds(10);
+                options.GracefulShutdown.Mode = GracefulShutdownMode.WaitForClientsClose;
+                options.GracefulShutdown.Timeout = TimeSpan.FromSeconds(10);
             });
 ```
 


### PR DESCRIPTION
Renamed `option` variable to `options` in the following code sample:

    services.AddSignalR()
        .AddAzureSignalR(options =>
            {
                options.ConnectionCount = 10;
                options.AccessTokenLifetime = TimeSpan.FromDays(1);
                options.ClaimsProvider = context => context.User.Claims;

                option.GracefulShutdown.Mode = GracefulShutdownMode.WaitForClientsClose;
                option.GracefulShutdown.Timeout = TimeSpan.FromSeconds(10);
            });

