### PR TITLE
Copy functions from `ServiceHubContextBuilder`  to `ServiceManagerBuilder`

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerBuilder.cs
@@ -145,9 +145,12 @@ namespace Microsoft.Azure.SignalR.Management
                 }
                 return serviceHubContext.ServiceProvider.GetRequiredService<ServiceHubContextImpl>();
             }
-            catch (Exception)
+            catch
             {
-                await serviceHubContext?.DisposeAsync();
+                if (serviceHubContext is not null)
+                {
+                    await serviceHubContext.DisposeAsync();
+                }
                 throw;
             }
         }


### PR DESCRIPTION
Prepare to merge two builder into one to reduce user migration cost.
