### PR TITLE
Various livescale-related fixes

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.SignalR
                 if (!endpoints.TryGetValue(hub, out var updatedEndpoints) 
                     || updatedEndpoints.Count == 0)
                 {
-                    return;
+                    continue;
                 }
                 var oldEndpoints = _endpointsPerHub[hub];
                 var newEndpoints = oldEndpoints.ToList();

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.SignalR
                 }
                 await Task.Delay(Constants.Periods.DefaultServersPingInterval);
             }
-            Log.TimeoutWaitingForAddingEndpoint(_logger, endpoint.ToString(), _scaleTimeout.Seconds);
+            Log.TimeoutWaitingForAddingEndpoint(_logger, endpoint.ToString(), (int)_scaleTimeout.TotalSeconds);
         }
 
         private bool IsServerReady(IServiceConnectionContainer container)
@@ -413,7 +413,7 @@ namespace Microsoft.Azure.SignalR
                 // status ping interval is 10s, quick delay 5s to do next check
                 await Task.Delay(Constants.Periods.DefaultCloseDelayInterval);
             }
-            Log.TimeoutWaitingClientsDisconnect(_logger, endpoint.ToString(), _scaleTimeout.Seconds);
+            Log.TimeoutWaitingClientsDisconnect(_logger, endpoint.ToString(), (int)_scaleTimeout.TotalSeconds);
         }
 
         internal static class Log

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/StrongServiceConnectionContainer.cs
@@ -20,11 +20,14 @@ namespace Microsoft.Azure.SignalR
         public override async Task HandlePingAsync(PingMessage pingMessage)
         {
             await base.HandlePingAsync(pingMessage);
-            if (RuntimeServicePingMessage.TryGetRebalance(pingMessage, out var target) && !string.IsNullOrEmpty(target))
+            if (ReadyForNewConnections)
             {
-                var connection = CreateServiceConnectionCore(ServiceConnectionType.OnDemand);
-                AddOnDemandConnection(connection);
-                await StartCoreAsync(connection, target);
+                if (RuntimeServicePingMessage.TryGetRebalance(pingMessage, out var target) && !string.IsNullOrEmpty(target))
+                {
+                    var connection = CreateServiceConnectionCore(ServiceConnectionType.OnDemand);
+                    AddOnDemandConnection(connection);
+                    await StartCoreAsync(connection, target);
+                }
             }
         }
     }


### PR DESCRIPTION
### Various fixes to unblock the additional message order tests
 - fixing Start/Stop for CustomizedPingTimer
 - fixing container stop logic (won't try restarting or accept on demand connections after stop or offline)
 - misc fixes

