### PR TITLE
Fix negotiation test

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
@@ -372,21 +373,18 @@ namespace Microsoft.Azure.SignalR
 
             try
             {
-                using (var cts = new CancellationTokenSource())
+                using var cts = new CancellationTokenSource();
+                if (!Debugger.IsAttached)
                 {
-                    if (!Debugger.IsAttached)
-                    {
-                        cts.CancelAfter(DefaultHandshakeTimeout);
-                    }
-
-                    if (await ReceiveHandshakeResponseAsync(context.Transport.Input, cts.Token))
-                    {
-                        Log.HandshakeComplete(Logger);
-                        return true;
-                    }
-
-                    return false;
+                    cts.CancelAfter(DefaultHandshakeTimeout);
                 }
+
+                if (await ReceiveHandshakeResponseAsync(context.Transport.Input, cts.Token))
+                {
+                    Log.HandshakeComplete(Logger);
+                    return true;
+                }
+                return false;
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 using Microsoft.AspNet.SignalR.Messaging;
@@ -23,8 +24,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Owin;
 using Microsoft.Owin.Hosting;
+
 using Newtonsoft.Json;
+
 using Owin;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -464,12 +468,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 
                 var scf = new TestServiceConnectionFactory(endpoint =>
                 {
-                    if (endpoint.Name != "es")
-                    {
-                        return new TestServiceConnection(ServiceConnectionStatus.Disconnected);
-                    };
-
-                    return new TestServiceConnection();
+                    var status = endpoint.Name == "es" ? ServiceConnectionStatus.Connected : ServiceConnectionStatus.Disconnected;
+                    return new TestServiceConnection(status);
                 });
                 hubConfig.Resolver.Register(typeof(IServiceConnectionFactory), () => scf);
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -10,12 +10,14 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests


### PR DESCRIPTION
Fix `TestRunAzureSignalRWithDefaultRouterNegotiateWithFallback`

Sometimes the test runs too quick, which will cause the `ConnectionInitializedTask` return immediately without service connection even tries to establish.