### PR TITLE
Remove unused code

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -69,13 +69,6 @@ namespace Microsoft.Azure.SignalR.Management
             return this;
         }
 
-        internal ServiceHubContextBuilder WithCallingAssembly()
-        {
-            var assembly = Assembly.GetCallingAssembly();
-            _services.WithAssembly(assembly);
-            return this;
-        }
-
         /// <summary>
         /// Builds <see cref="ServiceHubContext"/> instances.
         /// </summary>


### PR DESCRIPTION
SignalR Function extensions project doesn't use it anymore. `AddSignalRServiceManager()` sets a default product info.
`ServiceHubContextBuilder.WithCallingAssembly()` is never used