### PR TITLE
use memory pool for parsing.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ConnectionMessage.cs
@@ -157,10 +157,14 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// </summary>
         public ReadOnlySequence<byte> Payload { get; set; }
 
-
         /// <summary>
         /// Gets or sets the message ID
         /// </summary>
         public ulong? TracingId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lease for payload memory.
+        /// </summary>
+        public IDisposable Lease { get; set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MulticastDataMessage.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// Gets or sets the tracing Id
         /// </summary>
         public ulong? TracingId { get; set; }
+
+        public IDisposable[] Leases { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
- Allow to set the memory pool when create the protocol.
- Use memory pool for parsing messages when provided memory pool.

### Discuss
- Should we implement `IDisposable` for those messages contains memory owner?
  - Is it a breaking change?