### PR TITLE
Complete both pipe while migrating clients.

### DIFF
--- a/samples/ChatSample/ChatSample.NetCore31/Hub/Chat.cs
+++ b/samples/ChatSample/ChatSample.NetCore31/Hub/Chat.cs
@@ -38,7 +38,7 @@ namespace ChatSample.CoreApp3
                 c => ((HeartBeatContext)c).HeartBeat(),
                 new HeartBeatContext(_context, Context.Features.Get<IConnectionStatFeature>(), Context.ConnectionId));
 
-            var feature = Context.GetHttpContext().Features.Get<IConnectionMigrationFeature>();
+            var feature = Context.Features.Get<IConnectionMigrationFeature>();
             if (feature != null)
             {
                 Console.WriteLine($"[{feature.MigrateTo}] {Context.ConnectionId} is migrated from {feature.MigrateFrom}.");
@@ -51,7 +51,7 @@ namespace ChatSample.CoreApp3
         {
             Console.WriteLine($"{Context.ConnectionId} disconnected.");
 
-            var feature = Context.GetHttpContext().Features.Get<IConnectionMigrationFeature>();
+            var feature = Context.Features.Get<IConnectionMigrationFeature>();
             if (feature != null)
             {
                 Console.WriteLine($"[{feature.MigrateFrom}] {Context.ConnectionId} will be migrated to {feature.MigrateTo}.");

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
-        private async ValueTask TrySendPingAsync()
+        protected virtual async ValueTask TrySendPingAsync()
         {
             if (!_writeLock.Wait(0))
             {

--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Security.Claims;
+
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.SignalR.Protocol

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -152,11 +151,12 @@ namespace Microsoft.Azure.SignalR
                     context.Features.Set<IConnectionMigrationFeature>(new ConnectionMigrationFeature(ServerId, to));
                     // We have to prevent SignalR `{type: 7}` (close message) from reaching our client while doing migration.
                     // Since all data messages will be sent to `ServiceConnection` directly.
-                    // We can simply ignore all messages came from the application pipe.
-                    context.Application.Input.CancelPendingRead();
+                    // We can simply ignore all messages came from the application.
+                    context.CancelOutgoing();
+                    // The close connection message must be the last message, so we could complete the pipe.
+                    context.CompleteIncoming();
                 }
             }
-
             return PerformDisconnectAsyncCore(connectionId);
         }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Azure.SignalR
             {
                 if (closeConnectionMessage.Headers.TryGetValue(Constants.AsrsMigrateTo, out var to))
                 {
+                    context.AbortOnClose = false;
                     context.Features.Set<IConnectionMigrationFeature>(new ConnectionMigrationFeature(ServerId, to));
                     // We have to prevent SignalR `{type: 7}` (close message) from reaching our client while doing migration.
                     // Since all data messages will be sent to `ServiceConnection` directly.

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests
@@ -8,6 +9,8 @@ namespace Microsoft.Azure.SignalR.Tests
     internal class TestClientConnectionFactory : IClientConnectionFactory
     {
         public IList<ClientConnectionContext> Connections = new List<ClientConnectionContext>();
+
+        public IHubProtocol HubProtocol { get; } = new JsonHubProtocol();
 
         public ClientConnectionContext CreateConnection(OpenConnectionMessage message, Action<HttpContext> configureContext = null)
         {

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -11,13 +11,12 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
Fixed 2 bugs

1. The client connection that was migrated to another server will have a rare chance to be closed again.
2. Server sometimes cannot shutdown gracefully after all client connections have been migrated.

Fixed a sample code
#1374 