### PR TITLE
Don't reuse `Utf8JsonWriter` for `Stream` output

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ReusableUtf8JsonWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ReusableUtf8JsonWriter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
+using System.Buffers;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.SignalR
         private bool _inUse;
 #endif
 
-        public ReusableUtf8JsonWriter(Stream stream)
+        public ReusableUtf8JsonWriter(IBufferWriter<byte> stream)
         {
             _writer = new Utf8JsonWriter(stream, new JsonWriterOptions()
             {
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SignalR
             });
         }
 
-        public static ReusableUtf8JsonWriter Get(Stream stream)
+        public static ReusableUtf8JsonWriter Get(IBufferWriter<byte> stream)
         {
             var writer = _cachedInstance;
             if (writer == null)

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/PayloadMessageContentTest.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/PayloadMessageContentTest.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.Common.Tests
 {


### PR DESCRIPTION
The `Utf8JsonWriter.Reset(Stream)` and  `Utf8JsonWriter.Reset()` don't release the underlying array buffer, which is a memory leak. The problem gets worse with the using of thread-pool. If a `Utf8JsonWriter` is initialized or reset with an `IBufferWriter<byte>`, that won't cause memory leak as the underlying array buffer is null in that case.

* Reset `ReusableUtf8JsonWriter` for persistent mode.
* Optimize: Avoid new a `MediaTypeHeaderValue` every time.