### PR TITLE
Send serverId via http header.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.SignalR
         public static class Headers
         {
             public const string AsrsHeaderPrefix = "X-ASRS-";
+            public const string AsrsServerId = AsrsHeaderPrefix + "Server-Id";
             public const string AsrsMessageTracingId = AsrsHeaderPrefix + "Message-Tracing-Id";
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceEndpointProvider.cs
@@ -20,6 +20,5 @@ namespace Microsoft.Azure.SignalR
         string GetServerEndpoint(string hubName);
 
         IWebProxy Proxy { get; }
-
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Azure.SignalR
     internal class ConnectionFactory : IConnectionFactory
     {
         private readonly ILoggerFactory _loggerFactory;
-        private readonly string _userId;
+        private readonly string _serverId;
 
         public ConnectionFactory(IServerNameProvider nameProvider, ILoggerFactory loggerFactory)
         {
             _loggerFactory = loggerFactory != null ? new GracefulLoggerFactory(loggerFactory) : throw new ArgumentNullException(nameof(loggerFactory));
-            _userId = nameProvider?.GetName();
+            _serverId = nameProvider?.GetName();
         }
 
         public async Task<ConnectionContext> ConnectAsync(HubServiceEndpoint hubServiceEndpoint,
@@ -31,8 +31,15 @@ namespace Microsoft.Azure.SignalR
         {
             var provider = hubServiceEndpoint.Provider;
             var hubName = hubServiceEndpoint.Hub;
-            Task<string> accessTokenGenerater() => provider.GenerateServerAccessTokenAsync(hubName, _userId);
+            Task<string> accessTokenGenerater() => provider.GenerateServerAccessTokenAsync(hubName, _serverId);
             var url = GetServiceUrl(provider, hubName, connectionId, target);
+
+            headers ??= new Dictionary<string, string>();
+            if (!headers.ContainsKey(Constants.Headers.AsrsServerId))
+            {
+                headers.Add(Constants.Headers.AsrsServerId, _serverId);
+            }
+
             var connectionOptions = new WebSocketConnectionOptions
             {
                 Headers = headers,

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.SignalR
             var url = GetServiceUrl(provider, hubName, connectionId, target);
 
             headers ??= new Dictionary<string, string>();
-            if (!headers.ContainsKey(Constants.Headers.AsrsServerId))
+            if (!string.IsNullOrEmpty(_serverId) && !headers.ContainsKey(Constants.Headers.AsrsServerId))
             {
                 headers.Add(Constants.Headers.AsrsServerId, _serverId);
             }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -212,6 +212,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         public int ConnectionType { get; set; }
 
         /// <summary>
+        /// Gets or sets the target of service connection, only work for OnDemand connections.
+        /// </summary>
+        public string Target { get; set; }
+
+        /// <summary>
         /// Gets or sets the migratable flag.
         /// <value>
         /// <list type="bullet">
@@ -222,11 +227,6 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </value>
         /// </summary>
         public int MigrationLevel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target of service connection, only work for OnDemand connections.
-        /// </summary>
-        public string Target { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HandshakeRequestMessage"/> class.

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
         }
 
         [Fact(Skip = "Access token does not need to be unique")]
-        public async Task GenerateMutlipleAccessTokenShouldBeUnique()
+        public async Task GenerateMultipleAccessTokenShouldBeUnique()
         {
             var sep = new ServiceEndpointProvider(new ServiceEndpoint(DefaultConnectionString), new ServiceOptions() { });
             var userId = Guid.NewGuid().ToString();


### PR DESCRIPTION
`ServerId` is required while using our SDK in `server-sticky` mode. 

Well, with aad auth enabled, the server connection will use `AadToken` to connect to our service instead of `AccessToken` signed by our `AccessKey`, which does NOT contain the correct `UserIdentifier`.

To solve this, I'd like to move the `serverId` to the HTTP request header.