### PR TITLE
Fix persistent mode still check endpoint health with single endpoint 

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -77,10 +77,12 @@ namespace Microsoft.Azure.SignalR.Management
         {
             services.AddSingleton<IServiceManager, ServiceManagerImpl>();
             services.PostConfigure<ServiceManagerOptions>(o => o.ValidateOptions());
-            var tempServices = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR<CascadeServiceOptionsSetup>().Services;
-            services.Add(tempServices.Where(service => service.ServiceType != typeof(IHostedService)));
-            services.AddSingleton<IEndpointRouter, AutoHealthCheckRouter>();
+            var tempServices = new ServiceCollection()
+                .AddSingleton<IEndpointRouter, AutoHealthCheckRouter>()
+                .AddSignalR()
+                .AddAzureSignalR<CascadeServiceOptionsSetup>().Services
+                .Where(service => service.ServiceType != typeof(IHostedService));
+            services.Add(tempServices);
 
             //add dependencies for persistent mode only
             services

--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -77,10 +77,10 @@ namespace Microsoft.Azure.SignalR.Management
         {
             services.AddSingleton<IServiceManager, ServiceManagerImpl>();
             services.PostConfigure<ServiceManagerOptions>(o => o.ValidateOptions());
-            services.TryAddSingleton<IEndpointRouter, AutoHealthCheckRouter>();
             var tempServices = new ServiceCollection().AddSignalR()
                 .AddAzureSignalR<CascadeServiceOptionsSetup>().Services;
             services.Add(tempServices.Where(service => service.ServiceType != typeof(IHostedService)));
+            services.AddSingleton<IEndpointRouter, AutoHealthCheckRouter>();
 
             //add dependencies for persistent mode only
             services

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Negotiation/NegotiationFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Negotiation/NegotiationFacts.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Common;
+using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.SignalR.Management.Tests
+{
+    /// <summary>
+    /// Contains negotiation tests that need cooperation of multiple classes.
+    /// </summary>
+    public class NegotiationFacts
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        public NegotiationFacts(ITestOutputHelper testOutput)
+        {
+            _loggerFactory = new LoggerFactory();
+            _loggerFactory.AddXunit(testOutput);
+        }
+        [Theory]
+        [InlineData(ServiceTransportType.Persistent)]
+        [InlineData(ServiceTransportType.Transient)]
+        public async Task HubContextNotCheckEndpointHealthWithSingleEndpoint(ServiceTransportType serviceTransportType)
+        {
+            var serviceManager = new ServiceManagerBuilder()
+                .WithOptions(o =>
+                {
+                    o.ServiceTransportType = serviceTransportType;
+                    o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).First();
+                })
+                .WithLoggerFactory(_loggerFactory)
+                .BuildServiceManager();
+            var hubContext = await serviceManager.CreateHubContextAsync("hubName", default);
+            var negotiateResponse = await hubContext.NegotiateAsync();
+            Assert.NotNull(negotiateResponse);
+        }
+
+        [Theory]
+        [InlineData(ServiceTransportType.Persistent)]
+        [InlineData(ServiceTransportType.Transient)]
+        public async Task StrongTypedHubContextNotCheckEndpointHealthWithSingleEndpoint(ServiceTransportType serviceTransportType)
+        {
+            var serviceManager = new ServiceManagerBuilder()
+                .WithOptions(o =>
+                {
+                    o.ServiceTransportType = serviceTransportType;
+                    o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).First();
+                })
+                .WithLoggerFactory(_loggerFactory)
+                .BuildServiceManager();
+            var hubContext = await serviceManager.CreateHubContextAsync<IChat>("hubName", default);
+            var negotiateResponse = await hubContext.NegotiateAsync();
+            Assert.NotNull(negotiateResponse);
+        }
+
+        [Theory]
+        [InlineData(ServiceTransportType.Persistent)]
+        //[InlineData(ServiceTransportType.Transient)] Not implemented yet
+        public async Task HubContextCheckEndpointHealthWithMultiEndpoints(ServiceTransportType serviceTransportType)
+        {
+            var serviceManager = new ServiceManagerBuilder()
+                .WithOptions(o =>
+                {
+                    o.ServiceTransportType = serviceTransportType;
+                    o.ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray();
+                })
+                .WithLoggerFactory(_loggerFactory)
+                .BuildServiceManager();
+            var hubContext = await serviceManager.CreateHubContextAsync("hubName", default);
+            await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(() => hubContext.NegotiateAsync().AsTask());
+        }
+
+        [Theory]
+        [InlineData(ServiceTransportType.Persistent)]
+        //[InlineData(ServiceTransportType.Transient)] Not implemented yet
+        public async Task StrongTypedHubContextCheckEndpointHealthWithMultiEndpoints(ServiceTransportType serviceTransportType)
+        {
+            var serviceManager = new ServiceManagerBuilder()
+                .WithOptions(o =>
+                {
+                    o.ServiceTransportType = serviceTransportType;
+                    o.ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray();
+                })
+                .WithLoggerFactory(_loggerFactory)
+                .BuildServiceManager();
+            var hubContext = await serviceManager.CreateHubContextAsync<IChat>("hubName", default);
+            await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(() => hubContext.NegotiateAsync().AsTask());
+        }
+
+        public interface IChat
+        {
+            Task NewMessage(string message);
+        }
+    }
+}


### PR DESCRIPTION
* Add unit tests
Previously `IEndpointRouter` implementation `AutoHealthCheckRouter` is overridden by `DefaultEndpointRouter` introduced by ServerSDK