### PR TITLE
fix fail to dispose service provider inside ServiceHubContext

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
         public async Task DisposeAsync()
         {
             await _lifetimeManager.DisposeAsync();
-            (ServiceProvider as ServiceProvider)?.Dispose();
+            (ServiceProvider as IDisposable)?.Dispose();
         }
     }
 }


### PR DESCRIPTION
The actual impl of `IServiceProvider` can not be converted to `ServiceProvider`.