### PR TITLE
Refactor ServiceManager to use one endpoint from ServiceEndpointManager

### DIFF
--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             var serviceManager = services.AddSingleton(services.ToList() as IReadOnlyCollection<ServiceDescriptor>)
                 .BuildServiceProvider()
                 .GetRequiredService<IServiceManager>();
-            
+
             var actual = await serviceManager.IsServiceHealthy(default);
 
             Assert.True(actual);
@@ -175,14 +175,9 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         }
 
         [Fact]
-        public void ConnectionString_Only_Test()
+        public void ConnectionStringAbsent_Throw_Test()
         {
-            var serviceManager = new ServiceManagerBuilder().WithOptions(o =>
-            {
-                o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
-            }).Build();
-            Assert.NotNull(serviceManager.GetClientEndpoint(HubName));
-            Assert.NotNull(serviceManager.GenerateClientAccessToken(HubName));
+            Assert.Throws<InvalidOperationException>(() => new ServiceManagerBuilder().Build());
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -175,15 +175,14 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         }
 
         [Fact]
-        public async Task ConnectionStringNull_ServiceEndpointsExists_Test()
+        public void ConnectionString_Only_Test()
         {
             var serviceManager = new ServiceManagerBuilder().WithOptions(o =>
             {
-                o.ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray();
+                o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
             }).Build();
-            Assert.Throws<InvalidOperationException>(() => serviceManager.GetClientEndpoint(HubName));
-            Assert.Throws<InvalidOperationException>(() => serviceManager.GenerateClientAccessToken(HubName));
-            await Assert.ThrowsAsync<InvalidOperationException>(() => serviceManager.IsServiceHealthy(default));
+            Assert.NotNull(serviceManager.GetClientEndpoint(HubName));
+            Assert.NotNull(serviceManager.GenerateClientAccessToken(HubName));
         }
     }
 }


### PR DESCRIPTION
So that the behavior with only one endpoint configured is not changed, and the code simplified.