### PR TITLE
Update emulator to support Azure SignalR specific userId

### DIFF
--- a/src/Microsoft.Azure.SignalR.Emulator/AppBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/AppBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Emulator.HubEmulator;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -73,6 +74,7 @@ namespace Microsoft.Azure.SignalR.Emulator
         {
             services.AddSingleton(typeof(HubLifetimeManager<>), typeof(CachedHubLifetimeManager<>));
             services.AddSingleton(typeof(HubProxyHandler<>));
+            services.AddSingleton<IUserIdProvider, AzureSignalRCustomUserIdProvider>();
             services.AddSingleton(typeof(HttpServerlessMessageHandler<>));
             services.AddSingleton<IHttpUpstreamTrigger, HttpUpstreamTrigger>();
             services.AddSingleton<DynamicHubContextStore>();
@@ -101,6 +103,14 @@ namespace Microsoft.Azure.SignalR.Emulator
             }
 
             return null;
+        }
+
+        private sealed class AzureSignalRCustomUserIdProvider : IUserIdProvider
+        {
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return connection.Features.GetUserIdentifier();
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Emulator/Common/HttpContextExtenstions.cs
+++ b/src/Microsoft.Azure.SignalR.Emulator/Common/HttpContextExtenstions.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.Azure.SignalR.Common
 {
@@ -12,7 +13,12 @@ namespace Microsoft.Azure.SignalR.Common
     {
         internal static string GetUserIdentifier(this ConnectionContext connectionContext)
         {
-            var user = connectionContext.Features.Get<IConnectionUserFeature>()?.User;
+            return connectionContext.Features.GetUserIdentifier();
+        }
+
+        internal static string GetUserIdentifier(this IFeatureCollection userFeature)
+        {
+            var user = userFeature.Get<IConnectionUserFeature>()?.User;
             if (user != null)
             {
                 var customUserIdClaim = user.FindFirst(Constants.ClaimTypes.UserIdClaimType);


### PR DESCRIPTION
Fix https://github.com/Azure/azure-functions-signalrservice-extension/issues/259

Root Cause
============
The latest function extension updated to set userId to an Azure SignalR specific claim type. The emulator needs to be updated accordingly to support such change.
