### PR TITLE
Fix security issue from `Microsoft.AspNetCore.SignalR`  1.0.0 version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,12 +41,15 @@
     <SignedPackageFile Include="$(PublishDir)MessagePack.dll" Certificate="$(ThirdPartyAssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Authentication.JwtBearer.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Connections.Abstractions.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Connections.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Connections.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Http.Features.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.JsonPatch.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.Mvc.NewtonsoftJson.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)Microsoft.AspNetCore.WebSockets.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Azure.Services.AppAuthentication.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Azure.SignalR.AspNet.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Azure.SignalR.Common.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
@@ -78,6 +81,7 @@
     <SignedPackageFile Include="$(PublishDir)System.IdentityModel.Tokens.Jwt.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Text.Encodings.Web.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Memory.Data.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
+    <SignedPackageFile Include="$(PublishDir)System.Net.WebSockets.WebSocketProtocol.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Security.Cryptography.ProtectedData.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
   </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,18 +8,18 @@
     <MicrosoftAspNetCoreHttpConnectionsClientPackage3_0Version>3.0.0</MicrosoftAspNetCoreHttpConnectionsClientPackage3_0Version>
     <MicrosoftAspNetCoreHttpConnectionsClientPackage3_1Version>3.1.9</MicrosoftAspNetCoreHttpConnectionsClientPackage3_1Version>
     <MicrosoftAspNetCoreHttpConnectionsClientPackage5_0Version>5.0.1</MicrosoftAspNetCoreHttpConnectionsClientPackage5_0Version>
-    <MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>1.0.0</MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>
+    <MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>1.0.4</MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion>
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>3.0.0</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_0Version>
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>3.1.9</MicrosoftAspNetCoreHttpConnectionsCommonPackage3_1Version>
     <MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>5.0.1</MicrosoftAspNetCoreHttpConnectionsCommonPackage5_0Version>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>3.0.0</MicrosoftExtensionsLoggingAbstractionsPackage3_0Version>
     <MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>3.1.9</MicrosoftExtensionsLoggingAbstractionsPackage3_1Version>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackage3_0Version>3.0.0</MicrosoftExtensionsDependencyInjectionPackage3_0Version>
     <MicrosoftExtensionsDependencyInjectionPackage3_1Version>3.1.9</MicrosoftExtensionsDependencyInjectionPackage3_1Version>
     <MicrosoftExtensionHttpVersion>2.1.0</MicrosoftExtensionHttpVersion>
-    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>2.1.0</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>2.1.2</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
     <MicrosoftAspNetCoreConnectionsAbstractionsPackage3_0Version>3.0.0</MicrosoftAspNetCoreConnectionsAbstractionsPackage3_0Version>
     <MicrosoftAspNetCoreConnectionsAbstractionsPackage3_1Version>3.1.9</MicrosoftAspNetCoreConnectionsAbstractionsPackage3_1Version>
     <MicrosoftAspNetCoreSignalRPackageVersion>1.0.0</MicrosoftAspNetCoreSignalRPackageVersion>
@@ -32,14 +32,21 @@
     <SystemIdentityModelTokensJwtPackageVersion>5.5.0</SystemIdentityModelTokensJwtPackageVersion>
     <AzureIdentityPackageVersion>1.4.0</AzureIdentityPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>2.1.0</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>2.1.0</MicrosoftExtensionsPrimitivesPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>2.1.1</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftAspNetCoreSignalRClient>1.1.0</MicrosoftAspNetCoreSignalRClient>
     <MicrosoftRestClientRuntimePackageVersion>2.3.21</MicrosoftRestClientRuntimePackageVersion>
+    
+    <!--Security Patch-->
+    <!-- Fix risks from Microsoft.AspNetCore.SignalR 1.0.0-->
+    <MicrosoftAspNetCoreHttpPackageVersion>2.1.22</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreHttpConnectionsPackageVersion>1.0.15</MicrosoftAspNetCoreHttpConnectionsPackageVersion>
+    <MicrosoftAspNetCoreWebSocketsPackageVersion>2.1.7</MicrosoftAspNetCoreWebSocketsPackageVersion>
+    <SystemNetWebSocketsWebSocketProtocolPackageVersion>4.5.3</SystemNetWebSocketsWebSocketProtocolPackageVersion>
 
     <!-- Azure ASP.NET SignalR -->
     <MicrosoftAspNetSignalRPackageVersion>2.4.1</MicrosoftAspNetSignalRPackageVersion>
     <MicrosoftAspNetSignalRClientVersion>2.4.1</MicrosoftAspNetSignalRClientVersion>
-    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>2.1.0</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>2.1.2</MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingEventSourcePackageVersion>2.1.0</MicrosoftExtensionsLoggingEventSourcePackageVersion>
     <SystemThreadingChannelsPackageVersion>4.6.0</SystemThreadingChannelsPackageVersion>
     <SystemIOPipelinesPackageVersion>4.6.0</SystemIOPipelinesPackageVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,6 +52,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="$(MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
+    
+    <!--Security Patches-->
+    <!-- Fix risks from Microsoft.AspNetCore.SignalR-->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="$(MicrosoftAspNetCoreHttpConnectionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="$(MicrosoftAspNetCoreWebSocketsPackageVersion)" />
+    <PackageReference Include="System.Net.WebSockets.WebSocketProtocol" Version="$(SystemNetWebSocketsWebSocketProtocolPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Questions: Should we use floating version to get the latest patch version automatically?
## Vulnerable transitive dependencies update
* Microsoft.AspNetCore.Http  2.1.0 -> 2.1.22
* Microsof.tAspNetCore.Http.Connections 1.0.0 -> 1.0.15
*  Microsoft.AspNetCore.WebSockets 2.1.0 -> 2.1.7 
* System.Net.WebSockets.WebSocketProtocol 4.5.0 -> 4.5.3

## Other packages updates to resolve version conflicts
* Microsoft.AspNetCore.Http.Connections.Common 1.0.0 -> 1.0.4
* Microsoft.Extensions.Logging.Abstractions 2.1.0 -> 2.1.1
* Microsoft.AspNetCore.Connections.Abstractions 2.1.0 -> 2.1.2
* Microsoft.Extensions.Primitives 2.1.0 -> 2.1.2

[Use a tool locally](https://docs.opensource.microsoft.com/tools/cg/features/dev/) to running detection like online [Component Governance](https://docs.opensource.microsoft.com/tools/cg/) to get the following report:
<details>
<summary>Scanning report</summary>

[INFO] ====================================================== 
[INFO]     Component: Microsoft.AspNetCore.WebSockets 2.1.0 - NuGet 
[INFO]      Found In: /src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj 
[INFO]      Found In: /src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj 
[INFO] ====================================================== 
[INFO] ------------------ Vulnerability #1 ------------------ 
[INFO]         Title: CVE-2019-0548 
[INFO]      Severity: Moderate 
[INFO]   Description: A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka "ASP.NET Core Denial of Service Vulnerability." This affects ASP.NET Core 2.2, ASP.NET Core 2.1. This CVE ID is unique from CVE-2019-0564. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.SignalR - 1.1.0; Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets - 2.2.1; Microsoft.AspNetCore.Server.IIS - 2.2.1; Microsoft.AspNetCore.Server.IISIntegration - 2.2.1;Microsoft.AspNetCore.Server.Kestrel.Core - 2.1.7 
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2019-0548 
[INFO] ------------------ Vulnerability #2 ------------------ 
[INFO]         Title: CVE-2019-0564 
[INFO]      Severity: Moderate 
[INFO]   Description: A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka "ASP.NET Core Denial of Service Vulnerability." This affects ASP.NET Core 2.1. This CVE ID is unique from CVE-2019-0548. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.WebSockets - 2.1.7,2.2.1;Microsoft.AspNetCore.Server.Kestrel.Core - 2.1.7;System.Net.WebSockets.WebSocketProtocol - 4.5.3;Microsoft.NETCore.App - 2.1.7,2.2.1;Microsoft.AspNetCore.App - 2.1.7,2.2.1;Microsoft.AspNetCore.All - 2.1.7,2.2.1 
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2019-0564 
[INFO] 
 
[INFO] ====================================================== 
[INFO]     Component: Microsoft.AspNetCore.Http 2.1.0 - NuGet 
[INFO]      Found In: /src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj 
[INFO]      Found In: /src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj 
[INFO] ====================================================== 
[INFO] ------------------ Vulnerability #1 ------------------ 
[INFO]         Title: CVE-2020-1045 
[INFO]      Severity: Moderate 
[INFO]   Description: A security feature bypass vulnerability exists in the way Microsoft ASP.NET Core parses encoded cookie names.The ASP.NET Core cookie parser decodes entire cookie strings which could allow a malicious attacker to set a second cookie with the name being percent encoded.The security update addresses the vulnerability by fixing the way the ASP.NET Core cookie parser handles encoded names., aka 'Microsoft ASP.NET Core Security Feature Bypass Vulnerability'. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.App - 2.1.22, Microsoft.AspNetCore.All - 2.1.22,Microsoft.NETCore.App - 2.1.22, Microsoft.AspNetCore.Http - 2.1.22  
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-1045 
[INFO] 
 
[INFO] ====================================================== 
[INFO]     Component: Microsoft.AspNetCore.Http.Connections 1.0.0 - NuGet 
[INFO]      Found In: /src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj 
[INFO]      Found In: /src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj 
[INFO] ====================================================== 
[INFO] ------------------ Vulnerability #1 ------------------ 
[INFO]         Title: CVE-2020-0603 
[INFO]      Severity: Critical 
[INFO]   Description: A remote code execution vulnerability exists in ASP.NET Core software when the software fails to handle objects in memory.An attacker who successfully exploited the vulnerability could run arbitrary code in the context of the current user, aka 'ASP.NET Core Remote Code Execution Vulnerability'. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.Http.Connections - 1.0.15;Microsoft.AspNetCore.App - 2.1.15,3.0.1,3.1.1;Microsoft.AspNetCore.All - 2.1.15 
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-0603 
[INFO] ------------------ Vulnerability #2 ------------------ 
[INFO]         Title: CVE-2020-0602 
[INFO]      Severity: Moderate 
[INFO]   Description: A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka 'ASP.NET Core Denial of Service Vulnerability'. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.Http.Connections - 1.0.15;Microsoft.AspNetCore.App - 2.1.15,3.0.1,3.1.1;Microsoft.AspNetCore.All - 2.0.15 
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-0602 
[INFO] 
 
[INFO] ====================================================== 
[INFO]     Component: System.Net.WebSockets.WebSocketProtocol 4.5.0 - NuGet 
[INFO]      Found In: /src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj 
[INFO]      Found In: /src/Microsoft.Azure.SignalR.Management/Microsoft.Azure.SignalR.Management.csproj 
[INFO] ====================================================== 
[INFO] ------------------ Vulnerability #1 ------------------ 
[INFO]         Title: CVE-2019-0564 
[INFO]      Severity: Moderate 
[INFO]   Description: A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka "ASP.NET Core Denial of Service Vulnerability." This affects ASP.NET Core 2.1. This CVE ID is unique from CVE-2019-0548. 
[INFO]   Remediation: Upgrade to version Microsoft.AspNetCore.WebSockets - 2.1.7,2.2.1;Microsoft.AspNetCore.Server.Kestrel.Core - 2.1.7;System.Net.WebSockets.WebSocketProtocol - 4.5.3;Microsoft.NETCore.App - 2.1.7,2.2.1;Microsoft.AspNetCore.App - 2.1.7,2.2.1;Microsoft.AspNetCore.All - 2.1.7,2.2.1 
[INFO]      Fixed In:  
[INFO]           URL: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2019-0564 
[INFO] 
</details>