### PR TITLE
Support  strong typed hubs in Serverless SDK

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.SignalR.Management
             return services.AddSignalRServiceCore();
         }
 
-
-        public static IServiceCollection AddHub(this IServiceCollection services, string hubName)
+        public static IServiceCollection AddHub<THub>(this IServiceCollection services, string hubName)
+            where THub : Hub
         {
             //for persistent
             services.AddSingleton<IServiceConnectionContainer>(sp => sp.GetRequiredService<MultiEndpointConnectionContainerFactory>().Create(hubName))
@@ -51,12 +51,26 @@ namespace Microsoft.Azure.SignalR.Management
             services.AddSingleton(sp => ActivatorUtilities.CreateInstance<RestHealthCheckService>(sp, hubName));
 
             return services
+                .AddLogging()
                 .AddSingleton<ServiceHubLifetimeManagerFactory>()
                 .AddSingleton(sp => ActivatorUtilities.CreateInstance<HostedServiceFactory>(sp).Create())
-                .AddSingleton(sp => sp.GetRequiredService<ServiceHubLifetimeManagerFactory>().Create(hubName))
-                .AddSingleton(sp => (HubLifetimeManager<Hub>)sp.GetRequiredService<IServiceHubLifetimeManager>())
-                .AddSingleton(sp => ActivatorUtilities.CreateInstance<ServiceHubContextImpl>(sp, hubName))
-                .AddLogging();
+                //The following three lines register three reference types for the same instance.
+                .AddSingleton(sp => sp.GetRequiredService<ServiceHubLifetimeManagerFactory>().Create<THub>(hubName))
+                .AddSingleton(sp => (HubLifetimeManager<THub>)sp.GetRequiredService<IServiceHubLifetimeManager<THub>>())
+                .AddSingleton<IServiceHubLifetimeManager>(sp => sp.GetRequiredService<IServiceHubLifetimeManager<THub>>())
+                //used only when THub is Hub
+                .AddSingleton<ServiceHubContext>(sp => ActivatorUtilities.CreateInstance<ServiceHubContextImpl>(sp, hubName));
+        }
+
+        public static IServiceCollection AddHub<THub, T>(this IServiceCollection services, string hubName)
+            where THub : Hub
+            where T : class
+        {
+            return services
+                .AddHub<THub>(hubName)
+                .AddSingleton<ServiceHubContext<T>, ServiceHubContextImpl<T>>()
+                .AddSingleton(sp => sp.GetRequiredService<ServiceHubLifetimeManagerFactory>().Create<Hub<T>>(hubName))
+                .AddSingleton(sp => (HubLifetimeManager<Hub<T>>)sp.GetRequiredService<IServiceHubLifetimeManager<Hub<T>>>());
         }
 
         private static IServiceCollection AddSignalRServiceCore(this IServiceCollection services)
@@ -67,7 +81,7 @@ namespace Microsoft.Azure.SignalR.Management
             var tempServices = new ServiceCollection().AddSignalR()
                 .AddAzureSignalR<CascadeServiceOptionsSetup>().Services;
             services.Add(tempServices.Where(service => service.ServiceType != typeof(IHostedService)));
-            
+
             //add dependencies for persistent mode only
             services
                 .AddSingleton<ConnectionFactory>()

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -22,16 +22,16 @@ namespace Microsoft.Azure.SignalR.Management
             _options = context.Value;
         }
 
-        public IServiceHubLifetimeManager Create(string hubName)
+        public IServiceHubLifetimeManager<THub> Create<THub>(string hubName) where THub : Hub
         {
             switch (_options.ServiceTransportType)
             {
                 case ServiceTransportType.Persistent:
                     {
                         var container = _serviceProvider.GetRequiredService<IServiceConnectionContainer>();
-                        var connectionManager = new ServiceConnectionManager<Hub>();
+                        var connectionManager = new ServiceConnectionManager<THub>();
                         connectionManager.SetServiceConnection(container);
-                        return ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<Hub>>(_serviceProvider, connectionManager);
+                        return ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<THub>>(_serviceProvider, connectionManager);
                     }
                 case ServiceTransportType.Transient:
                     {
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.SignalR.Management
                         var httpClientFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
                         var serviceEndpoint = _serviceProvider.GetRequiredService<IServiceEndpointManager>().Endpoints.First().Key;
                         var restClient = new RestClient(httpClientFactory, payloadSerializerSettings, _options.EnableMessageTracing);
-                        return new RestHubLifetimeManager(hubName, serviceEndpoint, _options.ProductInfo, _options.ApplicationName, restClient);
+                        return new RestHubLifetimeManager<THub>(hubName, serviceEndpoint, _options.ProductInfo, _options.ApplicationName, restClient);
                     }
                 default: throw new InvalidEnumArgumentException(nameof(ServiceManagerOptions.ServiceTransportType), (int)_options.ServiceTransportType, typeof(ServiceTransportType));
             }

--- a/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager`T.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager`T.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal interface IServiceHubLifetimeManager<THub> : IServiceHubLifetimeManager where THub : Hub
+    {
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    internal class RestHubLifetimeManager : HubLifetimeManager<Hub>, IServiceHubLifetimeManager
+    internal class RestHubLifetimeManager<THub> : HubLifetimeManager<Hub>, IServiceHubLifetimeManager<THub> where THub : Hub
     {
         private const string NullOrEmptyStringErrorMessage = "Argument cannot be null or empty.";
         private const string TtlOutOfRangeErrorMessage = "Ttl cannot be less than 0.";

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.SignalR.Management
                 .AddSingleton(_endpointManager)
                 .AddSingleton<IEndpointRouter>(new FixedEndpointRouter(targetEndpoints));
 
-            return services.BuildServiceProvider().GetRequiredService<ServiceHubContextImpl>();
+            return services.BuildServiceProvider().GetRequiredService<ServiceHubContext>();
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl`T.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl`T.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal class ServiceHubContextImpl<T> : ServiceHubContext<T> where T : class
+    {
+        private readonly ServiceHubContext _baseHubContext;
+
+        public override IHubClients<T> Clients { get; }
+
+        public override GroupManager Groups => _baseHubContext.Groups;
+
+        public override ClientManager ClientManager => _baseHubContext.ClientManager;
+
+        public override UserGroupManager UserGroupManager => _baseHubContext.UserGroups;
+
+        public ServiceHubContextImpl(ServiceHubContext baseHubContext, IHubContext<Hub<T>,T> typedHubContext)
+        {
+            _baseHubContext = baseHubContext;
+            Clients = typedHubContext.Clients;
+        }
+
+        public override Task DisposeAsync() => _baseHubContext.DisposeAsync();
+
+        public override ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default) => _baseHubContext.NegotiateAsync(negotiationOptions, cancellationToken);
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext`T.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext`T.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.Azure.SignalR.Management
 {
+    //todo: make public strong-typed-hub
     internal abstract class ServiceHubContext<T> : IHubContext<Hub<T>, T> where T : class
     {
         public abstract IHubClients<T> Clients { get; }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext`T.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext`T.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    internal abstract class ServiceHubContext<T> : IHubContext<Hub<T>, T> where T : class
+    {
+        public abstract IHubClients<T> Clients { get; }
+
+        public abstract GroupManager Groups { get; }
+
+        public abstract UserGroupManager UserGroupManager { get; }
+
+        public abstract ClientManager ClientManager { get; }
+
+        IGroupManager IHubContext<Hub<T>, T>.Groups => Groups;
+
+        /// <summary>
+        /// Performs a negotiation operation asynchronously that routes a client to a Azure SignalR instance.
+        /// </summary>
+        /// <returns>A negotiation response object that contains an endpoint url and an access token for the client to connect to the Azure SignalR instance. </returns>
+        public abstract ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default);
+
+        public abstract Task DisposeAsync();
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.SignalR.Management
     {
         public abstract Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken);
 
+        //todo: make public strong-typed-hub
         internal virtual Task<ServiceHubContext<T>> CreateHubContextAsync<T>(string hubName, CancellationToken cancellationToken) where T : class => throw new NotImplementedException();
 
         public abstract Task<bool> IsServiceHealthy(CancellationToken cancellationToken);

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManager.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.SignalR.Management
     {
         public abstract Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken);
 
+        internal virtual Task<ServiceHubContext<T>> CreateHubContextAsync<T>(string hubName, CancellationToken cancellationToken) where T : class => throw new NotImplementedException();
+
         public abstract Task<bool> IsServiceHealthy(CancellationToken cancellationToken);
 
         public abstract void Dispose();

--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
@@ -47,6 +47,13 @@ namespace Microsoft.Azure.SignalR.Management
             return builder.CreateAsync(hubName, cancellationToken);
         }
 
+        internal override Task<ServiceHubContext<T>> CreateHubContextAsync<T>(string hubName, CancellationToken cancellation)
+        {
+            var builder = new ServiceHubContextBuilder(_services);
+            builder.ConfigureServices(services => services.Configure<ServiceManagerOptions>(o => o.ConnectionCount = 3));
+            return builder.CreateAsync<T>(hubName, cancellation);
+        }
+
         public override void Dispose()
         {
             (_serviceProvider as IDisposable)?.Dispose();

--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    internal class WebSocketsHubLifetimeManager<THub> : ServiceLifetimeManagerBase<THub>, IServiceHubLifetimeManager where THub : Hub
+    internal class WebSocketsHubLifetimeManager<THub> : ServiceLifetimeManagerBase<THub>, IServiceHubLifetimeManager<THub> where THub : Hub
     {
         private IOptions<ServiceManagerOptions> _serviceManagerOptions;
 


### PR DESCRIPTION
Usage:
```cs
public interface IChatClient
{
    Task NewMessage(string message);
}

var typedHubContext = serviceManager.CreateHubContextAsync<IChatClient>(hubName, cancellation);
await typedHubContext.Clients.All.NewMessage("message");
```
