### PR TITLE
Fix AAD with multiple endpoints

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Auth/AuthUtility.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Auth/AuthUtility.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Azure.SignalR
                 {
                     KeyId = signingKey.Id
                 };
+
+                if (signingKey is AadAccessKey)
+                {
+                    // disable cache when using AadAccessKey
+                    securityKey.CryptoProviderFactory.CacheSignatureProviders = false;
+                }
                 credentials = new SigningCredentials(securityKey, GetSecurityAlgorithm(algorithm));
             }
 


### PR DESCRIPTION
KeyId is required to help SignalR Service identity which key should be used to validate the token signature when using AAD.

However, the kid will be the same if you got them with the same Azure Identity (objectId)

In this case, if we enabled the cache, server SDK will get the signature from the cache regardless of the keyValue, while the keys for different endpoints are different though they share the same id.

[code link](https://cs.github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/922901505740480f3fe6349e501ad36082e441e3/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs#L575)