### PR TITLE
make IServiceContext public for function extension

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/IServiceContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceContext.cs
@@ -11,8 +11,7 @@ using Microsoft.AspNetCore.Http.Connections;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    //todo public later
-    internal interface IServiceContext : IDisposable
+    public interface IServiceContext : IDisposable
     {
         /// <summary>
         /// Creates an instance of <see cref="IServiceHubContext"/> asynchronously.


### PR DESCRIPTION
Because function extension will use `IServiceContext` as a constructor parameter in a `public` class
