### PR TITLE
update constructor for access key

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AadAccessKey.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AadAccessKey.cs
@@ -5,8 +5,11 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Azure.Core;
+
 using Microsoft.Azure.SignalR.Common;
+
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.SignalR
@@ -36,7 +39,7 @@ namespace Microsoft.Azure.SignalR
 
         private Task<object> InitializedTask => _initializedTcs.Task;
 
-        public AadAccessKey(TokenCredential credential, string endpoint, int? port) : base(endpoint, port)
+        public AadAccessKey(Uri endpoint, TokenCredential credential) : base(endpoint)
         {
             TokenCredential = credential;
         }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKey.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Azure.SignalR
         public string Id => Key?.Item1;
         public string Value => Key?.Item2;
 
+        public string Endpoint { get; }
+        public int Port { get; }
+
         protected Tuple<string, string> Key { get; set; }
 
-        public string Endpoint { get; }
-        public int? Port { get; }
-
-        public AccessKey(string key, string endpoint, int? port) : this(endpoint, port)
+        public AccessKey(Uri endpoint, string key) : this(endpoint)
         {
             Key = new Tuple<string, string>(key.GetHashCode().ToString(), key);
         }
 
-        protected AccessKey(string endpoint, int? port)
+        protected AccessKey(Uri endpoint)
         {
-            Endpoint = endpoint;
-            Port = port;
+            Endpoint = $"{endpoint.Scheme}://{endpoint.Host}";
+            Port = endpoint.Port;
         }
 
         public virtual Task<string> GenerateAccessTokenAsync(

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -17,6 +17,10 @@ namespace Microsoft.Azure.SignalR
 
         public string Endpoint => AccessKey?.Endpoint;
 
+        public string ServerEndpoint => Port.HasValue ? $"{Endpoint}:{Port}" : Endpoint;
+
+        public string ClientEndpoint => _clientEndpoint ?? ServerEndpoint;
+
         internal int? Port => AccessKey?.Port;
 
         /// <summary>
@@ -40,14 +44,14 @@ namespace Microsoft.Azure.SignalR
         /// </summary>
         public EndpointMetrics EndpointMetrics { get; internal set; } = new EndpointMetrics();
 
-        /// <summary>
-        /// The customized endpoint that the client will be redirected to
-        /// </summary>
-        internal string ClientEndpoint { get; }
-
         internal string Version { get; }
 
         internal AccessKey AccessKey { get; private set; }
+
+        /// <summary>
+        /// The customized endpoint that the client will be redirected to
+        /// </summary>
+        private readonly string _clientEndpoint;
 
         /// <summary>
         /// Connection string constructor with nameWithEndpointType
@@ -72,7 +76,7 @@ namespace Microsoft.Azure.SignalR
                 throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or whitespace", nameof(connectionString));
             }
 
-            (AccessKey, Version, ClientEndpoint) = ConnectionStringParser.Parse(connectionString);
+            (AccessKey, Version, _clientEndpoint) = ConnectionStringParser.Parse(connectionString);
 
             EndpointType = type;
             ConnectionString = connectionString;
@@ -107,7 +111,7 @@ namespace Microsoft.Azure.SignalR
             {
                 throw new ArgumentException("Endpoint scheme must be 'http://' or 'https://'");
             }
-            AccessKey = new AadAccessKey(credential, $"{endpoint.Scheme}://{endpoint.Host}", endpoint.Port);
+            AccessKey = new AadAccessKey(endpoint, credential);
             (Name, EndpointType) = (name, endpointType);
         }
 
@@ -124,7 +128,7 @@ namespace Microsoft.Azure.SignalR
                 Name = other.Name;
                 Version = other.Version;
                 AccessKey = other.AccessKey;
-                ClientEndpoint = other.ClientEndpoint;
+                _clientEndpoint = other._clientEndpoint;
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.SignalR
             {
                 throw new ArgumentException($"Endpoint property in connection string is not a valid URI: {dict[EndpointProperty]}.");
             }
+            var builder = new UriBuilder(endpoint);
 
             // parse and validate version.
             string version = null;
@@ -89,12 +90,11 @@ namespace Microsoft.Azure.SignalR
             }
 
             // parse and validate port.
-            int? port = null;
             if (dict.TryGetValue(PortProperty, out var s))
             {
                 if (int.TryParse(s, out var p) && p > 0 && p <= 0xFFFF)
                 {
-                    port = p;
+                    builder.Port = p;
                 }
                 else
                 {
@@ -114,8 +114,8 @@ namespace Microsoft.Azure.SignalR
             dict.TryGetValue(AuthTypeProperty, out string type);
             AccessKey accessKey = type?.ToLower() switch
             {
-                "aad" => BuildAadAccessKey(dict, endpoint, port),
-                _ => BuildAccessKey(dict, endpoint, port),
+                "aad" => BuildAadAccessKey(builder.Uri, dict),
+                _ => BuildAccessKey(builder.Uri, dict),
             };
             return (accessKey, version, clientEndpoint);
         }
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.SignalR
                    (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
         }
 
-        private static AccessKey BuildAadAccessKey(Dictionary<string, string> dict, string endpoint, int? port)
+        private static AccessKey BuildAadAccessKey(Uri endpoint, Dictionary<string, string> dict)
         {
             if (dict.TryGetValue(ClientIdProperty, out var clientId))
             {
@@ -134,11 +134,11 @@ namespace Microsoft.Azure.SignalR
                 {
                     if (dict.TryGetValue(ClientSecretProperty, out var clientSecret))
                     {
-                        return new AadAccessKey(new ClientSecretCredential(tenantId, clientId, clientSecret), endpoint, port);
+                        return new AadAccessKey(endpoint, new ClientSecretCredential(tenantId, clientId, clientSecret));
                     }
                     else if (dict.TryGetValue(ClientCertProperty, out var clientCertPath))
                     {
-                        return new AadAccessKey(new ClientCertificateCredential(tenantId, clientId, clientCertPath), endpoint, port);
+                        return new AadAccessKey(endpoint, new ClientCertificateCredential(tenantId, clientId, clientCertPath));
                     }
                     else
                     {
@@ -147,20 +147,20 @@ namespace Microsoft.Azure.SignalR
                 }
                 else
                 {
-                    return new AadAccessKey(new ManagedIdentityCredential(clientId), endpoint, port);
+                    return new AadAccessKey(endpoint, new ManagedIdentityCredential(clientId));
                 }
             }
             else
             {
-                return new AadAccessKey(new ManagedIdentityCredential(), endpoint, port);
+                return new AadAccessKey(endpoint, new ManagedIdentityCredential());
             }
         }
 
-        private static AccessKey BuildAccessKey(Dictionary<string, string> dict, string endpoint, int? port)
+        private static AccessKey BuildAccessKey(Uri endpoint, Dictionary<string, string> dict)
         {
             if (dict.TryGetValue(AccessKeyProperty, out var key))
             {
-                return new AccessKey(key, endpoint, port);
+                return new AccessKey(endpoint, key);
             }
             throw new ArgumentException(MissingAccessKeyProperty, AccessKeyProperty);
         }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AadAccessKeyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AadAccessKeyTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         public async Task TestUpdateAccessKey()
         {
             var credential = new EnvironmentCredential();
-            var endpoint = "http://localhost";
-            var key = new AadAccessKey(credential, endpoint, 80);
+            var endpoint = new Uri("http://localhost");
+            var key = new AadAccessKey(endpoint, credential);
 
             var audience = "http://localhost/chat";
             var claims = Array.Empty<Claim>();
@@ -39,8 +39,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         public async Task TestInitializeFailed()
         {
             var credential = new EnvironmentCredential();
-            var endpoint = "http://localhost";
-            var key = new AadAccessKey(credential, endpoint, 80);
+            var key = new AadAccessKey(new Uri("http://localhost"), credential);
 
             var audience = "http://localhost/chat";
             var claims = Array.Empty<Claim>();

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
@@ -1,16 +1,16 @@
-﻿using Xunit;
+﻿using System;
+
+using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 {
     public class AccessKeyTests
     {
-        private const string TestEndpoint = "http://localhost";
-        private readonly int? TestPort = 8080;
-
         [Fact]
         internal void TestConsturctor()
         {
-            var key = new AccessKey("abcde", TestEndpoint, TestPort);
+            var endpoint = new Uri("http://localhost:8080");
+            var key = new AccessKey(endpoint, "abcde");
             Assert.NotNull(key.Id);
             Assert.NotNull(key.Value);
         }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         public void TestAccessTokenTooLongThrowsException()
         {
             var claims = GenerateClaims(100);
-            var accessKey = new AccessKey(SigningKey, "http://localhost", 443);
+            var accessKey = new AccessKey(new Uri("https://localhost"), SigningKey);
             var exception = Assert.Throws<AzureSignalRAccessTokenTooLongException>(() => AuthUtility.GenerateAccessToken(accessKey, Audience, claims, DefaultLifetime, AccessTokenAlgorithm.HS256));
 
             Assert.Equal("AccessToken must not be longer than 4K.", exception.Message);
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             var count = 0;
             while (count < 1000)
             {
-                var accessKey = new AccessKey(SigningKey, "http://localhost", 443);
+                var accessKey = new AccessKey(new Uri("https://localhost"), SigningKey);
                 AuthUtility.GenerateJwtBearer(audience: Audience, expires: DateTime.UtcNow.Add(DefaultLifetime), signingKey: accessKey);
                 count++;
             };

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AzureActiveDirectoryTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AzureActiveDirectoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         public async Task TestAcquireAccessToken()
         {
             var options = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
-            var key = new AadAccessKey(options, "https://localhost", 8080);
+            var key = new AadAccessKey(new Uri("https://localhost"), options);
             var token = await key.GenerateAadTokenAsync();
             Assert.NotNull(token);
         }
@@ -70,8 +71,8 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         [Fact(Skip = "Provide valid aad options")]
         internal async Task TestAuthenticateAsync()
         {
-            var options = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
-            var key = new AadAccessKey(options, "https://localhost", 8080);
+            var credential = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
+            var key = new AadAccessKey(new Uri("https://localhost"), credential);
             await key.UpdateAccessKeyAsync();
 
             Assert.True(key.Authorized);

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ConnectionStringParserFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ConnectionStringParserFacts.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             Assert.Equal(expectedEndpoint, accessKey.Endpoint);
             Assert.Equal("bbb", accessKey.Value);
             Assert.Null(version);
-            Assert.Null(accessKey.Port);
         }
 
         [Theory]
@@ -49,7 +48,6 @@ namespace Microsoft.Azure.SignalR.Common.Tests
                 Assert.IsType<ManagedIdentityCredential>(aadAccessKey.TokenCredential);
             }
             Assert.Null(version);
-            Assert.Null(accessKey.Port);
             Assert.Null(clientEndpoint);
         }
 
@@ -66,14 +64,13 @@ namespace Microsoft.Azure.SignalR.Common.Tests
                 Assert.IsType<ClientSecretCredential>(aadAccessKey.TokenCredential);
             }
             Assert.Null(version);
-            Assert.Null(accessKey.Port);
             Assert.Null(clientEndpoint);
         }
 
         [Theory]
-        [InlineData("https://aaa", "1.0", null, "endpoint=https://aaa;AccessKey=bbb;version=1.0")]
-        [InlineData("https://aaa", "1.0-preview", null, "ENDPOINT=https://aaa/;ACCESSKEY=bbb;VERSION=1.0-preview")]
-        [InlineData("http://aaa", "1.1", null, "endpoint=http://aaa;AccessKey=bbb;Version=1.1")]
+        [InlineData("https://aaa", "1.0", 443, "endpoint=https://aaa;AccessKey=bbb;version=1.0")]
+        [InlineData("https://aaa", "1.0-preview", 443, "ENDPOINT=https://aaa/;ACCESSKEY=bbb;VERSION=1.0-preview")]
+        [InlineData("http://aaa", "1.1", 80, "endpoint=http://aaa;AccessKey=bbb;Version=1.1")]
         [InlineData("http://aaa", "1.1-beta2", 1234, "ENDPOINT=http://aaa/;ACCESSKEY=bbb;Version=1.1-beta2;Port=1234")]
         public void ValidConnectionString(string expectedEndpoint, string expectedVersion, int? expectedPort, string connectionString)
         {

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
@@ -78,13 +78,15 @@ namespace Microsoft.Azure.SignalR.Common.Tests
 
         [Theory]
         [InlineData("http://localhost", "http://localhost", 80)]
+        [InlineData("http://localhost:80", "http://localhost", 80)]
         [InlineData("https://localhost", "https://localhost", 443)]
+        [InlineData("https://localhost:443", "https://localhost", 443)]
         [InlineData("http://localhost:5050", "http://localhost", 5050)]
         [InlineData("https://localhost:5050", "https://localhost", 5050)]
         [InlineData("http://localhost/", "http://localhost", 80)]
         [InlineData("http://localhost/foo", "http://localhost", 80)]
         [InlineData("https://localhost/foo/", "https://localhost", 443)]
-        public void TestAadConstructor(string url, string endpoint, int port)
+        public void TestAadConstructor(string url, string endpoint, int? port)
         {
             var uri = new Uri(url);
             var serviceEndpoint = new ServiceEndpoint(uri, new DefaultAzureCredential());

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -52,14 +52,14 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddJsonFile(configPath, false, true).Build());
             using var provider = services.BuildServiceProvider();
             var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<ServiceOptions>>();
-            Assert.Equal(originUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint);
+            Assert.Equal(originUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint, ignoreCase: true);
 
             //update json config file
             configObj.Azure.SignalR.ConnectionString = $"Endpoint={newUrl};AccessKey={AccessKey};Version=1.0;";
             File.WriteAllText(configPath, JsonConvert.SerializeObject(configObj));
 
             await Task.Delay(5000);
-            Assert.Equal(newUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint);
+            Assert.Equal(newUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint, ignoreCase: true);
         }
 
         [Fact]
@@ -74,11 +74,11 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 .AddSingleton<IConfiguration>(new ConfigurationBuilder().Add(new ReloadableMemorySource(configProvider)).Build());
             using var provider = services.BuildServiceProvider();
             var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<ServiceOptions>>();
-            Assert.Equal(originUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint);
+            Assert.Equal(originUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint, ignoreCase: true);
 
             //update
             configProvider.Set("Azure:SignalR:ConnectionString", $"Endpoint={newUrl};AccessKey={AccessKey};Version=1.0;");
-            Assert.Equal(newUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint);
+            Assert.Equal(newUrl, new ServiceEndpoint(optionsMonitor.CurrentValue.ConnectionString).Endpoint, ignoreCase: true);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
             configProvider.Set("Azure:SignalR:ConnectionString", $"Endpoint={newUrl};AccessKey={AccessKey};Version=1.0;");
             Assert.Equal(appName, contextMonitor.CurrentValue.ApplicationName);  // configuration via delegate is conserved after reload config.
-            Assert.Equal(newUrl, new ServiceEndpoint(contextMonitor.CurrentValue.ConnectionString).Endpoint);
+            Assert.Equal(newUrl, new ServiceEndpoint(contextMonitor.CurrentValue.ConnectionString).Endpoint, ignoreCase: true);
 
             configProvider.Set("Azure:SignalR:ApplicationName", newAppName);
             Assert.Equal(newAppName, contextMonitor.CurrentValue.ApplicationName);

--- a/test/Microsoft.Azure.SignalR.Tests/JwtTokenHelper.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/JwtTokenHelper.cs
@@ -13,10 +13,6 @@ namespace Microsoft.Azure.SignalR.Tests
     {
         public static readonly JwtSecurityTokenHandler JwtHandler = new JwtSecurityTokenHandler();
 
-        private const string TestEndpoint = "http://localhost";
-
-        private const int TestPort = 443;
-
         public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, AccessKey accessKey, IEnumerable<Claim> customClaims = null)
         {
             var requestId = token.Claims.FirstOrDefault(claim => claim.Type == Constants.ClaimType.Id)?.Value;
@@ -47,7 +43,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, string key, IEnumerable<Claim> customClaims = null)
         {
-            return GenerateExpectedAccessToken(token, audience, new AccessKey(key, TestEndpoint, TestPort), customClaims: customClaims);
+            return GenerateExpectedAccessToken(token, audience, new AccessKey(new Uri("https://localhost"), key), customClaims: customClaims);
         }
 
         public static string GenerateJwtBearer(
@@ -79,7 +75,7 @@ namespace Microsoft.Azure.SignalR.Tests
             string signingKey
         )
         {
-            return GenerateJwtBearer(audience, subject, expires, notBefore, issueAt, new AccessKey(signingKey, TestEndpoint, TestPort));
+            return GenerateJwtBearer(audience, subject, expires, notBefore, issueAt, new AccessKey(new Uri("https://localhost"), signingKey));
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             public string Token { get; } = Guid.NewGuid().ToString();
 
-            public TestAadAccessKey() : base(null, "localhost", 80)
+            public TestAadAccessKey() : base(new Uri("http://localhost"), null)
             {
             }
 


### PR DESCRIPTION
1. Update `AccessKey` and `AadAccessKey` constructor to use `Uri endpoint` insteadof `string endpoint` & `int? port`
2. Replace `StringBuilder` with `UriBuilder` to generate Urls and Tokens.

## This PR includes some breaking changes
1. `ServiceEndpoint.Port` will return 80 or 443 instead of `null` when Port is not given in the `ConnectionString`, depends on the scheme type of the given endpoint.
2. `ServiceEndpoint.Endpoint` will convert its hostname into **lowercase** even when the given hostname is in uppercase. It will also influence the generated **accessToken** and **url**. [RFC4343](https://datatracker.ietf.org/doc/html/rfc4343)