### PR TITLE
Resolve `Newtonsoft.Json` version conflicts

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimePackageVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityPackageVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'">


### PR DESCRIPTION
Issue: When AAD auth, we've got an error like this:

>       Failed in authorizing AccessKey for 'https://zityang-signalr-standard-dev-2.service.signalr.net/', will retry in 3 seconds
>      System.IO.FileNotFoundException: Could not load file or assembly 'Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'. The system cannot find the file specified.
>      File name: 'Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
>         at Microsoft.Azure.SignalR.AadAccessKey.UpdateAccessKeyAsync()

This error would occur on both server SDK and management SDK. `Microsoft.AspNetCore.Http.Connections.Common` 1.0.0 -> `Newtonsoft.Json` 11.0.2 while other transitive dependencies for `Newtonsoft.Json` are 10.0.*. This causes version conflicts.
