### PR TITLE
Extended service manager options to configure JSON serialization

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.SignalR
 {
     internal class RestClient
     {
+        public JsonSerializerSettings JsonSerializerSettings { get; set; } = new JsonSerializerSettings();
+
         public Task SendAsync(
             RestApiEndpoint api,
             HttpMethod httpMethod,
@@ -134,7 +136,7 @@ namespace Microsoft.Azure.SignalR
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenString);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Add(Constants.AsrsUserAgent, productInfo);
-            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+            request.Content = new StringContent(JsonConvert.SerializeObject(payload, JsonSerializerSettings), Encoding.UTF8, "application/json");
             return request;
         }
     }

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Newtonsoft.Json;
 using System;
 using System.Net;
 
@@ -41,8 +42,13 @@ namespace Microsoft.Azure.SignalR.Management
         /// </summary>
         public ServiceTransportType ServiceTransportType { get; set; } = ServiceTransportType.Transient;
 
-        internal string ProductInfo { get; set; }
+        /// <summary>
+        /// Gets the json serializer settings that will be used to serialize content sent to Azure SignalR Service.
+        /// </summary>
+        public JsonSerializerSettings JsonSerializerSettings { get; } = new JsonSerializerSettings();
 
+        internal string ProductInfo { get; set; }
+        
         internal void ValidateOptions()
         {
             if ((ServiceEndpoints == null || ServiceEndpoints.Length == 0) && string.IsNullOrWhiteSpace(ConnectionString))

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.SignalR.Management
                     }
                 case ServiceTransportType.Transient:
                     {
-                        return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName);
+                        return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName, _options.JsonSerializerSettings);
                     }
                 default: throw new InvalidEnumArgumentException(nameof(ServiceManagerOptions.ServiceTransportType), (int)_options.ServiceTransportType, typeof(ServiceTransportType));
             }

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.SignalR.Management
 {
@@ -25,12 +26,14 @@ namespace Microsoft.Azure.SignalR.Management
         private readonly string _hubName;
         private readonly string _appName;
 
-        public RestHubLifetimeManager(string hubName, ServiceEndpoint endpoint, string productInfo, string appName)
+        public RestHubLifetimeManager(string hubName, ServiceEndpoint endpoint, string productInfo, string appName, JsonSerializerSettings jsonSerializerSettings)
         {
             _restApiProvider = new RestApiProvider(endpoint);
             _productInfo = productInfo;
             _appName = appName;
             _hubName = hubName;
+            
+            _restClient.JsonSerializerSettings = jsonSerializerSettings;
         }
 
         public override async Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)


### PR DESCRIPTION
The REST client currently uses the default serialization settings, but it would be very helpful to change the settings (e.g. to enable camel case for property serialization).