### PR TITLE
Add more property to GroupBroadcastMessage

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -147,9 +147,9 @@ namespace Microsoft.Azure.SignalR.Protocol
         public IReadOnlyList<string> ExcludedUserList { get; set; }
 
         /// <summary>
-        /// Gets or sets the user ID of the sender
+        /// Gets or sets the user ID of the message caller
         /// </summary>
-        public string SenderId { get; set; }
+        public string CallerUserId { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GroupBroadcastDataMessage"/> class.

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -142,6 +142,16 @@ namespace Microsoft.Azure.SignalR.Protocol
         public IReadOnlyList<string> ExcludedList { get; set; }
 
         /// <summary>
+        /// Gets or sets the list of excluded user Ids.
+        /// </summary>
+        public IReadOnlyList<string> ExcludedUserList { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user ID of the sender
+        /// </summary>
+        public string SenderId { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GroupBroadcastDataMessage"/> class.
         /// </summary>
         /// <param name="groupName">The group name.</param>

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -450,12 +450,14 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         private static void WriteGroupBroadcastDataMessage(ref MessagePackWriter writer, GroupBroadcastDataMessage message)
         {
-            writer.WriteArrayHeader(5);
+            writer.WriteArrayHeader(7);
             writer.Write(ServiceProtocolConstants.GroupBroadcastDataMessageType);
             writer.Write(message.GroupName);
             WriteStringArray(ref writer, message.ExcludedList);
             WritePayloads(ref writer, message.Payloads);
             message.WriteExtensionMembers(ref writer);
+            WriteStringArray(ref writer, message.ExcludedUserList);
+            writer.Write(message.SenderId);
         }
 
         private static void WriteMultiGroupBroadcastDataMessage(ref MessagePackWriter writer, MultiGroupBroadcastDataMessage message)
@@ -869,6 +871,8 @@ namespace Microsoft.Azure.SignalR.Protocol
             {
                 result.ReadExtensionMembers(ref reader);
             }
+            result.ExcludedUserList = ReadStringArray(ref reader, "excludedUserList");
+            result.SenderId = ReadString(ref reader, "senderId");
             return result;
         }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -871,8 +871,13 @@ namespace Microsoft.Azure.SignalR.Protocol
             {
                 result.ReadExtensionMembers(ref reader);
             }
-            result.ExcludedUserList = ReadStringArray(ref reader, "excludedUserList");
-            result.SenderId = ReadString(ref reader, "senderId");
+
+            if (arrayLength >= 7)
+            {
+                result.ExcludedUserList = ReadStringArray(ref reader, "excludedUserList");
+                result.SenderId = ReadString(ref reader, "senderId");
+            }
+
             return result;
         }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Azure.SignalR.Protocol
             WritePayloads(ref writer, message.Payloads);
             message.WriteExtensionMembers(ref writer);
             WriteStringArray(ref writer, message.ExcludedUserList);
-            writer.Write(message.SenderId);
+            writer.Write(message.CallerUserId);
         }
 
         private static void WriteMultiGroupBroadcastDataMessage(ref MessagePackWriter writer, MultiGroupBroadcastDataMessage message)
@@ -875,7 +875,7 @@ namespace Microsoft.Azure.SignalR.Protocol
             if (arrayLength >= 7)
             {
                 result.ExcludedUserList = ReadStringArray(ref reader, "excludedUserList");
-                result.SenderId = ReadString(ref reader, "senderId");
+                result.CallerUserId = ReadString(ref reader, "callerUserId");
             }
 
             return result;

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         private bool GroupBroadcastDataMessagesEqual(GroupBroadcastDataMessage x, GroupBroadcastDataMessage y)
         {
             return StringEqual(x.GroupName, y.GroupName) &&
-                   StringEqual(x.SenderId, y.SenderId) &&
+                   StringEqual(x.CallerUserId, y.CallerUserId) &&
                    SequenceEqual(x.ExcludedList, y.ExcludedList) &&
                    SequenceEqual(x.ExcludedUserList, y.ExcludedUserList) &&
                    PayloadsEqual(x.Payloads, y.Payloads) &&

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -216,7 +216,9 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         private bool GroupBroadcastDataMessagesEqual(GroupBroadcastDataMessage x, GroupBroadcastDataMessage y)
         {
             return StringEqual(x.GroupName, y.GroupName) &&
+                   StringEqual(x.SenderId, y.SenderId) &&
                    SequenceEqual(x.ExcludedList, y.ExcludedList) &&
+                   SequenceEqual(x.ExcludedUserList, y.ExcludedUserList) &&
                    PayloadsEqual(x.Payloads, y.Payloads) &&
                    x.TracingId == y.TracingId;
         }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -9,6 +9,7 @@ using System.Security.Claims;
 using System.Text;
 
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Protocol.Tests
@@ -232,6 +233,33 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "AckWithMessage_NoOptionalField",
                 message: new AckMessage(2, 101, "Joined group successfully"),
                 binary: "lBQCZblKb2luZWQgZ3JvdXAgc3VjY2Vzc2Z1bGx5"),
+            new ProtocolTestData(
+                name: "GroupBroadcastExcept",
+                message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "lQ2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgA=="),
+            new ProtocolTestData(
+                name: "GroupBroadcast",
+                message: new GroupBroadcastDataMessage("group3",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }),
+                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoA="),
+            new ProtocolTestData(
+                name: "GroupBroadcastWithTracingId",
+                message: new GroupBroadcastDataMessage("group3",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: 1234L),
+                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoEBzQTS"),
         }.ToDictionary(t => t.Name);
 
         public static IDictionary<string, ProtocolTestData> TestData => new[]
@@ -402,7 +430,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoA="),
+                binary: "lw2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoCQwA=="),
             new ProtocolTestData(
                 name: "GroupBroadcastExcept",
                 message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
@@ -411,7 +439,29 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                         ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
                         ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
                     }),
-                binary: "lQ2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgA=="),
+                binary: "lw2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgJDA"),
+            new ProtocolTestData(
+                name: "GroupBroadcastExceptUser",
+                message: new GroupBroadcastDataMessage("group3", new [] {"conn12", "conn13"},
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    })
+                {
+                    ExcludedUserList = new [] {"user1", "user2"},
+                    SenderId = "user3"
+                },
+                binary: "lw2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgJKldXNlcjGldXNlcjKldXNlcjM="),
+            new ProtocolTestData(
+                name: "GroupBroadcastWithTracingId",
+                message: new GroupBroadcastDataMessage("group3",
+                    new Dictionary<string, ReadOnlyMemory<byte>>
+                    {
+                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
+                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
+                    }, tracingId: 1234L),
+                binary: "lw2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoEBzQTSkMA="),
             new ProtocolTestData(
                 name: "MultiGroupBroadcast",
                 message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},
@@ -497,15 +547,6 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "UserLeaveGroupWithTracingId",
                 message: new UserLeaveGroupMessage("conn11", "group2", tracingId: 1234L),
                 binary: "lBGmY29ubjExpmdyb3VwMoEBzQTS"),
-            new ProtocolTestData(
-                name: "GroupBroadcastWithTracingId",
-                message: new GroupBroadcastDataMessage("group3",
-                    new Dictionary<string, ReadOnlyMemory<byte>>
-                    {
-                        ["json"] = new byte[] {6, 7, 1, 2, 3, 4, 5},
-                        ["messagepack"] = new byte[] {7, 1, 2, 3, 4, 5, 6}
-                    }, tracingId: 1234L),
-                binary: "lQ2mZ3JvdXAzkIKkanNvbsQHBgcBAgMEBattZXNzYWdlcGFja8QHBwECAwQFBoEBzQTS"),
             new ProtocolTestData(
                 name: "MultiGroupBroadcastWithTracingId",
                 message: new MultiGroupBroadcastDataMessage(new [] {"group4", "group5"},

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     })
                 {
                     ExcludedUserList = new [] {"user1", "user2"},
-                    SenderId = "user3"
+                    CallerUserId = "user3"
                 },
                 binary: "lw2mZ3JvdXAzkqZjb25uMTKmY29ubjEzgqRqc29uxAcGBwECAwQFq21lc3NhZ2VwYWNrxAcHAQIDBAUGgJKldXNlcjGldXNlcjKldXNlcjM="),
             new ProtocolTestData(


### PR DESCRIPTION
Provide the ability for group broadcast to exclude users, and also add "senderId" property to group broadcast for client pub-sub
