### PR TITLE
add new serivce events: BufferFull

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/enums.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/enums.cs
@@ -45,8 +45,8 @@
         /// </summary>
         NotExisted,
         /// <summary>
-        /// The overload-protecting event.
+        /// The buffer-full event.
         /// </summary>
-        OverloadProtecting,
+        BufferFull,
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/enums.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/enums.cs
@@ -45,7 +45,7 @@
         /// </summary>
         NotExisted,
         /// <summary>
-        /// The buffer-full event. Normally it caused by sending messages rapidly.
+        /// The buffer-full event. When the server is sending too many messages at the same time, the service would back-pressure the messages to the server-side and also trigger this `BufferFull` event.
         /// </summary>
         BufferFull,
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/enums.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/enums.cs
@@ -45,7 +45,7 @@
         /// </summary>
         NotExisted,
         /// <summary>
-        /// The buffer-full event.
+        /// The buffer-full event. Normally it caused by sending messages rapidly.
         /// </summary>
         BufferFull,
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/enums.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/enums.cs
@@ -21,6 +21,10 @@
         /// The group.
         /// </summary>
         Group,
+        /// <summary>
+        /// The server connection.
+        /// </summary>
+        ServerConnection,
     }
 
     /// <summary>
@@ -40,5 +44,9 @@
         /// The id is not existed.
         /// </summary>
         NotExisted,
+        /// <summary>
+        /// The overload-protecting event.
+        /// </summary>
+        OverloadProtecting,
     }
 }


### PR DESCRIPTION
When hub servers try to send too many messages, service side will throttle the message sending, it will keep sending messages in a reasonable rate.
We add the `OverloadProtecting` event to notify app server, app server can hook it, and decrease the rate of message sending to avoid OOM in app server side.