### PR TITLE
fixed null reference error when arguments is not supplied/null

### DIFF
--- a/src/Microsoft.Azure.SignalR.Emulator/Controllers/SignalRServiceEmulatorWebApi.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Controllers/SignalRServiceEmulatorWebApi.cs
@@ -237,7 +237,9 @@ namespace Microsoft.Azure.SignalR.Emulator.Controllers
 
         private Task SendAsync(IClientProxy client, string method, object[] arguments, CancellationToken cancellationToken = default)
         {
-            switch (arguments.Length)
+            var argsLen = arguments?.Length ?? 0;
+
+            switch (argsLen)
             {
                 case 0:
                     return client.SendAsync(method, cancellationToken);


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
`Microsoft.Azure.SignalR.Emulator.Controllers.SendAsync` will error if `object[] arguments` is null.  `arguments` is not required on the `SignalRMessage` class and therefore could very well be null.

Fixes #bugnumber (in this specific format)
