### PR TITLE
work-around fix for connection migration

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/Internal/WebSocketsTransport.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/Internal/WebSocketsTransport.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Azure.SignalR.Connections.Client.Internal
 {

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -151,8 +151,9 @@ namespace Microsoft.Azure.SignalR
                 {
                     context.Features.Set<IConnectionMigrationFeature>(new ConnectionMigrationFeature(ServerId, to));
                     // We have to prevent SignalR `{type: 7}` (close message) from reaching our client while doing migration.
-                    // Since all user-created messages will be sent to `ServiceConnection` directly.
+                    // Since all data messages will be sent to `ServiceConnection` directly.
                     // We can simply ignore all messages came from the application pipe.
+                    context.Application.Input.CancelPendingRead();
                 }
             }
 


### PR DESCRIPTION
The code is for intercepting `CloseMessage` to prevent the message from reaching the client before it has been logically migrated. (There is a short time period that the client connection belongs to 2 servers so we cannot simply ignore messages from the old server)

It was accidentally applied for all scenarios while doing code refactor.
#814 

And has finally been removed in the following PR to fix another issue.
#986 

Since it is a little tricky to have this logic in the server SDK, we decided to move this interceptor into our service.
So it's a work-around fix.