### PR TITLE
Add a unified way to customize JSON serialization for Newtonsoft

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -47,6 +47,8 @@
     <MicrosoftConfigurationUserSecretVersion>2.2.0</MicrosoftConfigurationUserSecretVersion>
     <MicrosoftConfigurationEnvironmentVariablesVersion>2.2.0</MicrosoftConfigurationEnvironmentVariablesVersion>
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>1.0.11</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
+    <MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson3_0Version>3.0.0</MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson3_0Version>
+    <MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson5_0Version>5.0.1</MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson5_0Version>
 
     <!-- Signing -->
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// </summary>
         public ServiceTransportType ServiceTransportType { get; set; } = ServiceTransportType.Transient;
 
+        // TODO: make obsolete once `ServiceHubContextBuilder.WithNewtonsoftJsonHubProtocol()` are public.
         /// <summary>
         /// Gets the json serializer settings that will be used to serialize content sent to Azure SignalR Service.
         /// </summary>

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -33,10 +33,12 @@ namespace Microsoft.Azure.SignalR.Management
                     }
                 case ServiceTransportType.Transient:
                     {
-                        var newtonsoftServiceHubProtocolOptions = _serviceProvider.GetService<IOptions<NewtonsoftServiceHubProtocolOptions>>();
+                        var restHubProtocol = _serviceProvider.GetService<IRestHubProtocol>();
                         var payloadSerializerSettings = _options.JsonSerializerSettings;
-                        if (newtonsoftServiceHubProtocolOptions != null)
+                        //Currently RestHubProtocol only has Newtonsoft
+                        if (restHubProtocol != null)
                         {
+                            var newtonsoftServiceHubProtocolOptions = _serviceProvider.GetService<IOptions<NewtonsoftServiceHubProtocolOptions>>();
                             payloadSerializerSettings = newtonsoftServiceHubProtocolOptions.Value.PayloadSerializerSettings;
                         }
                         return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName, payloadSerializerSettings);

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Linq;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -34,7 +33,13 @@ namespace Microsoft.Azure.SignalR.Management
                     }
                 case ServiceTransportType.Transient:
                     {
-                        return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName, _options.JsonSerializerSettings);
+                        var newtonsoftServiceHubProtocolOptions = _serviceProvider.GetService<IOptions<NewtonsoftServiceHubProtocolOptions>>();
+                        var payloadSerializerSettings = _options.JsonSerializerSettings;
+                        if (newtonsoftServiceHubProtocolOptions != null)
+                        {
+                            payloadSerializerSettings = newtonsoftServiceHubProtocolOptions.Value.PayloadSerializerSettings;
+                        }
+                        return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName, payloadSerializerSettings);
                     }
                 default: throw new InvalidEnumArgumentException(nameof(ServiceManagerOptions.ServiceTransportType), (int)_options.ServiceTransportType, typeof(ServiceTransportType));
             }

--- a/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
+++ b/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
@@ -29,9 +29,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="$(MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson5_0Version)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="$(MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson3_0Version)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/IRestHubProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/IRestHubProtocol.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal interface IRestHubProtocol
+    {
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/JsonHubProtocolOptionsSetup.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/JsonHubProtocolOptionsSetup.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if NETSTANDARD2_0
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class JsonHubProtocolOptionsSetup : IConfigureOptions<JsonHubProtocolOptions>
+    {
+        private readonly IOptions<NewtonsoftServiceHubProtocolOptions> _srcOptions;
+
+        public JsonHubProtocolOptionsSetup(IOptions<NewtonsoftServiceHubProtocolOptions> srcOptions)
+        {
+            _srcOptions = srcOptions;
+        }
+
+        public void Configure(JsonHubProtocolOptions options)
+        {
+            options.PayloadSerializerSettings = _srcOptions.Value.PayloadSerializerSettings;
+        }
+    }
+}
+#endif

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftHubProtocolOptionsSetup.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftHubProtocolOptionsSetup.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETCOREAPP3_0_OR_GREATER
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    /// <summary>
+    /// An options setup class used to convert our own <see cref="NewtonsoftServiceHubProtocolOptions"/> to Asp.Net Core <see cref="NewtonsoftJsonHubProtocolOptions"/>
+    /// </summary>
+    internal class NewtonsoftHubProtocolOptionsSetup : IConfigureOptions<NewtonsoftJsonHubProtocolOptions>
+    {
+        private readonly IOptions<NewtonsoftServiceHubProtocolOptions> _srcOptions;
+
+        public NewtonsoftHubProtocolOptionsSetup(IOptions<NewtonsoftServiceHubProtocolOptions> options)
+        {
+            _srcOptions = options;
+        }
+
+        public void Configure(NewtonsoftJsonHubProtocolOptions options)
+        {
+            options.PayloadSerializerSettings = _srcOptions.Value.PayloadSerializerSettings;
+        }
+    }
+}
+#endif

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftRestHubProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftRestHubProtocol.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class NewtonsoftRestHubProtocol : IRestHubProtocol
+    {
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    public class NewtonsoftServiceHubProtocolOptions
+    internal class NewtonsoftServiceHubProtocolOptions
     {
         /// <summary>
         /// Gets or sets the settings used to serialize invocation arguments and return values.

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// <summary>
         /// Gets or sets the settings used to serialize invocation arguments and return values.
         /// </summary>
-        public JsonSerializerSettings PayloadSerializerSettings { get; } = new()
+        public JsonSerializerSettings PayloadSerializerSettings { get; set; } = new()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR.Management
         /// <summary>
         /// Gets or sets the settings used to serialize invocation arguments and return values.
         /// </summary>
-        public JsonSerializerSettings PayloadSerializerSettings = new()
+        public JsonSerializerSettings PayloadSerializerSettings { get; } = new()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/NewtonsoftServiceHubProtocolOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    public class NewtonsoftServiceHubProtocolOptions
+    {
+        /// <summary>
+        /// Gets or sets the settings used to serialize invocation arguments and return values.
+        /// </summary>
+        public JsonSerializerSettings PayloadSerializerSettings = new()
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.SignalR.Management
         public static IServiceCollection AddNewtonsoftHubProtocol(this IServiceCollection services, Action<IOptions<NewtonsoftServiceHubProtocolOptions>> configure)
         {
             services.Configure(configure);
-
+            
             // for persistent transport type only:
 #if NETCOREAPP3_0_OR_GREATER
             services.AddSingleton<IHubProtocol, NewtonsoftJsonHubProtocol>();
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.SignalR.Management
             services.ConfigureOptions<JsonHubProtocolOptionsSetup>();
 #endif
 
+            // for transient transport type only:
+            services.AddSingleton<IRestHubProtocol, NewtonsoftRestHubProtocol>();
             return services;
         }
     }

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.SignalR.Management
 {
     internal static class SerializationDependencyInjectionExtensions
     {
-        public static IServiceCollection AddNewtonsoftHubProtocol(this IServiceCollection services, Action<IOptions<NewtonsoftServiceHubProtocolOptions>> configure)
+        public static IServiceCollection AddNewtonsoftHubProtocol(this IServiceCollection services, Action<NewtonsoftServiceHubProtocolOptions> configure)
         {
             services.Configure(configure);
             

--- a/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Serialization/SerializationDependencyInjectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal static class SerializationDependencyInjectionExtensions
+    {
+        public static IServiceCollection AddNewtonsoftHubProtocol(this IServiceCollection services, Action<IOptions<NewtonsoftServiceHubProtocolOptions>> configure)
+        {
+            services.Configure(configure);
+
+            // for persistent transport type only:
+#if NETCOREAPP3_0_OR_GREATER
+            services.AddSingleton<IHubProtocol, NewtonsoftJsonHubProtocol>();
+            services.ConfigureOptions<NewtonsoftHubProtocolOptionsSetup>();
+#endif
+#if NETSTANDARD2_0
+            services.ConfigureOptions<JsonHubProtocolOptionsSetup>();
+#endif
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Azure.SignalR.Management
             return this;
         }
 
+        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol()
+        {
+            return WithNewtonsoftJsonHubProtocol(o => { });
+        }
+
         /// <summary>
         /// Provides a hook to configure services before building.
         /// </summary>

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -60,6 +60,12 @@ namespace Microsoft.Azure.SignalR.Management
             return this;
         }
 
+        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol(Action<IOptions<NewtonsoftServiceHubProtocolOptions>> configure)
+        {
+            _services.AddNewtonsoftHubProtocol(configure);
+            return this;
+        }
+
         /// <summary>
         /// Provides a hook to configure services before building.
         /// </summary>

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.SignalR.Management
             return this;
         }
 
-        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol(Action<IOptions<NewtonsoftServiceHubProtocolOptions>> configure)
+        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol(Action<NewtonsoftServiceHubProtocolOptions> configure)
         {
             _services.AddNewtonsoftHubProtocol(configure);
             return this;


### PR DESCRIPTION
`_serviceProvider.GetService<IOptions<NewtonsoftServiceHubProtocolOptions>>()` is always not null, so it is wrong to use it to determine whether `ServiceHubContextBuilder.AddNewtonsoftJsonHubProtocol()` is called.