### PR TITLE
Add always reconnect logic

### DIFF
--- a/samples/ChatSample/ChatSample.Net50/ChatSample.Net50.csproj
+++ b/samples/ChatSample/ChatSample.Net50/ChatSample.Net50.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net5.0</TargetFramework>
+      <UserSecretsId>ChatSample.Net50</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ChatSample/ChatSample.Net50/wwwroot/index.html
+++ b/samples/ChatSample/ChatSample.Net50/wwwroot/index.html
@@ -153,7 +153,7 @@
 
             function onConnectionError(error) {
                 if (error && error.message) {
-                    console.error(error.message);
+                    console.warn(error.message);
                     var modal = document.getElementById('myModal');
                 } else {
                     var modal = document.getElementById('closeModal');
@@ -162,19 +162,27 @@
                 modal.style = 'display: block;';
             }
 
+            function getRandom(min, max) {
+                return Math.floor(Math.random() * (max - min + 1) + min);
+            }
+
             var connection = new signalR.HubConnectionBuilder()
-                        .withUrl('/chat')
-                        .withAutomaticReconnect()
-                        .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
-                        .build();
-                            
+                .withUrl('/chat')
+                .withAutomaticReconnect({
+                    nextRetryDelayInMilliseconds: function (retryContext) {
+                        return getRandom(2000, 5000); // always retry
+                    }
+                })
+                .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
+                .build();
+
             bindConnectionMessage(connection);
             connection.start()
                 .then(function () {
                     onConnected(connection);
                 })
                 .catch(function (error) {
-                    console.error(error.message);
+                    console.warn(error);
                 });
         });
     </script>


### PR DESCRIPTION
The default retry policy for aspnet.core signalr using `withAutomaticReconnect` is :
> SignalR will try and reconnect immediately, then 2 seconds later, then again after 10 seconds and then after 30 seconds. At that time, if the connection could still not be reestablished, it will stop trying to reconnect:

When using Azure SignalR, we would suggest clients always reconnect to the service as a common practice.