### PR TITLE
Allow to choose SignalR hub protocol in management SDK

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -64,7 +63,6 @@ namespace Microsoft.Azure.SignalR.Management
             {
                 throw new ArgumentNullException(nameof(endpoints));
             }
-            
 
             var targetEndpoints = _endpointManager.GetEndpoints(_hubName).Intersect(endpoints, EqualityComparer<ServiceEndpoint>.Default).Select(e => e as HubServiceEndpoint).ToList();
             var container = new MultiEndpointMessageWriter(targetEndpoints, ServiceProvider.GetRequiredService<ILoggerFactory>());
@@ -73,19 +71,16 @@ namespace Microsoft.Azure.SignalR.Management
                 .Add(servicesFromServiceManager)
                 //Allow chained call serviceHubContext.WithEndpoints(...).WithEndpoints(...)
                 .AddSingleton(servicesFromServiceManager)
-
                 //add factory method
                 .AddHub(_hubName)
-
                 //overwrite container
                 .AddSingleton<IServiceConnectionContainer>(container)
-
                 //add required service instances
                 .AddSingleton(ServiceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>())
                 .AddSingleton(_negotiateProcessor)
                 .AddSingleton(_endpointManager);
-                return services.BuildServiceProvider()
-                .GetRequiredService<ServiceHubContext>();
+
+            return services.BuildServiceProvider().GetRequiredService<ServiceHubContext>();
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.SignalR.Management
 
         public async Task<IServiceHubContext> CreateHubContextAsync(string hubName, ILoggerFactory loggerFactory = null, CancellationToken cancellationToken = default)
         {
-            var servicesPerHub = new ServiceCollection().Add(_services).AddHub(hubName);
+            var servicesPerHub = new ServiceCollection().Add(_services).AddSingleton(_services).AddHub(hubName);
             if (loggerFactory != null)
             {
                 servicesPerHub.AddSingleton(loggerFactory);


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - Add services from `ServiceManager` to the `ServiceHubContext` created from `ServiceHubContext.WithEndpoints()` , rather than `AddSignalR().Services`, so that we can specify `IHubProtocol` instead of the default protocol added by `AddSignalR()` when create `ServiceManager`.

### Reason
Azure Function runtime v3 uses .Net framework version higher than Net Core 3.0, which uses System.Text.Json instead of Newtonsoft.Json as the default Json protocol of SignalR. To make our function extension compatible with Azure Function v2 and v3, function extension will use Newtonsoft.Json as the SignalR protocol.
