### PR TITLE
Add methods to parse `ServiceEndpoint` from configuration based on identity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,6 +56,7 @@
     <SignedPackageFile Include="$(PublishDir)Microsoft.Azure.SignalR.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Bcl.AsyncInterfaces.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.DotNet.SignTool.SignedFileContentKey.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Azure.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.CommandLineUtils.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.DependencyInjection.Abstractions.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.DependencyInjection.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,6 +12,7 @@
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>3.0.0</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>3.1.9</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>5.0.1</MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>
+    <MicrosoftExtensionsAzurePackageVersion>1.1.0</MicrosoftExtensionsAzurePackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>3.0.0</MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>3.1.9</MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="$(MicrosoftExtensionsAzurePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionHttpVersion)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimePackageVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityPackageVersion)" />

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Azure.SignalR
             public static readonly string ConnectionStringKeyPrefix = $"{ConnectionStringDefaultKey}:";
             public static readonly string ApplicationNameDefaultKeyPrefix = $"{ApplicationNameDefaultKey}:";
             public static readonly string ConnectionStringSecondaryKeyPrefix = $"{ConnectionStringSecondaryKey}:";
+
+            // The followings are keys for identity-based service endpoint configuration.
+            public const string ServiceUriKey = "ServiceUri";
+            public const string EndpointTypeKey = "Type";
         }
 
         public const string AsrsMigrateFrom = "Asrs-Migrate-From";

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/IConfigurationExtension.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/IConfigurationExtension.cs
@@ -1,22 +1,71 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.SignalR
 {
     internal static class IConfigurationExtension
     {
-        /// <param name="configuration"></param>
-        /// <param name="sectionName"></param>
         public static IEnumerable<ServiceEndpoint> GetEndpoints(this IConfiguration configuration, string sectionName)
         {
             var section = configuration.GetSection(sectionName);
             return section.AsEnumerable(true)
                           .Where(entry => !string.IsNullOrEmpty(entry.Value))
                           .Select(entry => new ServiceEndpoint(entry.Key, entry.Value));
+        }
+
+        public static IEnumerable<ServiceEndpoint> GetEndpoints(this IConfiguration config, AzureComponentFactory azureComponentFactory)
+        {
+            foreach (var child in config.GetChildren())
+            {
+                var serviceEndpoint = child.GetNamedEndpointFromIdentity(azureComponentFactory);
+                if (serviceEndpoint != null)
+                {
+                    yield return serviceEndpoint;
+                }
+                else
+                {
+                    foreach(var endpoint in GetNamedEndpointsFromConnectionString(child))
+                    {
+                        yield return endpoint;
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<ServiceEndpoint> GetNamedEndpointsFromConnectionString(this IConfigurationSection section)
+        {
+            var endpointName = section.Key;
+            if (section.Value != null)
+            {
+                yield return new ServiceEndpoint(section.Key, section.Value);
+            }
+            //This part isn't responsible for deduplicating.
+            if (section["primary"] != null)
+            {
+                yield return new ServiceEndpoint(section["primary"], EndpointType.Primary, endpointName);
+            }
+            if (section["secondary"] != null) {
+                yield return new ServiceEndpoint(section["secondary"], EndpointType.Secondary, endpointName);
+            }
+        }
+
+        public static ServiceEndpoint GetNamedEndpointFromIdentity(this IConfigurationSection section, AzureComponentFactory azureComponentFactory)
+        {
+            var uri = section[Constants.Keys.ServiceUriKey];
+            if (uri != null)
+            {
+                var name = section.Key;
+                var type = section.GetValue(Constants.Keys.EndpointTypeKey, EndpointType.Primary);
+                var credential = azureComponentFactory.CreateTokenCredential(section);
+                return new ServiceEndpoint(new Uri(uri), credential, type, name);
+            }
+            return null;
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/IConfigurationExtensionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/IConfigurationExtensionsFacts.cs
@@ -2,28 +2,105 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+using Azure.Identity;
 using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests
 {
     public class IConfigurationExtensionsFacts
     {
-        [Theory]
-        [InlineData("a")]
-        [InlineData("a:primary")]
-        [InlineData("secondary")]
-        [InlineData("a:secondary")]
-        [InlineData(":secondary")]
-        public void GetEndpointsWithSuffix(string relativePath)
+        [Fact]
+        public void TestGetNamedEndpointFromIdentityWithNoUri()
+        {
+            var services = new ServiceCollection();
+            services.AddAzureClientsCore();
+            var factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            Assert.Null(config.GetSection("eastus").GetNamedEndpointFromIdentity(factory));
+        }
+
+        [Fact]
+        public void TestGetNamedEndpointFromIdentityWithOnlyUri()
+        {
+            var services = new ServiceCollection();
+            services.AddAzureClientsCore();
+            var factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var uri = "http://signalr.service.uri.com:441";
+            config["eastus:serviceUri"] = uri;
+
+            var endpoint = config.GetSection("eastus").GetNamedEndpointFromIdentity(factory);
+            Assert.NotNull(endpoint);
+            Assert.Equal("eastus", endpoint.Name);
+            Assert.Equal(uri, endpoint.Endpoint);
+            Assert.IsType<DefaultAzureCredential>((endpoint.AccessKey as AadAccessKey).TokenCredential);
+            Assert.Equal(EndpointType.Primary, endpoint.EndpointType);
+        }
+
+        [Fact]
+        public void TestGetNamedEndpointFromIdentityWithAllEndpointField()
+        {
+            var services = new ServiceCollection();
+            services.AddAzureClientsCore();
+            var factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var uri = "http://signalr.service.uri.com:441";
+            config["eastus:serviceUri"] = uri;
+            config["eastus:credential"] = "managedidentity";
+            config["eastus:type"] = "secondary";
+
+            var endpoint = config.GetSection("eastus").GetNamedEndpointFromIdentity(factory);
+            Assert.NotNull(endpoint);
+            Assert.Equal("eastus", endpoint.Name);
+            Assert.Equal(uri, endpoint.Endpoint);
+            Assert.IsType<ManagedIdentityCredential>((endpoint.AccessKey as AadAccessKey).TokenCredential);
+            Assert.Equal(EndpointType.Secondary, endpoint.EndpointType);
+        }
+
+        [Fact]
+        public void TestGetNamedEndpointsFromConnectionString()
         {
             var connectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
-            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
-            var connectionStringKey = "key";
-            configuration[connectionStringKey] = connectionString;
-            configuration[$"{connectionStringKey}:{relativePath}"] = connectionString;
-            Assert.Single(configuration.GetEndpoints(connectionStringKey));
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            config["eastus"] = connectionString;
+            config["eastus:primary"] = connectionString;
+            config["eastus:secondary"] = connectionString;
+            var endpoints = config.GetSection("eastus").GetNamedEndpointsFromConnectionString().ToArray();
+            Assert.Equal(3, endpoints.Length);
+            Assert.All(endpoints, e => Assert.Equal("eastus", e.Name));
+            Assert.Equal(EndpointType.Primary, endpoints[0].EndpointType);
+            Assert.Equal(EndpointType.Primary, endpoints[1].EndpointType);
+            Assert.Equal(EndpointType.Secondary, endpoints[2].EndpointType);
+        }
+
+        [Fact]
+        public void TestGetEndpointsFromIdentityAndConnectionString()
+        {
+            var services = new ServiceCollection();
+            services.AddAzureClientsCore();
+            var factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+            var serviceUri = "http://signalr.service.uri.com:441";
+            config["endpoints:eastus:serviceUri"] = serviceUri;
+            config["endpoints:westus:secondary"] = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+
+            var endpoints = config.GetSection("endpoints").GetEndpoints(factory).ToArray();
+            Assert.Collection(endpoints, e =>
+            {
+                Assert.Equal("eastus", e.Name);
+                Assert.Equal(serviceUri, e.Endpoint);
+            }, e =>
+            {
+                Assert.Equal("westus", e.Name);
+                Assert.Equal(EndpointType.Secondary, e.EndpointType);
+            });
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Microsoft.Azure.SignalR.Common.Tests.csproj
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Microsoft.Azure.SignalR.Common.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Now support following format (identity-based + connection string):
```json
{
    "<SectionNameForEndpoints>": {
        "eastus": {
            "serviceUri": "http://signalr.service.uri.com:441",
            "credential": "managedidentity",
            "type": "secondary"
        },
        "westus": {
            "primary": "<ConnectionString>",
            "secondary": "<ConnectionString>"
        },
        "southasia": "<ConnectionString>"
    }
}
```
