### PR TITLE
Server connection does not block on client connection lifetime

### DIFF
--- a/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ClientConnectionContext.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Azure.SignalR
 
         private readonly TaskCompletionSource<object> _connectionEndTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly CancellationTokenSource _abortOutgoingCts = new CancellationTokenSource();
-        private readonly CancellationTokenSource _abortApplicationCts = new CancellationTokenSource();
 
         private int _connectionState = IdleState;
 
@@ -108,8 +107,6 @@ namespace Microsoft.Azure.SignalR
         public HttpContext HttpContext { get; set; }
 
         public CancellationToken OutgoingAborted => _abortOutgoingCts.Token;
-
-        public CancellationToken ApplicationAborted => _abortApplicationCts.Token;
 
         public DateTime LastMessageReceivedAtUtc => new DateTime(Volatile.Read(ref _lastMessageReceivedAt), DateTimeKind.Utc);
 
@@ -234,21 +231,6 @@ namespace Microsoft.Azure.SignalR
             else
             {
                 _abortOutgoingCts.CancelAfter(millisecondsDelay);
-            }
-        }
-
-        /// <summary>
-        /// Cancel the application task
-        /// </summary>
-        public void CancelApplication(int millisecondsDelay = 0)
-        {
-            if (millisecondsDelay <= 0)
-            {
-                _abortApplicationCts.Cancel();
-            }
-            else
-            {
-                _abortApplicationCts.CancelAfter(millisecondsDelay);
             }
         }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
@@ -75,6 +75,15 @@ namespace Microsoft.Azure.SignalR
             private static readonly Action<ILogger, int, string, Exception> _closingClientConnections =
                 LoggerMessage.Define<int, string>(LogLevel.Information, new EventId(25, "ClosingClientConnections"), "Closing {ClientCount} client connection(s) for server connection {ServerConnectionId}.");
 
+
+            private static readonly Action<ILogger, string, Exception> _detectedLongRunningApplicationTask =
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(26, "DetectedLongRunningApplicationTask"), "The connection {TransportConnectionId} has a long running application logic that prevents the connection from complete.");
+
+            public static void DetectedLongRunningApplicationTask(ILogger logger, string connectionId)
+            {
+                _detectedLongRunningApplicationTask(logger, connectionId, null);
+            }
+
             public static void WaitingForTransport(ILogger logger)
             {
                 _waitingForTransport(logger, null);

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
 
                 // since the service connection ends, the client connection is cleaned up from the collection...
-                Assert.Single(ccm.ClientConnections);
+                Assert.Empty(ccm.ClientConnections);
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -194,13 +194,15 @@ namespace Microsoft.Azure.SignalR.Tests
         }
 
         [Fact]
-        public async Task TestServiceConnectionWithEndlessApplicationTask()
+        public async Task TestServiceConnectionWithEndlessApplicationTaskNeverEnds()
         {
+            var clientConnectionId = Guid.NewGuid().ToString();
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
                 logChecker: logs =>
                 {
                     Assert.Single(logs);
-                    Assert.Equal("ApplicationTaskFailed", logs[0].Write.EventId.Name);
+                    Assert.Equal("DetectedLongRunningApplicationTask", logs[0].Write.EventId.Name);
+                    Assert.Equal($"The connection {clientConnectionId} has a long running application logic that prevents the connection from complete.", logs[0].Write.Message);
                     return true;
                 }))
             {
@@ -221,14 +223,13 @@ namespace Microsoft.Azure.SignalR.Tests
                 ConnectionDelegate handler = builder.Build();
                 var connection = new ServiceConnection(protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
                     "serverId", Guid.NewGuid().ToString("N"),
-                    null, null, null, closeTimeOutMilliseconds: 1000);
+                    null, null, null, closeTimeOutMilliseconds: 1);
 
                 var connectionTask = connection.StartAsync();
 
                 // completed handshake
                 await connection.ConnectionInitializedTask.OrTimeout();
                 Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
-                var clientConnectionId = Guid.NewGuid().ToString();
 
                 await transportConnection.Application.Output.WriteAsync(
                     protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, new Claim[] { })));
@@ -238,14 +239,15 @@ namespace Microsoft.Azure.SignalR.Tests
                 // complete reading to end the connection
                 transportConnection.Application.Output.Complete();
 
-                await clientConnection.LifetimeTask.OrTimeout();
+                // Assert timeout
+                var lifetime = clientConnection.LifetimeTask;
+                var task = await Task.WhenAny(lifetime, Task.Delay(1000));
+                Assert.NotEqual(lifetime, task);
 
-                // 500ms for application task to timeout
-                await connectionTask.OrTimeout(1000);
                 Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
-                Assert.Empty(ccm.ClientConnections);
 
-                connectionHandler.CancellationToken.Cancel();
+                // since the service connection ends, the client connection is cleaned up from the collection...
+                Assert.Single(ccm.ClientConnections);
             }
         }
 
@@ -255,9 +257,8 @@ namespace Microsoft.Azure.SignalR.Tests
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
                 logChecker: logs =>
                 {
-                    Assert.Equal(2, logs.Count);
+                    Assert.Single(logs);
                     Assert.Equal("SendLoopStopped", logs[0].Write.EventId.Name);
-                    Assert.Equal("ApplicationTaskFailed", logs[1].Write.EventId.Name);
                     return true;
                 }))
             {
@@ -294,6 +295,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
                 clientConnection.CancelOutgoing();
 
+                connectionHandler.CancellationToken.Cancel();
                 await clientConnection.LifetimeTask.OrTimeout();
 
                 // complete reading to end the connection
@@ -303,8 +305,6 @@ namespace Microsoft.Azure.SignalR.Tests
                 await connectionTask.OrTimeout(1000);
                 Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
                 Assert.Empty(ccm.ClientConnections);
-
-                connectionHandler.CancellationToken.Cancel();
             }
         }
 
@@ -436,8 +436,7 @@ namespace Microsoft.Azure.SignalR.Tests
             using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
                 logChecker: logs =>
                 {
-                    Assert.Single(logs);
-                    Assert.Equal("ApplicationTaskFailed", logs[0].Write.EventId.Name);
+                    Assert.Empty(logs);
                     return true;
                 }))
             {
@@ -451,6 +450,7 @@ namespace Microsoft.Azure.SignalR.Tests
                     return Task.CompletedTask;
                 });
                 var services = new ServiceCollection();
+
                 var connectionHandler = new EndlessConnectionHandler();
                 services.AddSingleton(connectionHandler);
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
@@ -471,10 +471,10 @@ namespace Microsoft.Azure.SignalR.Tests
 
                 var clientConnection = await ccm.WaitForClientConnectionAsync(clientConnectionId).OrTimeout();
 
-                clientConnection.CancelApplication();
-
                 // complete reading to end the connection
                 transportConnection.Application.Output.Complete();
+
+                connectionHandler.CancellationToken.Cancel();
 
                 await clientConnection.LifetimeTask.OrTimeout();
 
@@ -482,8 +482,6 @@ namespace Microsoft.Azure.SignalR.Tests
                 await connectionTask.OrTimeout(1000);
                 Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
                 Assert.Empty(ccm.ClientConnections);
-
-                connectionHandler.CancellationToken.Cancel();
             }
         }
 
@@ -491,7 +489,9 @@ namespace Microsoft.Azure.SignalR.Tests
         public async Task TestServiceConnectionForMigratedIn()
         {
             var factory = new TestClientConnectionFactory();
-            var connection = MockServiceConnection(null, factory);
+
+            CancellationTokenSource cts = new();
+            var connection = MockServiceConnection(cts, null, factory);
 
             // create a connection with migration header.
             await connection.OnClientConnectedAsyncForTest(new OpenConnectionMessage("foo", new Claim[0])
@@ -526,7 +526,8 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             var factory = new TestClientConnectionFactory();
 
-            var connection = MockServiceConnection(null, factory, mode: GracefulShutdownMode.MigrateClients);
+            CancellationTokenSource cts = new();
+            var connection = MockServiceConnection(cts, null, factory, mode: GracefulShutdownMode.MigrateClients);
 
             // create a connection with migration header.
             await connection.OnClientConnectedAsyncForTest(new OpenConnectionMessage("foo", new Claim[0]));
@@ -536,11 +537,14 @@ namespace Microsoft.Azure.SignalR.Tests
             var closeMessage = new CloseConnectionMessage(context.ConnectionId);
             closeMessage.Headers.Add(Constants.AsrsMigrateTo, "another-server");
 
-            await connection.OnClientDisconnectedAsyncForTest(closeMessage);
+            var disconnect = connection.OnClientDisconnectedAsyncForTest(closeMessage);
 
             var feature = context.Features.Get<IConnectionMigrationFeature>();
             Assert.NotNull(feature);
             Assert.Equal("another-server", feature.MigrateTo);
+
+            cts.Cancel();
+            await disconnect.OrTimeout();
         }
 
         private sealed class TestConnectionHandler : ConnectionHandler
@@ -606,7 +610,7 @@ namespace Microsoft.Azure.SignalR.Tests
             }
         }
 
-        private TestServiceConnection MockServiceConnection(IConnectionFactory serviceConnectionFactory = null,
+        private TestServiceConnection MockServiceConnection(CancellationTokenSource cts, IConnectionFactory serviceConnectionFactory = null,
                                                             IClientConnectionFactory clientConnectionFactory = null,
                                                             ILoggerFactory loggerFactory = null,
                                                             GracefulShutdownMode mode = GracefulShutdownMode.Off)
@@ -616,7 +620,7 @@ namespace Microsoft.Azure.SignalR.Tests
             loggerFactory ??= NullLoggerFactory.Instance;
 
             var services = new ServiceCollection();
-            var connectionHandler = new EndlessConnectionHandler();
+            var connectionHandler = new EndlessConnectionHandler(cts);
             services.AddSingleton(connectionHandler);
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<EndlessConnectionHandler>();
@@ -648,13 +652,22 @@ namespace Microsoft.Azure.SignalR.Tests
 
         private sealed class EndlessConnectionHandler : ConnectionHandler
         {
-            public CancellationTokenSource CancellationToken { get; } = new CancellationTokenSource();
+            public CancellationTokenSource CancellationToken { get; }
 
+            public EndlessConnectionHandler()
+            {
+                CancellationToken = new CancellationTokenSource();
+            }
+
+            public EndlessConnectionHandler(CancellationTokenSource token)
+            {
+                CancellationToken = token;
+            }
             public override async Task OnConnectedAsync(ConnectionContext connection)
             {
                 while (!CancellationToken.IsCancellationRequested)
                 {
-                    await Task.Delay(1000);
+                    await Task.Delay(100);
                 }
             }
         }


### PR DESCRIPTION
To solve the issue described here https://github.com/Azure/azure-signalr/issues/1318, to be consistent with self-host SignalR, our SDK should not timeout on long-run client hub logic.

Why we have this timeout is because the client connection lifetime impacts the auto-reconnect of the server connection. When a server connection drops, it first cleans up all the existing client connections, waiting for the client connections to complete their lifetime, and then restart another server connection. If there is some malformed code inside one client hub, it can impact the whole stability of the server connection if there is no timeout.

Server connection, can be considered as the transport layer to carry traffics for some mapped client connections. Server connection drops, similar to network issues, should not terminate the client hub application logic. If the client hub logic depends on the transport layer, the client hub logic can determine if it throws or continue. Considering this, we change the server-connection cleanup logic to not blocked by client lifetime.