### PR TITLE
Add ServiceHubContextBuilder

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/IInternalServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IInternalServiceHubContext.cs
@@ -2,20 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Connections;
 
 namespace Microsoft.Azure.SignalR.Management
 {
     internal interface IInternalServiceHubContext : IServiceHubContext
     {
-        /// <summary>
-        /// Gets client endpoint access information object for SignalR hub connections to connect to Azure SignalR Service
-        /// </summary>
-        /// <returns>Client endpoint and access token to Azure SignalR Service.</returns>
-        Task<NegotiationResponse> NegotiateAsync(NegotiationOptions options = null, CancellationToken cancellationToken = default);
-
         IEnumerable<ServiceEndpoint> GetServiceEndpoints();
 
         IInternalServiceHubContext WithEndpoints(IEnumerable<ServiceEndpoint> endpoints);

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal abstract class ServiceHubContext : IServiceHubContext
+    {
+        /// <summary>
+        /// Gets a user group manager instance which implements <see cref="IUserGroupManager"/> that can be used to add and remove users to named groups.
+        /// </summary>
+        public virtual IUserGroupManager UserGroups => null;
+
+        public virtual IHubClients Clients => null;
+
+        public virtual IGroupManager Groups => null;
+
+        /// <summary>
+        /// Performs a negotiation operation asynchronously that routes a client to a Azure SignalR instance.
+        /// </summary>
+        /// <returns>A negotiation response object that contains an endpoint url and an access token for the client to connect to the Azure SignalR instance. </returns>
+        public virtual Task<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default) => null;
+
+        public virtual Task DisposeAsync() => Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class ServiceHubContextBuilder
+    {
+        private readonly IServiceCollection _services;
+
+        internal ServiceHubContextBuilder(IServiceCollection services)
+        {
+            _services = services;
+        }
+
+        public ServiceHubContextBuilder() : this(new ServiceCollection())
+        {
+            _services.AddSignalRServiceManager();
+        }
+
+        private Action<IServiceCollection> _configureAction;
+
+        /// <summary>
+        /// Registers an action used to configure <see cref="IServiceManager"/>.
+        /// </summary>
+        /// <param name="configure">A callback to configure the <see cref="IServiceManager"/>.</param>
+        /// <returns>The same instance of the <see cref="ServiceManagerBuilder"/> for chaining.</returns>
+        public ServiceHubContextBuilder WithOptions(Action<ServiceManagerOptions> configure)
+        {
+            _services.Configure(configure);
+            return this;
+        }
+
+        public ServiceHubContextBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            _services.AddSingleton(loggerFactory);
+            return this;
+        }
+
+        public ServiceHubContextBuilder WithConfiguration(IConfiguration configuration)
+        {
+            _services.AddSingleton(configuration);
+            return this;
+        }
+
+        public ServiceHubContextBuilder WithRouter(IEndpointRouter router)
+        {
+            _services.AddSingleton(router);
+            return this;
+        }
+
+        /// <summary>
+        /// Provides a hook to configure services before building.
+        /// </summary>
+        internal ServiceHubContextBuilder ConfigureServices(Action<IServiceCollection> configureAction)
+        {
+            _configureAction = configureAction;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds <see cref="ServiceHubContext"/> instances.
+        /// </summary>
+        /// <returns>The instance of the <see cref="IServiceManager"/>.</returns>
+        public async Task<ServiceHubContext> CreateAsync(string hubName, CancellationToken cancellationToken)
+        {
+            //add requried services
+            var transportType = _services.BuildServiceProvider()
+                .GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ServiceTransportType;
+            _services.AddHub(hubName, transportType);
+            _configureAction?.Invoke(_services);
+            _services.AddSingleton(_services.ToList() as IReadOnlyCollection<ServiceDescriptor>);
+
+            //build
+            var serviceHubContext = _services.BuildServiceProvider()
+                .GetRequiredService<ServiceHubContextImpl>();
+
+            //initialize
+            var connectionContainer = serviceHubContext.ServiceProvider.GetService<IServiceConnectionContainer>();
+            if (connectionContainer != null)
+            {
+                await connectionContainer.ConnectionInitializedTask.OrTimeout(cancellationToken);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await serviceHubContext?.DisposeAsync();
+                return null;
+            }
+            return serviceHubContext.ServiceProvider.GetRequiredService<ServiceHubContextImpl>();
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    internal class ServiceHubContextImpl : IInternalServiceHubContext
+    internal class ServiceHubContextImpl : ServiceHubContext, IInternalServiceHubContext
     {
         private readonly string _hubName;
         private readonly IHubContext<Hub> _hubContext;
@@ -25,11 +25,11 @@ namespace Microsoft.Azure.SignalR.Management
 
         internal IServiceProvider ServiceProvider { get; }
 
-        public IHubClients Clients => _hubContext.Clients;
+        public override IHubClients Clients => _hubContext.Clients;
 
-        public IGroupManager Groups => _hubContext.Groups;
+        public override IGroupManager Groups => _hubContext.Groups;
 
-        public IUserGroupManager UserGroups { get; }
+        public override IUserGroupManager UserGroups { get; }
 
         public ServiceHubContextImpl(string hubName, IHubContext<Hub> hubContext, IServiceHubLifetimeManager lifetimeManager, IServiceProvider serviceProvider, NegotiateProcessor negotiateProcessor, IServiceEndpointManager endpointManager)
         {
@@ -42,14 +42,14 @@ namespace Microsoft.Azure.SignalR.Management
             _endpointManager = endpointManager;
         }
 
-        Task<NegotiationResponse> IInternalServiceHubContext.NegotiateAsync(NegotiationOptions options, CancellationToken cancellationToken)
+        public override Task<NegotiationResponse> NegotiateAsync(NegotiationOptions options, CancellationToken cancellationToken)
         {
             return _negotiateProcessor.NegotiateAsync(_hubName, options, cancellationToken);
         }
 
         IEnumerable<ServiceEndpoint> IInternalServiceHubContext.GetServiceEndpoints() => _endpointManager.GetEndpoints(_hubName);
 
-        public async Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
             await _lifetimeManager.DisposeAsync();
             (ServiceProvider as IDisposable)?.Dispose();

--- a/test/Microsoft.Azure.SignalR.E2ETests/Management/NegotiateProcessorE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Management/NegotiateProcessorE2EFacts.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.SignalR.Management.E2ETests
             //reduce the effect of randomness
             for (int i = 0; i < 5; i++)
             {
-                var clientEndoint = await (hubContext as IInternalServiceHubContext).NegotiateAsync();
+                var clientEndoint = await (hubContext as ServiceHubContext).NegotiateAsync();
                 var expectedUrl = ClientEndpointUtils.GetExpectedClientEndpoint(hubName, null, realEndpoint);
                 Assert.Equal(expectedUrl, clientEndoint.Url);
             }


### PR DESCRIPTION
* `ServiceManager` uses `ServiceHubContextBuilder` to build `ServiceHubContext`.
* Move `NegotiateAsync` method from `IInternalServiceHubContext` to `ServiceHubContext` abstract class.