### PR TITLE
Ignoring connection string from environment

### DIFF
--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/HotReloadIntegrationTestStartup.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/HotReloadIntegrationTestStartup.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
                     //todo: move to params
                     o.ServiceScaleTimeout = TimeSpan.FromSeconds(3);
                     o.ClaimsProvider = context => new[] { new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"]) };  // todo: migrate to TParams
-                    o.ConnectionString = TestConfiguration.Instance.ConnectionString;
                     o.ApplicationName = applicationName;
                 });
 

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IntegrationTestStartup.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IntegrationTestStartup.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
                     o.GracefulShutdown.Mode = p.ShutdownMode;
                     o.Endpoints = p.ServiceEndpoints;
                     o.ClaimsProvider = context => new[] { new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"]) };  // todo: migrate to TParams
-                    o.ConnectionString = TestConfiguration.Instance.ConnectionString;
                     o.ApplicationName = applicationName;
                 });
 


### PR DESCRIPTION
Ignore connection strings from test environment (only use dummy ones hardcoded in the tests).