### PR TITLE
Raise user-friendly ex when aad auth failed.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Exceptions/AzureSignalRUnauthorizedException.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Exceptions/AzureSignalRUnauthorizedException.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.SignalR.Common
     [Serializable]
     public class AzureSignalRUnauthorizedException : AzureSignalRException
     {
-        private const string ErrorMessage = "Authorization failed. Make sure you provide the correct connection string and have access to the resource.";
+        private const string ErrorMessage = "Authorization failed. If you were using AccessKey, please check connection string and see if the AccessKey is correct. If you were using Azure Active Directory, please note that the role assignments will take up to 30 minutes to take effect if it was added recently.";
 
         public AzureSignalRUnauthorizedException(string requestUri, Exception innerException) : base(string.IsNullOrEmpty(requestUri) ? ErrorMessage : $"{ErrorMessage} Request Uri: {requestUri}", innerException)
         {

--- a/src/Microsoft.Azure.SignalR.Common/Exceptions/ExceptionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Exceptions/ExceptionExtensions.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.WebSockets;
+
 using Microsoft.Rest;
 
-namespace Microsoft.Azure.SignalR.Common.RestClients
+namespace Microsoft.Azure.SignalR.Common
 {
     internal static class ExceptionExtensions
     {
@@ -33,6 +35,20 @@ namespace Microsoft.Azure.SignalR.Common.RestClients
                     return new AzureSignalRInaccessibleEndpointException(baseUri.ToString(), requestException);
                 default:
                     return e;
+            }
+        }
+
+        internal static Exception WrapAsAzureSignalRException(this Exception e)
+        {
+            switch (e)
+            {
+                case WebSocketException webSocketException:
+                    if (e.Message.StartsWith("The server returned status code \"401\""))
+                    {
+                        return new AzureSignalRUnauthorizedException(webSocketException);
+                    }
+                    return e;
+                default: return e;
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/RestClients/SignalRServiceRestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Common/RestClients/SignalRServiceRestClient.cs
@@ -5,7 +5,8 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Common.RestClients;
+
+using Microsoft.Azure.SignalR.Common;
 using Microsoft.Rest;
 
 namespace Microsoft.Azure.SignalR

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/Internal/WebSocketsTransport.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/Internal/WebSocketsTransport.cs
@@ -8,6 +8,8 @@ using System.Net.WebSockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Azure.SignalR.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.Connections.Client.Internal
@@ -18,7 +20,7 @@ namespace Microsoft.Azure.SignalR.Connections.Client.Internal
     internal partial class WebSocketsTransport : IDuplexPipe
     {
         public static PipeOptions DefaultOptions = new PipeOptions(writerScheduler: PipeScheduler.ThreadPool, readerScheduler: PipeScheduler.ThreadPool, useSynchronizationContext: false, pauseWriterThreshold: 0, resumeWriterThreshold: 0);
-        
+
         private readonly WebSocketMessageType _webSocketMessageType = WebSocketMessageType.Binary;
         private readonly ClientWebSocket _webSocket;
         private readonly Func<Task<string>> _accessTokenProvider;
@@ -116,10 +118,10 @@ namespace Microsoft.Azure.SignalR.Connections.Client.Internal
             {
                 await _webSocket.ConnectAsync(resolvedUrl, cancellationToken);
             }
-            catch
+            catch (Exception e)
             {
                 _webSocket.Dispose();
-                throw;
+                throw e.WrapAsAzureSignalRException();
             }
 
             Log.StartedTransport(_logger);

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
@@ -7,10 +7,8 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Common.RestClients;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Rest;
 
 namespace Microsoft.Azure.SignalR.Management
 {


### PR DESCRIPTION
According to [this](https://docs.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#role-assignment-changes-are-not-being-detected), a role assignments change requires up to 30 minutes to take effect if the token had not been forced refreshed. 

However, it took seldomly longer than 15 minutes in our daily integration tests.

I'd like to try reducing the time to take effect, but now, let's give our customer some hints.