### PR TITLE
Add `EnableDetailedErrors` flag to the `ServiceHubContext` negotiate options

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/Negotiation/NegotiateProcessor.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Negotiation/NegotiateProcessor.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
             var userId = negotiationOptions.UserId;
             var claims = negotiationOptions.Claims;
             var isDiagnosticClient = negotiationOptions.IsDiagnosticClient;
+            var enableDetailedErrors = negotiationOptions.EnableDetailedErrors;
             var lifetime = negotiationOptions.TokenLifetime;
             try
             {
@@ -49,7 +50,7 @@ namespace Microsoft.Azure.SignalR.Management
                 {
                     claimProvider = () => claims;
                 }
-                var claimsWithUserId = ClaimsUtility.BuildJwtClaims(httpContext?.User, userId: userId, claimProvider, isDiagnosticClient: isDiagnosticClient);
+                var claimsWithUserId = ClaimsUtility.BuildJwtClaims(httpContext?.User, userId: userId, claimProvider, enableDetailedErrors: enableDetailedErrors, isDiagnosticClient: isDiagnosticClient);
 
                 var tokenTask = provider.GenerateClientAccessTokenAsync(hubName, claimsWithUserId, lifetime);
                 await tokenTask.OrTimeout(cancellationToken, Timeout, GeneratingTokenTaskDescription);

--- a/src/Microsoft.Azure.SignalR.Management/Negotiation/NegotiationOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Negotiation/NegotiationOptions.cs
@@ -37,5 +37,10 @@ namespace Microsoft.Azure.SignalR.Management
         /// Gets or sets the flag indicates whether the client is a diagnostic client.
         /// </summary>
         public bool IsDiagnosticClient { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the flag indicates whether detailed errors are logged in the client side.
+        /// </summary>
+        public bool EnableDetailedErrors { get; set; } = false;
     }
 }


### PR DESCRIPTION
So that when close connection from app server side, client can see the error msg.