### PR TITLE
Throw exc while key doesn't have read accesskey permit.

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointManager.cs
@@ -11,12 +11,15 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         private readonly IServerNameProvider _provider;
 
+        private readonly ILoggerFactory _loggerFactory;
+
         public ServiceEndpointManager(IServerNameProvider provider, ServiceOptions options, ILoggerFactory loggerFactory) : 
             base(options,
                 loggerFactory?.CreateLogger<ServiceEndpointManager>())
         {
             _provider = provider;
             _options = options;
+            _loggerFactory = loggerFactory;
         }
 
         public override IServiceEndpointProvider GetEndpointProvider(ServiceEndpoint endpoint)
@@ -26,7 +29,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 return null;
             }
 
-            return new ServiceEndpointProvider(_provider, endpoint, _options);
+            return new ServiceEndpointProvider(_provider, endpoint, _options, _loggerFactory);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.AspNet
 {
@@ -32,7 +33,11 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         public IWebProxy Proxy { get; }
 
-        public ServiceEndpointProvider(IServerNameProvider provider, ServiceEndpoint endpoint, ServiceOptions options)
+        public ServiceEndpointProvider(
+            IServerNameProvider provider,
+            ServiceEndpoint endpoint,
+            ServiceOptions options,
+            ILoggerFactory loggerFactory)
         {
             _accessTokenLifetime = options.AccessTokenLifetime;
 
@@ -46,8 +51,12 @@ namespace Microsoft.Azure.SignalR.AspNet
 
             _provider = provider;
             Proxy = options.Proxy;
-        }
 
+            if (endpoint.AccessKey is AadAccessKey key)
+            {
+                _ = key.UpdateAccessKeyAsync(provider, loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)));
+            }
+        }
 
         private string GetPrefixedHubName(string applicationName, string hubName)
         {

--- a/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/Middleware/NegotiateMiddleware.cs
@@ -173,8 +173,16 @@ namespace Microsoft.Azure.SignalR.AspNet
             }
 
             var url = provider.GetClientEndpoint(null, originalPath, queryString);
-
-            return GenerateClientAccessTokenAsync(provider, context, url, claims);
+            try
+            {
+                return GenerateClientAccessTokenAsync(provider, context, url, claims);
+            }
+            catch (AzureSignalRAccessTokenNotAuthorizedException e)
+            {
+                Log.NegotiateFailed(_logger, e.Message);
+                context.Response.StatusCode = 500;
+                return context.Response.End("");
+            }
         }
 
         private async Task GenerateClientAccessTokenAsync(

--- a/src/Microsoft.Azure.SignalR.Common/Exceptions/AzureSignalRAccessTokenNotAuthorizedException.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Exceptions/AzureSignalRAccessTokenNotAuthorizedException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Common
+{
+    /// <summary>
+    /// The exception throws when AccessKey is not authorized.
+    /// </summary>
+    public class AzureSignalRAccessTokenNotAuthorizedException : AzureSignalRException
+    {
+         /// <summary>
+        /// Initializes a new instance of the <see cref="AzureSignalRAccessTokenNotAuthorizedException"/> class.
+        /// </summary>
+        public AzureSignalRAccessTokenNotAuthorizedException() : base("This AccessKey doesn't have the permission to generate access token.")
+        {
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Azure.SignalR
             IServerNameProvider provider,
             ServiceEndpoint endpoint,
             ServiceOptions serviceOptions,
-            ILoggerFactory loggerFactory
-        )
+            ILoggerFactory loggerFactory)
         {
             _accessTokenLifetime = serviceOptions.AccessTokenLifetime;
             _accessKey = endpoint.AccessKey;

--- a/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
+++ b/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Azure.SignalR
                 await context.Response.WriteAsync(ex.Message);
                 return;
             }
+            catch (AzureSignalRAccessTokenNotAuthorizedException ex)
+            {
+                Log.NegotiateFailed(logger, ex.Message);
+                context.Response.StatusCode = 500;
+                return;
+            }
             catch (AzureSignalRNotConnectedException e)
             {
                 Log.NegotiateFailed(logger, e.Message);

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetclient")]
         public async Task TestGenerateClientAccessToken(string connectionString, string expectedAudience)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { }, NullLoggerFactory.Instance);
 
             var clientToken = await provider.GenerateClientAccessTokenAsync(null, new Claim[]
             {
@@ -53,7 +54,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://abc.com;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "orig<inal.com", "?abc=%21dcf", "https://abc.com/aspnetclient?abc=%21dcf&asrs.op=orig%3Cinal.com")]
         public void TestGenerateClientEndpoint(string connectionString, string originalPath, string queryString, string expectedEndpoint)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { }, NullLoggerFactory.Instance);
 
             var clientEndpoint = provider.GetClientEndpoint(null, originalPath, queryString);
 
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=hub1")]
         public async Task TestGenerateServerAccessToken(string connectionString, string expectedAudience)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { }, NullLoggerFactory.Instance);
 
             var clientToken = await provider.GenerateServerAccessTokenAsync("hub1", "user1");
 
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]
         public async Task TestGenerateServerAccessTokenWIthPrefix(string connectionString, string expectedAudience)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { ApplicationName = "prefix" });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { ApplicationName = "prefix" }, NullLoggerFactory.Instance);
 
             var clientToken = await provider.GenerateServerAccessTokenAsync("hub1", "user1");
 
@@ -108,7 +109,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=hub1")]
         public void TestGenerateServerEndpoint(string connectionString, string expectedEndpoint)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { }, NullLoggerFactory.Instance);
 
             var clientEndpoint = provider.GetServerEndpoint("hub1");
 
@@ -121,7 +122,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         [InlineData("Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;", "https://localhost/aspnetserver/?hub=prefix_hub1")]
         public void TestGenerateServerEndpointWithPrefix(string connectionString, string expectedEndpoint)
         {
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { ApplicationName = "prefix" });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { ApplicationName = "prefix" }, NullLoggerFactory.Instance);
 
             var clientEndpoint = provider.GetServerEndpoint("hub1");
 
@@ -134,7 +135,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         public async Task TestGenerateServerAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
         {
             var connectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0";
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { AccessTokenAlgorithm = algorithm });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { AccessTokenAlgorithm = algorithm }, NullLoggerFactory.Instance);
             var generatedToken = await provider.GenerateServerAccessTokenAsync("hub1", "user1");
 
             var handler = new JwtSecurityTokenHandler();
@@ -149,7 +150,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         public async Task TestGenerateClientAccessTokenWithSpecifedAlgorithm(AccessTokenAlgorithm algorithm)
         {
             var connectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0";
-            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { AccessTokenAlgorithm = algorithm });
+            var provider = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(connectionString), new ServiceOptions() { AccessTokenAlgorithm = algorithm }, NullLoggerFactory.Instance);
             var generatedToken = await provider.GenerateClientAccessTokenAsync("hub1");
 
             var handler = new JwtSecurityTokenHandler();
@@ -162,7 +163,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         public async Task GenerateMutlipleAccessTokenShouldBeUnique()
         {
             var count = 1000;
-            var sep = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(DefaultConnectionString), new ServiceOptions() { });
+            var sep = new ServiceEndpointProvider(new DefaultServerNameProvider(), new ServiceEndpoint(DefaultConnectionString), new ServiceOptions() { }, NullLoggerFactory.Instance);
             var userId = Guid.NewGuid().ToString();
             var tokens = new List<string>();
             for (int i = 0; i < count; i++)


### PR DESCRIPTION
1. Throw `AzureSignalRAccessKeyNotAuthorizedException` while the given Accesskey doesn't have permission to generate `AccessToken` for clients.
2. Add exception handler for both `ASP.NET Core SignalR` and `ASP.NET SignalR`.