### PR TITLE
support user-assigned managed identity

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Auth/AadManagedIdentityOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Auth/AadManagedIdentityOptions.cs
@@ -5,12 +5,27 @@ namespace Microsoft.Azure.SignalR
 {
     internal class AadManagedIdentityOptions : AuthOptions, IAadTokenGenerator
     {
+        private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
+
         internal override string AuthType => "ManagedIdentity";
+
+        internal ManagedIdentityType ManagedIdentityType { get; }
+
+        public AadManagedIdentityOptions()
+        {
+            _azureServiceTokenProvider = new AzureServiceTokenProvider("RunAs=App", AzureActiveDirectoryInstance);
+            ManagedIdentityType = ManagedIdentityType.System;
+        }
+
+        public AadManagedIdentityOptions(string clientId)
+        {
+            _azureServiceTokenProvider = new AzureServiceTokenProvider($"RunAs=App;AppId={clientId}", AzureActiveDirectoryInstance);
+            ManagedIdentityType = ManagedIdentityType.UserAssigned;
+        }
 
         public override async Task<string> AcquireAccessToken()
         {
-            var azureServiceTokenProvider = new AzureServiceTokenProvider(azureAdInstance: AzureActiveDirectoryInstance);
-            return await azureServiceTokenProvider.GetAccessTokenAsync(Audience);
+            return await _azureServiceTokenProvider.GetAccessTokenAsync(Audience);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Auth/ManagedIdentityType.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Auth/ManagedIdentityType.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Azure.SignalR
+{
+    internal enum ManagedIdentityType
+    {
+        None,
+        System,
+        UserAssigned,
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth
@@ -10,19 +12,38 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         private const string TestTenantId = "";
 
         private const string TestEndpoint = "http://localhost";
-        private int? TestPort = 8080;
+        private readonly int? TestPort = 8080;
 
         [Fact]
-        public void TestConsturctor()
+        internal void TestConsturctor()
         {
             var key = new AccessKey("abcde", TestEndpoint, TestPort);
             Assert.NotNull(key.Id);
+            Assert.NotNull(key.Value);
         }
 
         [Fact]
-        public void TestConstructorForAad()
+        internal void TestConstructorForAadApplication()
         {
-            var key = new AadAccessKey(new AadManagedIdentityOptions(), TestEndpoint, TestPort);
+            var clientId = Guid.NewGuid().ToString();
+            var tenantId = Guid.NewGuid().ToString();
+            var options = new AadApplicationOptions(clientId, tenantId);
+            var key = new AadAccessKey(options, TestEndpoint, TestPort);
+            Assert.IsAssignableFrom<AccessKey>(key);
+            Assert.False(key.Authorized);
+            Assert.Null(key.Id);
+            Assert.Null(key.Value);
+        }
+
+        [Theory]
+        [InlineData(null, ManagedIdentityType.System)]
+        [InlineData("foo", ManagedIdentityType.UserAssigned)]
+        internal void TestConstructorForAadManagedIdeneity(string clientId, ManagedIdentityType expectedType)
+        {
+            var options = clientId == null ? new AadManagedIdentityOptions() : new AadManagedIdentityOptions(clientId);
+            Assert.Equal(expectedType, options.ManagedIdentityType);
+
+            var key = new AadAccessKey(options, TestEndpoint, TestPort);
             Assert.IsAssignableFrom<AccessKey>(key);
             Assert.False(key.Authorized);
             Assert.Null(key.Id);
@@ -30,7 +51,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         }
 
         [Fact(Skip ="Provide valid aad options")]
-        public async Task TestAuthenticateAsync()
+        internal async Task TestAuthenticateAsync()
         {
             var options = new AadApplicationOptions(TestClientId, TestTenantId).WithClientSecret(TestClientSecret);
             var key = new AadAccessKey(options, TestEndpoint, TestPort);


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
- Add support for user-assigned managed identity

#### Usage

To choose one of the user-assigned managed identity:

```text
Endpoint={endpoint};AuthType=aad;ClientId={ClientId of user-assigned identity}
```

> There is no need to provide **TenantId** according to this [link](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication)

Doc changes are on the way : )

Fixes:

Issue #1237 