### PR TITLE
Fix serverless protocol project version

### DIFF
--- a/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
+++ b/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.Azure.SignalR.Serverless.Protocols</RootNamespace>
     <!--Override the global version prefix-->
     <VersionPrefix>1.7.0</VersionPrefix>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Fix issue that when `IsFinalBuild` == true, the version of serverless protocol project would be the same as other projects.
