### PR TITLE
Enable source link and symbol package

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -35,7 +35,7 @@
     <MicrosoftExtensionsPrimitivesPackageVersion>2.1.1</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftAspNetCoreSignalRClient>1.1.0</MicrosoftAspNetCoreSignalRClient>
     <MicrosoftRestClientRuntimePackageVersion>2.3.21</MicrosoftRestClientRuntimePackageVersion>
-    
+
     <!--Security Patch-->
     <!-- Fix risks from Microsoft.AspNetCore.SignalR 1.0.0-->
     <MicrosoftAspNetCoreHttpPackageVersion>2.1.22</MicrosoftAspNetCoreHttpPackageVersion>
@@ -65,6 +65,8 @@
 
     <!-- Signing -->
     <MicrosoftVisualStudioEngMicroBuildCoreVersion>1.0.0</MicrosoftVisualStudioEngMicroBuildCoreVersion>
+    <!-- Source link -->
+    <MicrosoftSourceLinkGitHubPackageVersion>1.1.1</MicrosoftSourceLinkGitHubPackageVersion>
 
     <!-- Samples -->
     <MicrosoftAspNetCorePackageVersion>2.1.0</MicrosoftAspNetCorePackageVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,8 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;azure;signalr</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;azure;signalr</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,7 +55,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="$(MicrosoftAspNetCoreHttpConnectionsCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
-    
+
     <!--Security Patches-->
     <!-- Fix risks from Microsoft.AspNetCore.SignalR-->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />


### PR DESCRIPTION
Improve cross-project debug experience. Currently if we want to debug SDK in other projects, we have to reference the local SDK project. With source link or symbol package we don't have to do that.

As the new symbol package format `*.snupkg` is not supported by KoreBuild, we cannot enable symbol package yet.
[Symbol packages](https://docs.microsoft.com/dotnet/standard/library-guidance/nuget#symbol-packages)
[Source link](https://docs.microsoft.com/dotnet/standard/library-guidance/sourcelink)

