### PR TITLE
Make `ServiceHubContext` implements `IDisposable`

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    public abstract class ServiceHubContext : IServiceHubContext
+    public abstract class ServiceHubContext : IServiceHubContext, IDisposable
     {
         /// <summary>
         /// Gets a user group manager instance which implements <see cref="IUserGroupManager"/> that can be used to add and remove users to named groups.
@@ -31,5 +31,10 @@ namespace Microsoft.Azure.SignalR.Management
         public virtual ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public virtual Task DisposeAsync() => Task.CompletedTask;
+
+        public void Dispose()
+        {
+            DisposeAsync().GetAwaiter().GetResult();
+        }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
 
         public virtual Task DisposeAsync() => Task.CompletedTask;
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             DisposeAsync().GetAwaiter().GetResult();
         }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.SignalR.Management
         private readonly NegotiateProcessor _negotiateProcessor;
         private readonly IServiceEndpointManager _endpointManager;
         
-        private bool _disposed;
+        private bool _disposing;
         internal IServiceProvider ServiceProvider { get; }
 
         public override IHubClients Clients => _hubContext.Clients;
@@ -57,9 +57,9 @@ namespace Microsoft.Azure.SignalR.Management
         {
             // Check _disposed to avoid disposing twice.
             // When host is diposed, it will dispose all the disposable services including this class.
-            if (!_disposed)
+            if (!_disposing)
             {
-                _disposed = true;
+                _disposing = true;
                 using var host = ServiceProvider.GetRequiredService<IHost>();
                 await host.StopAsync();
             }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Management
 {
-    internal class ServiceHubContextImpl : ServiceHubContext, IInternalServiceHubContext
+    internal sealed class ServiceHubContextImpl : ServiceHubContext, IInternalServiceHubContext
     {
         private readonly string _hubName;
         private readonly IHubContext<Hub> _hubContext;

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.SignalR.Management
         private readonly IHubContext<Hub> _hubContext;
         private readonly NegotiateProcessor _negotiateProcessor;
         private readonly IServiceEndpointManager _endpointManager;
-
+        
+        private bool _disposed;
         internal IServiceProvider ServiceProvider { get; }
 
         public override IHubClients Clients => _hubContext.Clients;
@@ -54,8 +55,14 @@ namespace Microsoft.Azure.SignalR.Management
 
         public override async Task DisposeAsync()
         {
-            using var host = ServiceProvider.GetRequiredService<IHost>();
-            await host.StopAsync();
+            // Check _disposed to avoid disposing twice.
+            // When host is diposed, it will dispose all the disposable services including this class.
+            if (!_disposed)
+            {
+                _disposed = true;
+                using var host = ServiceProvider.GetRequiredService<IHost>();
+                await host.StopAsync();
+            }
         }
 
         ServiceHubContext IInternalServiceHubContext.WithEndpoints(IEnumerable<ServiceEndpoint> endpoints)

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         internal async Task TestRestHealthCheckServiceWithUnhealthyEndpoint(RestClientFactory implementationInstance)
         {
             using var _ = StartLog(out var loggerFactory);
-            var serviceHubContext = await new ServiceManagerBuilder()
+            using var serviceHubContext = await new ServiceManagerBuilder()
                 .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
                 .WithLoggerFactory(loggerFactory)
                 .ConfigureServices(services =>
@@ -52,7 +52,6 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 .CreateHubContextAsync(HubName, default);
             var endpoint = (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IServiceEndpointManager>().GetEndpoints(HubName).First();
             Assert.False(endpoint.Online);
-            await serviceHubContext.DisposeAsync();
         }
 
         [Fact]
@@ -78,7 +77,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                     o.RetryInterval = retryInterval;
                     o.EnabledForSingleEndpoint = true;
                 });
-            var serviceHubContext = await new ServiceManagerBuilder(services)
+            using var serviceHubContext = await new ServiceManagerBuilder(services)
                 .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
                 .WithLoggerFactory(loggerFactory)
                 .BuildServiceManager()
@@ -93,8 +92,6 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             //Wait until the next health check finish
             await Task.Delay(checkInterval + retryTime + TimeSpan.FromSeconds(1));
             Assert.False(endpoint.Online);
-
-            await serviceHubContext.DisposeAsync();
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -186,14 +186,13 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         [Fact]
         public async Task TestCreateServiceHubContext()
         {
-            var serviceHubContext = await new ServiceManagerBuilder()
+            using var serviceHubContext = await new ServiceManagerBuilder()
                 .WithOptions(o => o.ConnectionString = _testConnectionString)
                 // avoid waiting for health check result for long time
                 .ConfigureServices(services => services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, HttpStatusCode.OK)))
                 .BuildServiceManager()
                 .CreateHubContextAsync(HubName, default);
             Assert.Equal(3, (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ConnectionCount);
-            await serviceHubContext.DisposeAsync();
         }
     }
 }


### PR DESCRIPTION
* Make `ServiceHubContext` implements `IDisposable` 
  So that we can use `using var serviceHubContext = ...`
* Avoid disposing twice

* Make the class `sealed` to avoid dispose pattern

* Make `Dispose` virtual to allow properly implements dispose pattern in the non-sealed subclass.
  Our current sub class is sealed, but in case user want to implement non-sealed subclass.
