### PR TITLE
Allow transient mode to use `ServiceManagerOptions.ServiceEndpoints`

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.SignalR.Management
                 }
                 if (count > 1)
                 {
-                    throw new NotImplementedException($"Multiple service endpoints are set via {ConnectionString} or {ServiceEndpoints}, but multiple service endpoints in transient mode are not implemented now.");
+                    throw new NotImplementedException($"Multiple service endpoints are set via {ConnectionString} or {ServiceEndpoints}, but multiple service endpoints in transient mode are not implemented yet.");
                 }
             }
         }

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.SignalR.Management
                 }
                 if (count > 1)
                 {
-                    throw new InvalidOperationException($"Multiple service endpoints are set via {ConnectionString} or {ServiceEndpoints}, but transient transport type does not support multiple service endpoints yet.");
+                    throw new NotImplementedException($"Multiple service endpoints are set via {ConnectionString} or {ServiceEndpoints}, but multiple service endpoints in transient mode are not implemented now.");
                 }
             }
         }

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net;
-using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.SignalR.Management
@@ -64,7 +63,7 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new InvalidOperationException($"{nameof(ServiceEndpoints)} is empty. {nameof(ConnectionString)} is  null, empty, or consists only of white-space.");
             }
             // forbid multiple endpoints in transient mode.
-            if (ServiceTransportType == ServiceTransportType.Transient )
+            if (ServiceTransportType == ServiceTransportType.Transient)
             {
                 var count = ConnectionString == null ? 0 : 1;
                 if (ServiceEndpoints != null)

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -63,15 +63,17 @@ namespace Microsoft.Azure.SignalR.Management
             {
                 throw new InvalidOperationException($"{nameof(ServiceEndpoints)} is empty. {nameof(ConnectionString)} is  null, empty, or consists only of white-space.");
             }
-            if (ServiceTransportType == ServiceTransportType.Transient)
+            // forbid multiple endpoints in transient mode.
+            if (ServiceTransportType == ServiceTransportType.Transient )
             {
-                if (string.IsNullOrWhiteSpace(ConnectionString))
+                var count = ConnectionString == null ? 0 : 1;
+                if (ServiceEndpoints != null)
                 {
-                    throw new InvalidOperationException($"{nameof(ConnectionString)} must be set for transient mode.");
+                    count += ServiceEndpoints.Length;
                 }
-                if (ServiceEndpoints?.Length > 0)
+                if (count > 1)
                 {
-                    throw new NotSupportedException($"Multiple endpoints are not supported for transient mode. Please unset {nameof(ServiceEndpoints)}");
+                    throw new InvalidOperationException($"Multiple service endpoints are set via {ConnectionString} or {ServiceEndpoints}, but transient transport type does not support multiple service endpoints yet.");
                 }
             }
         }

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,8 +46,9 @@ namespace Microsoft.Azure.SignalR.Management
                             payloadSerializerSettings = newtonsoftServiceHubProtocolOptions.Value.PayloadSerializerSettings;
                         }
                         var httpClientFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
+                        var serviceEndpoint = _serviceProvider.GetRequiredService<IServiceEndpointManager>().Endpoints.First().Key;
                         var restClient = new RestClient(httpClientFactory, payloadSerializerSettings, _options.EnableMessageTracing);
-                        return new RestHubLifetimeManager(hubName, new ServiceEndpoint(_options.ConnectionString), _options.ProductInfo, _options.ApplicationName, restClient);
+                        return new RestHubLifetimeManager(hubName, serviceEndpoint, _options.ProductInfo, _options.ApplicationName, restClient);
                     }
                 default: throw new InvalidEnumArgumentException(nameof(ServiceManagerOptions.ServiceTransportType), (int)_options.ServiceTransportType, typeof(ServiceTransportType));
             }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -167,10 +167,10 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         }
 
         [Fact]
-        public async Task ServiceEndpoints_NotAppliedToTransientModeAsync()
+        public async Task MultiServiceEndpoints_NotAppliedToTransientModeAsync()
         {
             // to avoid possible file name conflict with another FileConfigHotReloadTest
-            string configPath = nameof(ServiceEndpoints_NotAppliedToTransientModeAsync);
+            string configPath = nameof(MultiServiceEndpoints_NotAppliedToTransientModeAsync);
             var connStr = FakeEndpointUtils.GetFakeConnectionString(1).Single();
             var configObj = new
             {
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             var optionsMonitor = provider.GetRequiredService<IOptionsMonitor<ServiceOptions>>();
             Assert.Equal(connStr, optionsMonitor.CurrentValue.ConnectionString);
 
-            //update json config file
+            //update json config file which won't pass validation
             var newConfigObj = new
             {
                 Azure = new
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             };
             File.WriteAllText(configPath, JsonConvert.SerializeObject(newConfigObj));
             await Task.Delay(5000);
-            Assert.Equal(connStr, optionsMonitor.CurrentValue.ConnectionString);// new config not reloaded
+            Assert.Equal(connStr, optionsMonitor.CurrentValue.ConnectionString);// as new config don't pass validation, it is not reloaded
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -161,7 +161,6 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         {
             Assert.Throws<InvalidOperationException>(
                 () => new ServiceCollection().AddSignalRServiceManager()
-                                   .Configure<ServiceManagerOptions>(o => o.ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray())
                                    .BuildServiceProvider()
                                    .GetRequiredService<IOptions<ServiceManagerOptions>>()
                                    .Value);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         [Fact]
         public void ForbidMultipleEndpointsInTransientModeFact()
         {
-            Assert.Throws<InvalidOperationException>(() => new ServiceManagerOptions
+            Assert.Throws<NotImplementedException>(() => new ServiceManagerOptions
             {
                 ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single(),
                 ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray()
             }.ValidateOptions());
 
-            Assert.Throws<InvalidOperationException>(() => new ServiceManagerOptions
+            Assert.Throws<NotImplementedException>(() => new ServiceManagerOptions
             {
                 ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray()
             }.ValidateOptions());

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.SignalR.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Management.Tests
+{
+    public class ServiceManagerOptionsFacts
+    {
+        [Fact]
+        public void ForbidMultipleEndpointsInTransientModeFact()
+        {
+            Assert.Throws<InvalidOperationException>(() => new ServiceManagerOptions
+            {
+                ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single(),
+                ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray()
+            }.ValidateOptions());
+
+            Assert.Throws<InvalidOperationException>(() => new ServiceManagerOptions
+            {
+                ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray()
+            }.ValidateOptions());
+        }
+
+        [Fact]
+        public void AllowSingleEndpointInTransientModeFact()
+        {
+            new ServiceManagerOptions { ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray() }.ValidateOptions();
+        }
+    }
+}


### PR DESCRIPTION
Users need to use `ServiceManagerOptions.ServiceEndpoints` when they want to use `TokenCrendential`.
Fix problem mentioned at https://github.com/Azure/azure-signalr/issues/1404#issuecomment-908058532
