### PR TITLE
Disable endpoint online check from `IEndpointRouter` side for single endpoint in Serverless SDK

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.SignalR.Management
         {
             services.AddSingleton<IServiceManager, ServiceManagerImpl>();
             services.PostConfigure<ServiceManagerOptions>(o => o.ValidateOptions());
-            
+            services.TryAddSingleton<IEndpointRouter, AutoHealthCheckRouter>();
             var tempServices = new ServiceCollection().AddSignalR()
                 .AddAzureSignalR<CascadeServiceOptionsSetup>().Services;
             services.Add(tempServices.Where(service => service.ServiceType != typeof(IHostedService)));

--- a/src/Microsoft.Azure.SignalR.Management/Negotiation/RouterWithHealthCheckSwitch.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Negotiation/RouterWithHealthCheckSwitch.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    /// <summary>
+    /// An endpoint router that only checks health when there are multiple endpoints.
+    /// </summary>
+    internal class AutoHealthCheckRouter : EndpointRouterDecorator
+    {
+        public override ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)
+        {
+            return endpoints.Count() == 1 ? endpoints.Single() : base.GetNegotiateEndpoint(context, endpoints);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Management.Tests/NegotiateProcessorFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/NegotiateProcessorFacts.cs
@@ -72,18 +72,12 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         public async Task GetDiagnosticClientNegotiateResponseTest(bool isDiagnosticClient, bool hasClaims)
         {
             var endpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray();
-            var routerMock = new Mock<IEndpointRouter>();
-            routerMock
-                .SetupSequence(router => router.GetNegotiateEndpoint(null, endpoints))
-                .Returns(endpoints[0]);
-            var router = routerMock.Object;
             var provider = new ServiceCollection().AddSignalRServiceManager()
             .Configure<ServiceManagerOptions>(o =>
             {
                 o.ServiceEndpoints = endpoints;
                 o.ServiceTransportType = ServiceTransportType.Persistent;
-            })
-            .AddSingleton(router).BuildServiceProvider();
+            }).BuildServiceProvider();
             var userId = "user";
             var negotiateProcessor = provider.GetRequiredService<NegotiateProcessor>();
             var negotiationResponse = await negotiateProcessor.NegotiateAsync(


### PR DESCRIPTION
This affects both persistent mode and transient mode
