### PR TITLE
Fix management SDK error on .NET standard 2.0: Multiple JSON protocols are registered

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -84,11 +84,13 @@ namespace Microsoft.Azure.SignalR.Management
                 .Where(service => service.ServiceType != typeof(IServiceConnectionContainer))
                 .Where(service => service.ServiceType != typeof(IHostedService));
             services.Add(tempServices);
-            services.AddSingleton<IHubProtocol>(sp =>
+            // Remove the JsonHubProtocol and add new one.
+            // On .NET Standard 2.0, registering multiple hub protocols with the same name is forbidden.
+            services.Replace(ServiceDescriptor.Singleton<IHubProtocol>(sp =>
             {
                 var objectSerializer = sp.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ObjectSerializer;
                 return objectSerializer != null ? new JsonObjectSerializerHubProtocol(objectSerializer) : new JsonHubProtocol();
-            });
+            }));
             //add dependencies for persistent mode only
             services
                 .AddSingleton<ConnectionFactory>()


### PR DESCRIPTION
On .NET standard 2.0, registering multiple hub protocols with the same name is invalid.
https://github.com/aspnet/SignalR/blob/a9def470e3b8e1480c55d1c311e4b37472140307/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubProtocolResolver.cs#L32

Following task: #1534