### PR TITLE
Allow to configure `HttpTransportType` for server SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,8 +41,8 @@
     <SignedPackageFile Include="$(PublishDir)MessagePack.dll" Certificate="$(ThirdPartyAssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Authentication.JwtBearer.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Connections.Abstractions.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
-    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Features.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Connections.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Features.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.JsonPatch.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Mvc.NewtonsoftJson.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,7 @@
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Authentication.JwtBearer.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Connections.Abstractions.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Features.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Connections.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.JsonPatch.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Mvc.NewtonsoftJson.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,6 +8,10 @@
     <MicrosoftAspNetCoreHttpConnectionsClientPackage3_0Version>3.0.0</MicrosoftAspNetCoreHttpConnectionsClientPackage3_0Version>
     <MicrosoftAspNetCoreHttpConnectionsClientPackage3_1Version>3.1.9</MicrosoftAspNetCoreHttpConnectionsClientPackage3_1Version>
     <MicrosoftAspNetCoreHttpConnectionsClientPackage5_0Version>5.0.1</MicrosoftAspNetCoreHttpConnectionsClientPackage5_0Version>
+    <MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>1.0.0</MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>
+    <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>3.0.0</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>
+    <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>3.1.9</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>
+    <MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>5.0.1</MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>3.0.0</MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>3.1.9</MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackage3_0Version)" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackage3_0Version)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="$(MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackage3_0Version)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>
@@ -25,6 +26,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackage3_1Version)" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackage3_1Version)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="$(MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackage3_1Version)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackage3_1Version)" />
   </ItemGroup>
@@ -32,6 +34,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="$(MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.SignalR
             public const string MaxPollInterval = AzureSignalRSysPrefix + "ttl";
             public const string DiagnosticClient = AzureSignalRSysPrefix + "dc";
             public const string CustomHandshakeTimeout = AzureSignalRSysPrefix + "cht";
+            public const string HttpTransportType = AzureSignalRSysPrefix + "htt";
 
             public const string AzureSignalRUserPrefix = "asrs.u.";
         }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ClaimsUtility.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR
@@ -34,7 +35,8 @@ namespace Microsoft.Azure.SignalR
             bool enableDetailedErrors = false, 
             int endpointsCount = 1,
             int? maxPollInterval = null,
-            bool isDiagnosticClient = false, int handshakeTimeout = Constants.Periods.DefaultHandshakeTimeout)
+            bool isDiagnosticClient = false, int handshakeTimeout = Constants.Periods.DefaultHandshakeTimeout,
+            HttpTransportType? httpTransportType = null)
         {
             if (userId != null)
             {
@@ -97,6 +99,11 @@ namespace Microsoft.Azure.SignalR
             if (maxPollInterval.HasValue)
             {
                 yield return new Claim(Constants.ClaimType.MaxPollInterval, maxPollInterval.Value.ToString());
+            }
+
+            if (httpTransportType.HasValue)
+            {
+                yield return new Claim(Constants.ClaimType.HttpTransportType, ((int)httpTransportType).ToString());
             }
 
             // return customer's claims

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Localization;
@@ -18,6 +19,27 @@ namespace Microsoft.Azure.SignalR
 {
     internal class NegotiateHandler<THub> where THub : Hub
     {
+        //AvailableTransport copy from https://github.com/dotnet/aspnetcore/tree/2be49d930a5fb53e781abd175c3b2a8f8b7827d4/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+        private static readonly AvailableTransport _webSocketAvailableTransport =
+            new()
+            {
+                Transport = nameof(HttpTransportType.WebSockets),
+                TransferFormats = new List<string> { nameof(TransferFormat.Text), nameof(TransferFormat.Binary) }
+            };
+
+        private static readonly AvailableTransport _serverSentEventsAvailableTransport =
+            new()
+            {
+                Transport = nameof(HttpTransportType.ServerSentEvents),
+                TransferFormats = new List<string> { nameof(TransferFormat.Text) }
+            };
+
+        private static readonly AvailableTransport _longPollingAvailableTransport =
+            new()
+            {
+                Transport = nameof(HttpTransportType.LongPolling),
+                TransferFormats = new List<string> { nameof(TransferFormat.Text), nameof(TransferFormat.Binary) }
+            };
         private readonly IUserIdProvider _userIdProvider;
         private readonly IConnectionRequestIdProvider _connectionRequestIdProvider;
         private readonly Func<HttpContext, IEnumerable<Claim>> _claimsProvider;
@@ -33,15 +55,16 @@ namespace Microsoft.Azure.SignalR
         private readonly int _customHandshakeTimeout;
         private readonly string _hubName;
         private readonly ILogger<NegotiateHandler<THub>> _logger;
+        private readonly Func<HttpContext, HttpTransportType> _transportTypeProvider;
 
         public NegotiateHandler(
             IOptions<HubOptions> globalHubOptions,
             IOptions<HubOptions<THub>> hubOptions,
-            IServiceEndpointManager endpointManager, 
-            IEndpointRouter router, 
-            IUserIdProvider userIdProvider, 
-            IServerNameProvider nameProvider, 
-            IConnectionRequestIdProvider connectionRequestIdProvider, 
+            IServiceEndpointManager endpointManager,
+            IEndpointRouter router,
+            IUserIdProvider userIdProvider,
+            IServerNameProvider nameProvider,
+            IConnectionRequestIdProvider connectionRequestIdProvider,
             IOptions<ServiceOptions> options,
             IBlazorDetector blazorDetector,
             ILogger<NegotiateHandler<THub>> logger)
@@ -59,6 +82,7 @@ namespace Microsoft.Azure.SignalR
             _enableDetailedErrors = globalHubOptions.Value.EnableDetailedErrors == true;
             _endpointsCount = options.Value.Endpoints.Length;
             _maxPollInterval = options.Value.MaxPollIntervalInSeconds;
+            _transportTypeProvider = options.Value.TransportTypeProvider;
             _customHandshakeTimeout = GetCustomHandshakeTimeout(hubOptions.Value.HandshakeTimeout ?? globalHubOptions.Value.HandshakeTimeout);
             _hubName = typeof(THub).Name;
         }
@@ -77,13 +101,14 @@ namespace Microsoft.Azure.SignalR
             }
 
             var queryString = GetQueryString(request.QueryString.HasValue ? request.QueryString.Value.Substring(1) : null, cultureName);
+            var availableTransports = GetAvailableTransports(_transportTypeProvider.Invoke(context));
 
             return new NegotiationResponse
             {
                 Url = provider.GetClientEndpoint(_hubName, originalPath, queryString),
                 AccessToken = await provider.GenerateClientAccessTokenAsync(_hubName, claims),
                 // Need to set this even though it's technically protocol violation https://github.com/aspnet/SignalR/issues/2133
-                AvailableTransports = new List<AvailableTransport>()
+                AvailableTransports = availableTransports
             };
         }
 
@@ -164,6 +189,24 @@ namespace Microsoft.Azure.SignalR
             return path.EndsWith(Constants.Path.Negotiate)
                 ? path.Substring(0, path.Length - Constants.Path.Negotiate.Length)
                 : string.Empty;
+        }
+
+        private static List<AvailableTransport> GetAvailableTransports(HttpTransportType httpTransportType)
+        {
+            var availableTransports = new List<AvailableTransport>();
+            if ((httpTransportType & HttpTransportType.WebSockets) != 0)
+            {
+                availableTransports.Add(_webSocketAvailableTransport);
+            }
+            if ((httpTransportType & HttpTransportType.ServerSentEvents) != 0)
+            {
+                availableTransports.Add(_serverSentEventsAvailableTransport);
+            }
+            if ((httpTransportType & HttpTransportType.LongPolling) != 0)
+            {
+                availableTransports.Add(_longPollingAvailableTransport);
+            }
+            return availableTransports;
         }
 
         private static class Log

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.SignalR
@@ -90,5 +91,10 @@ namespace Microsoft.Azure.SignalR
         /// Default value is 5, limited to [1, 300].
         /// </summary>
         public int? MaxPollIntervalInSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the server should use to receive HTTP requests.
+        /// </summary>
+        public Func<HttpContext, HttpTransportType> TransportTypeProvider { get; set; } = context => HttpTransports.All;
     }
 }

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.SignalR
         public int? MaxPollIntervalInSeconds { get; set; }
 
         /// <summary>
-        /// Gets or sets a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the server should use to receive HTTP requests.
+        /// Gets or sets a function which accepts <see cref="HttpContext"/> and returns a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the service should use to receive HTTP requests.
         /// </summary>
-        public Func<HttpContext, HttpTransportType> TransportTypeProvider { get; set; } = context => HttpTransports.All;
+        public Func<HttpContext, HttpTransportType> TransportTypeDetector { get; set; } = null;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.StartsWith("http://redirect/client/?hub=hub", negotiateResponse.Url);
             Assert.NotNull(negotiateResponse.AccessToken);
             Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
+            Assert.Equal(3, negotiateResponse.AvailableTransports.Count);
 
             var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
             Assert.Equal(expectedUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.NotNull(negotiateResponse.Url);
             Assert.NotNull(negotiateResponse.AccessToken);
             Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
+            Assert.Equal(3, negotiateResponse.AvailableTransports.Count);
 
             var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
             Assert.Equal(DefaultUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.NotNull(negotiateResponse.Url);
             Assert.NotNull(negotiateResponse.AccessToken);
             Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
+            Assert.Equal(3, negotiateResponse.AvailableTransports.Count);
 
             var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
 


### PR DESCRIPTION
To fixes #1325 
At first, I try to take SignalR's `HttpConnectionDispatcherOptions` option if the transport type is configured, but found that we can't get the `HttpConnectionDispatcherOptions`, so I make another options.


Usage:
```cs
  .AddAzureSignalR(o =>
  {
      o.ConnectionString = DefaultConnectionString;
      o.TransportTypeDetector = context => ...;
  })

```
If user set the `TransportTypeDetector`, then a claim will be added to the access token.

CliamType: `asrs.u.htt`   Value: the int number of the `HttpTransportType` flag.

If user doesn't set the `TransportDetector`, then no related claim.