### PR TITLE
Remove unnecessary intermediate LINQ execution for claims

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR
             var mode = _blazorDetector.IsBlazor(_hubName) ? ServerStickyMode.Required : _mode;
             var userId = _userIdProvider.GetUserId(new ServiceHubConnectionContext(context));
             var httpTransportType = _transportTypeDetector?.Invoke(context);
-            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsDiagnosticClient(context), _customHandshakeTimeout, httpTransportType).ToList();
+            return ClaimsUtility.BuildJwtClaims(context.User, userId, GetClaimsProvider(context), _serverName, mode, _enableDetailedErrors, _endpointsCount, _maxPollInterval, IsDiagnosticClient(context), _customHandshakeTimeout, httpTransportType);
         }
 
         private Func<IEnumerable<Claim>> GetClaimsProvider(HttpContext context)


### PR DESCRIPTION
The final usage of the `IEnumerable<Claim>` in our code is 
https://github.com/Azure/azure-signalr/blob/e8e113ff3b61603f46a5d20c965a9d56192853b2/src/Microsoft.Azure.SignalR.Common/Auth/AuthUtility.cs#L31

And `ClaimsIdentity` creates a `List<Claim>` itself and adds the claims to the list. 
https://source.dot.net/#System.Security.Claims/System/Security/Claims/ClaimsIdentity.cs,601dacbeca044900

So we don't need to `ToList()` in our code.