### PR TITLE
Refactor `ServiceHubContext` initialization

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -48,6 +48,7 @@
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>1.0.11</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
     <MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson3_0Version>3.0.0</MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson3_0Version>
     <MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson5_0Version>5.0.1</MicrosoftAspNetCoreSignalRProtocolsNewtonsoftJson5_0Version>
+    <MicrosoftExtensionsHostingVersion>2.1.0</MicrosoftExtensionsHostingVersion>
 
     <!-- Signing -->
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>

--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -38,17 +38,18 @@ namespace Microsoft.Azure.SignalR.Management
             return services.AddSignalRServiceCore();
         }
 
-        public static IServiceCollection AddHub(this IServiceCollection services, string hubName, ServiceTransportType transportType)
+
+        public static IServiceCollection AddHub(this IServiceCollection services, string hubName)
         {
-            switch (transportType)
-            {
-                case ServiceTransportType.Persistent: 
-                    services.AddSingleton<IServiceConnectionContainer>(sp => sp.GetRequiredService<MultiEndpointConnectionContainerFactory>().Connect(hubName));
-                    break;
-                case ServiceTransportType.Transient: break;
-            }
+            //for persistent
+            services.AddSingleton<IServiceConnectionContainer>(sp => sp.GetRequiredService<MultiEndpointConnectionContainerFactory>().Create(hubName))
+                .AddSingleton<ConnectionService>();
+            //for transient
+            services.AddSingleton<RestHealthCheckService>();
+
             return services
                 .AddSingleton<ServiceHubLifetimeManagerFactory>()
+                .AddSingleton(sp => ActivatorUtilities.CreateInstance<HostedServiceFactory>(sp).Create())
                 .AddSingleton(sp => sp.GetRequiredService<ServiceHubLifetimeManagerFactory>().Create(hubName))
                 .AddSingleton(sp => (HubLifetimeManager<Hub>)sp.GetRequiredService<IServiceHubLifetimeManager>())
                 .AddSingleton(sp => ActivatorUtilities.CreateInstance<ServiceHubContextImpl>(sp, hubName))

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ConnectionService.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ConnectionService.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class ConnectionService : IHostedService
+    {
+        private readonly IServiceConnectionContainer _connectionContainer;
+
+        public ConnectionService(IServiceConnectionContainer connectionContainer)
+        {
+            _connectionContainer = connectionContainer;
+        }
+
+        public async Task StartAsync(CancellationToken token)
+        {
+            _ = _connectionContainer.StartAsync();
+            await _connectionContainer.ConnectionInitializedTask.OrTimeout(token, TimeSpan.FromMinutes(1), "establishing service connections");
+        }
+
+        public Task StopAsync(CancellationToken _)
+        {
+            return _connectionContainer.StopAsync();
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ConnectionService.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ConnectionService.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.SignalR.Management
             _connectionContainer = connectionContainer;
         }
 
-        public async Task StartAsync(CancellationToken token)
+        public Task StartAsync(CancellationToken token)
         {
             _ = _connectionContainer.StartAsync();
-            await _connectionContainer.ConnectionInitializedTask.OrTimeout(token, TimeSpan.FromMinutes(1), "establishing service connections");
+            return _connectionContainer.ConnectionInitializedTask.OrTimeout(token, TimeSpan.FromMinutes(1), "establishing service connections");
         }
 
         public Task StopAsync(CancellationToken _)

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/HostedServiceFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/HostedServiceFactory.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class HostedServiceFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ServiceManagerOptions _options;
+        private bool _used = false;
+
+        public HostedServiceFactory(IServiceProvider serviceProvider, IOptions<ServiceManagerOptions> options)
+        {
+            _serviceProvider = serviceProvider;
+            _options = options.Value;
+        }
+
+        public IHostedService Create()
+        {
+            if (_used)
+            {
+                throw new InvalidOperationException("Don't create multiple IHostedService from this factory.");
+            }
+            _used = true;
+            return _options.ServiceTransportType switch
+            {
+                ServiceTransportType.Persistent => _serviceProvider.GetRequiredService<ConnectionService>(),
+                ServiceTransportType.Transient => _serviceProvider.GetRequiredService<RestHealthCheckService>(),
+                _ => throw new NotSupportedException(),
+            };
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.SignalR.Management
             _router = router;
         }
 
-        public MultiEndpointServiceConnectionContainer Connect(string hubName)
+        public MultiEndpointServiceConnectionContainer Create(string hubName)
         {
             var container = new MultiEndpointServiceConnectionContainer(
                 hubName,
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.SignalR.Management
                 _endpointManager,
                 _router,
                 _loggerFactory);
-            container.StartAsync();
             return container;
         }
     }

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/RestHealthCheckService.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/RestHealthCheckService.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class RestHealthCheckService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager.cs
@@ -15,7 +15,5 @@ namespace Microsoft.Azure.SignalR.Management
         Task<bool> UserExistsAsync(string userId, CancellationToken cancellationToken);
 
         Task<bool> GroupExistsAsync(string groupName, CancellationToken cancellationToken);
-
-        Task DisposeAsync();
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
+++ b/src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj
@@ -39,5 +39,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionHttpVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="$(MicrosoftAspNetCoreSignalRPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -9,87 +9,22 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    public class ServiceHubContextBuilder
+    internal class ServiceHubContextBuilder
     {
-        private readonly IServiceCollection _services;
+        private readonly HostBuilder _hostBuilder = new();
 
-        internal ServiceHubContextBuilder(IServiceCollection services)
+        internal ServiceHubContextBuilder(IEnumerable<ServiceDescriptor> srcServices)
         {
-            _services = services;
+            _hostBuilder.ConfigureServices(collection => collection.Add(srcServices));
         }
 
-        public ServiceHubContextBuilder() : this(new ServiceCollection())
+        internal ServiceHubContextBuilder ConfigureServices(Action<IServiceCollection> configure)
         {
-            _services.AddSignalRServiceManager();
-        }
-
-        private Action<IServiceCollection> _configureAction;
-
-        /// <summary>
-        /// Registers an action used to configure <see cref="IServiceManager"/>.
-        /// </summary>
-        /// <param name="configure">A callback to configure the <see cref="IServiceManager"/>.</param>
-        /// <returns>The same instance of the <see cref="ServiceManagerBuilder"/> for chaining.</returns>
-        public ServiceHubContextBuilder WithOptions(Action<ServiceManagerOptions> configure)
-        {
-            _services.Configure(configure);
-            return this;
-        }
-
-        public ServiceHubContextBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            _services.AddSingleton(loggerFactory);
-            return this;
-        }
-
-        public ServiceHubContextBuilder WithConfiguration(IConfiguration configuration)
-        {
-            _services.AddSingleton(configuration);
-            return this;
-        }
-
-        public ServiceHubContextBuilder WithRouter(IEndpointRouter router)
-        {
-            _services.AddSingleton(router);
-            return this;
-        }
-
-        /// <summary>
-        /// Uses Newtonsoft.Json library to serialize messages sent to SignalR.
-        /// </summary>
-        /// <param name="configure">A delegate that can be used to configure the <see cref="NewtonsoftServiceHubProtocolOptions"/>.</param>
-        /// <returns>The <see cref="ServiceHubContextBuilder"/> instance itself.</returns>
-        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol(Action<NewtonsoftServiceHubProtocolOptions> configure)
-        {
-            if (configure is null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            _services.AddNewtonsoftHubProtocol(configure);
-            return this;
-        }
-
-        /// <summary>
-        /// Uses Newtonsoft.Json library to serialize messages sent to SignalR.
-        /// </summary>
-        /// <returns>The <see cref="ServiceHubContextBuilder"/> instance itself.</returns>
-        public ServiceHubContextBuilder WithNewtonsoftJsonHubProtocol()
-        {
-            return WithNewtonsoftJsonHubProtocol(o => { });
-        }
-
-        /// <summary>
-        /// Provides a hook to configure services before building.
-        /// </summary>
-        internal ServiceHubContextBuilder ConfigureServices(Action<IServiceCollection> configureAction)
-        {
-            _configureAction = configureAction;
+            _hostBuilder.ConfigureServices(configure);
             return this;
         }
 
@@ -97,33 +32,30 @@ namespace Microsoft.Azure.SignalR.Management
         /// Builds <see cref="ServiceHubContext"/> instances.
         /// </summary>
         /// <returns>The instance of the <see cref="IServiceManager"/>.</returns>
-        public async Task<ServiceHubContext> CreateAsync(string hubName, CancellationToken cancellationToken)
+        internal async Task<ServiceHubContext> CreateAsync(string hubName, CancellationToken cancellationToken)
         {
-            //add requried services
-            using var serviceProvider = _services.BuildServiceProvider();
-            var transportType = serviceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ServiceTransportType;
-            var services = new ServiceCollection().Add(_services);
-            services.AddHub(hubName, transportType);
-            _configureAction?.Invoke(services);
-            services.AddSingleton(services.ToList() as IReadOnlyCollection<ServiceDescriptor>);
-
-            //build
-            var serviceHubContext = services.BuildServiceProvider()
-                .GetRequiredService<ServiceHubContextImpl>();
-
-            //initialize
-            var connectionContainer = serviceHubContext.ServiceProvider.GetService<IServiceConnectionContainer>();
-            if (connectionContainer != null)
+            _hostBuilder.ConfigureServices(services =>
             {
-                await connectionContainer.ConnectionInitializedTask.OrTimeout(cancellationToken);
-            }
+                services.AddHub(hubName);
+                services.AddSingleton(services.ToList() as IReadOnlyCollection<ServiceDescriptor>);
+            });
 
-            if (cancellationToken.IsCancellationRequested)
+            IHost host = null;
+            try
             {
-                await serviceHubContext?.DisposeAsync();
-                return null;
+                host = _hostBuilder.Build();
+                await host.StartAsync(cancellationToken);
+                return host.Services.GetRequiredService<ServiceHubContextImpl>();
             }
-            return serviceHubContext.ServiceProvider.GetRequiredService<ServiceHubContextImpl>();
+            catch
+            {
+                if (host != null)
+                {
+                    await host.StopAsync();
+                    host.Dispose();
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.SignalR.Management
             });
 
             IHost host = null;
+            var shouldDispose = false;
             try
             {
                 host = _hostBuilder.Build();
@@ -49,12 +50,19 @@ namespace Microsoft.Azure.SignalR.Management
             }
             catch
             {
+                shouldDispose = true;
                 if (host != null)
                 {
                     await host.StopAsync();
-                    host.Dispose();
                 }
                 throw;
+            }
+            finally
+            {
+                if(shouldDispose && host!=null)
+                {
+                    host.Dispose();
+                }
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.SignalR.Management
             });
 
             IHost host = null;
-            var shouldDispose = false;
             try
             {
                 host = _hostBuilder.Build();
@@ -50,19 +49,11 @@ namespace Microsoft.Azure.SignalR.Management
             }
             catch
             {
-                shouldDispose = true;
-                if (host != null)
+                using (host)
                 {
                     await host.StopAsync();
                 }
                 throw;
-            }
-            finally
-            {
-                if(shouldDispose && host!=null)
-                {
-                    host.Dispose();
-                }
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -54,9 +54,8 @@ namespace Microsoft.Azure.SignalR.Management
 
         public override async Task DisposeAsync()
         {
-            var host = ServiceProvider.GetRequiredService<IHost>();
+            using var host = ServiceProvider.GetRequiredService<IHost>();
             await host.StopAsync();
-            host.Dispose();
         }
 
         ServiceHubContext IInternalServiceHubContext.WithEndpoints(IEnumerable<ServiceEndpoint> endpoints)

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    //todo public
+    //todo: public [ServiceManager]
     internal abstract class ServiceManager : IDisposable
     {
         public abstract Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken);

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
@@ -43,11 +43,10 @@ namespace Microsoft.Azure.SignalR.Management
             return serviceHubContext;
         }
 
-        public async override Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken)
+        public override Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken)
         {
             var builder = new ServiceHubContextBuilder(_services);
-            var serviceHubContext = await builder.CreateAsync(hubName, cancellationToken);
-            return serviceHubContext;
+            return builder.CreateAsync(hubName, cancellationToken);
         }
 
         public override void Dispose()

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
@@ -9,14 +9,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Common.RestClients;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.Rest;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    //todo public
+    //todo public [ServiceManager]
     internal class ServiceManagerImpl : ServiceManager, IServiceManager
     {
         private readonly RestClientFactory _restClientFactory;
@@ -36,44 +34,20 @@ namespace Microsoft.Azure.SignalR.Management
 
         public async Task<IServiceHubContext> CreateHubContextAsync(string hubName, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
         {
-            var builder = new ServiceHubContextBuilder(new ServiceCollection().Add(_services));
+            var builder = new ServiceHubContextBuilder(_services);
             if (loggerFactory != null)
             {
-                builder.WithLoggerFactory(loggerFactory);
+                builder.ConfigureServices(services => services.AddSingleton(loggerFactory));
             }
             var serviceHubContext = await builder.CreateAsync(hubName, cancellationToken);
             return serviceHubContext;
         }
 
-        public override async Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken)
+        public async override Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken)
         {
-            var services = new ServiceCollection().Add(_services);
-            using var serviceProvider = services.BuildServiceProvider();
-            var transportType = serviceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ServiceTransportType;
-            services.AddSingleton(_services);
-            services.AddHub(hubName, transportType);
-            ServiceHubContextImpl serviceHubContext = null;
-            try
-            {
-                //build
-                serviceHubContext = services.BuildServiceProvider()
-                    .GetRequiredService<ServiceHubContextImpl>();
-                //initialize
-                var connectionContainer = serviceHubContext.ServiceProvider.GetService<IServiceConnectionContainer>();
-                if (connectionContainer != null)
-                {
-                    await connectionContainer.ConnectionInitializedTask.OrTimeout(cancellationToken);
-                }
-                return serviceHubContext.ServiceProvider.GetRequiredService<ServiceHubContextImpl>();
-            }
-            catch
-            {
-                if (serviceHubContext is not null)
-                {
-                    await serviceHubContext.DisposeAsync();
-                }
-                throw;
-            }
+            var builder = new ServiceHubContextBuilder(_services);
+            var serviceHubContext = await builder.CreateAsync(hubName, cancellationToken);
+            return serviceHubContext;
         }
 
         public override void Dispose()

--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -183,11 +183,6 @@ namespace Microsoft.Azure.SignalR.Management
             return WriteAckableMessageAsync(message);
         }
 
-        public Task DisposeAsync()
-        {
-            return ServiceConnectionContainer.StopAsync();
-        }
-
         protected override T AppendMessageTracingId<T>(T message)
         {
             if (_serviceManagerOptions.Value.EnableMessageTracing)


### PR DESCRIPTION
Make the initialization logic unified in the `ServiceHubContextBuilder` no matter what service transport type is
