### PR TITLE
Ensure service hub context created from service manager independent f…

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubContextFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubContextFactory.cs
@@ -1,33 +1,35 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.Management
 {
     internal class ServiceHubContextFactory
     {
         private readonly ServiceHubLifetimeManagerFactory _managerFactory;
+        private readonly IServiceProvider _serviceProvider;
 
-        public ServiceHubContextFactory(ServiceHubLifetimeManagerFactory managerFactory)
+        public ServiceHubContextFactory(ServiceHubLifetimeManagerFactory managerFactory,IServiceProvider serviceProvider)
         {
             _managerFactory = managerFactory;
+            _serviceProvider = serviceProvider;
         }
 
-        public async Task<IServiceHubContext> CreateAsync(string hubName, ILoggerFactory loggerFactory = null, CancellationToken cancellationToken = default)
+        public Task<IServiceHubContext> CreateAsync(string hubName)
         {
-            var manager = await _managerFactory.CreateAsync(hubName, cancellationToken, loggerFactory);
+            var manager = _managerFactory.Create(hubName);
             var servicesPerHub = new ServiceCollection();
             servicesPerHub.AddSignalRCore();
             servicesPerHub.AddSingleton((HubLifetimeManager<Hub>)manager);
             var serviceProviderPerHub = servicesPerHub.BuildServiceProvider();
             // The impl of IHubContext<Hub> we want is an internal class. We can only get it by this way.
             var hubContext = serviceProviderPerHub.GetRequiredService<IHubContext<Hub>>();
-            return new ServiceHubContext(hubContext, manager, serviceProviderPerHub);
+            return Task.FromResult(new ServiceHubContext(hubContext, manager, serviceProviderPerHub) as IServiceHubContext);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.SignalR.Management
             _context = context.Value;
         }
 
-        public  IServiceHubLifetimeManager Create(string hubName)
+        public IServiceHubLifetimeManager Create(string hubName)
         {
             switch (_context.ServiceTransportType)
             {

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -4,11 +4,8 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Management
@@ -16,28 +13,24 @@ namespace Microsoft.Azure.SignalR.Management
     internal class ServiceHubLifetimeManagerFactory
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly MultiEndpointConnectionContainerFactory _connectionContainerFactory;
         private readonly ContextOptions _context;
 
-        public ServiceHubLifetimeManagerFactory(IServiceProvider sp, IOptions<ContextOptions> context, MultiEndpointConnectionContainerFactory connectionContainerFactory)
+        public ServiceHubLifetimeManagerFactory(IServiceProvider sp, IOptions<ContextOptions> context)
         {
             _serviceProvider = sp;
-            _connectionContainerFactory = connectionContainerFactory;
             _context = context.Value;
         }
 
-        public async Task<IServiceHubLifetimeManager> CreateAsync(string hubName, CancellationToken cancellationToken, ILoggerFactory loggerFactoryPerHub = null)
+        public  IServiceHubLifetimeManager Create(string hubName)
         {
             switch (_context.ServiceTransportType)
             {
                 case ServiceTransportType.Persistent:
                     {
-                        var container = _connectionContainerFactory.GetOrCreate(hubName, loggerFactoryPerHub);
-                        //ensure connections to each endpoint are initialized, so that the online status of endpoints are valid
+                        var container = _serviceProvider.GetRequiredService<IServiceConnectionContainer>();
                         var connectionManager = new ServiceConnectionManager<Hub>();
                         connectionManager.SetServiceConnection(container);
-                        await container.ConnectionInitializedTask.OrTimeout(cancellationToken);
-                        return loggerFactoryPerHub == null ? ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<Hub>>(_serviceProvider, connectionManager) : ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<Hub>>(_serviceProvider, connectionManager, loggerFactoryPerHub);
+                        return ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<Hub>>(_serviceProvider, connectionManager);
                     }
                 case ServiceTransportType.Transient:
                     {

--- a/src/Microsoft.Azure.SignalR.Management/Obsolete/ServiceManagerBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Obsolete/ServiceManagerBuilder.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Azure.SignalR.Management
         public IServiceManager Build()
         {
             _services.AddSignalRServiceManager();
-            var serviceProvider = _services.BuildServiceProvider();
-            return serviceProvider.GetRequiredService<IServiceManager>();
+            return new ServiceManager(_services);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.SignalR.Management
 
         public Task<IServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken = default)
         {
-            return _serviceHubContextFactory.CreateAsync(hubName, null, cancellationToken);
+            throw new NotImplementedException();
         }
 
         public Task<NegotiationResponse> GetClientEndpointAsync(string hubName, HttpContext httpContext = null, string userId = null, IList<Claim> claims = null, TimeSpan? lifetime = null, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.SignalR.Management
         private readonly IHubContext<Hub> _hubContext;
         private readonly IServiceHubLifetimeManager _lifetimeManager;
 
-        internal ServiceProvider ServiceProvider { get; }
+        internal IServiceProvider ServiceProvider { get; }
 
         public IHubClients Clients => _hubContext.Clients;
 
@@ -20,7 +21,7 @@ namespace Microsoft.Azure.SignalR.Management
 
         public IUserGroupManager UserGroups { get; }
 
-        public ServiceHubContext(IHubContext<Hub> hubContext, IServiceHubLifetimeManager lifetimeManager, ServiceProvider serviceProvider)
+        public ServiceHubContext(IHubContext<Hub> hubContext, IServiceHubLifetimeManager lifetimeManager, IServiceProvider serviceProvider)
         {
             _hubContext = hubContext;
             _lifetimeManager = lifetimeManager;
@@ -31,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
         public async Task DisposeAsync()
         {
             await _lifetimeManager.DisposeAsync();
-            ServiceProvider?.Dispose();
+            (ServiceProvider as ServiceProvider)?.Dispose();
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -122,8 +122,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             services.AddSignalRServiceManager();
             services.Configure<ServiceManagerOptions>(o => o.ConnectionString = _testConnectionString);
             services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, HttpStatusCode.OK));
-            using var serviceProvider = services.BuildServiceProvider();
-            var serviceManager = serviceProvider.GetRequiredService<IServiceManager>();
+            using var serviceManager = new ServiceManager(services);
             var actual = await serviceManager.IsServiceHealthy(default);
 
             Assert.True(actual);
@@ -139,8 +138,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             services.Configure<ServiceManagerOptions>(o => o.ConnectionString = _testConnectionString);
             services.AddSignalRServiceManager();
             services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, statusCode));
-            using var serviceProvider = services.BuildServiceProvider();
-            var serviceManager = serviceProvider.GetRequiredService<IServiceManager>();
+            using var serviceManager = new ServiceManager(services);
 
             var actual = await serviceManager.IsServiceHealthy(default);
 
@@ -158,8 +156,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             services.AddSignalRServiceManager();
             services.Configure<ServiceManagerOptions>(o => o.ConnectionString = _testConnectionString);
             services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, statusCode));
-            using var serviceProvider = services.BuildServiceProvider();
-            var serviceManager = serviceProvider.GetRequiredService<IServiceManager>();
+            using var serviceManager = new ServiceManager(services);
 
             var exception = await Assert.ThrowsAnyAsync<AzureSignalRException>(() => serviceManager.IsServiceHealthy(default));
             Assert.IsType(expectedException, exception);


### PR DESCRIPTION
…rom each other

### Summary of the changes (Less than 80 chars)
 - Use separate service collection for each hub again
 - Change the `ServiceHubContext` creation for `IServiceContext` to not implemented, as it needs redesign.

### Some considerations
1. If `MultiendpointServiceConnectionContainer` is reused, then `ServiceHubContext` s with same hub name are not independent from each other. If one of them is disposed, then other won't work. 
2. What's more, if `IServiceEndpointManager` is an singleton, then multiple `ServiceHubContext` s with same hub name also have problems, as `IServiceEndpointManager` allows only one `IServiceConnectionContainer` for each `HubServiceEndpoint`.
