### PR TITLE
Support implicit conversion from `ServiceHubContextImpl<T>` to `ServiceHubContextImpl`.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextBuilder.cs
@@ -37,14 +37,14 @@ namespace Microsoft.Azure.SignalR.Management
         {
             _hostBuilder.ConfigureServices(services => services.AddHub<Hub>(hubName));
             var host = await CreateAndStartHost(cancellationToken);
-            return host.Services.GetRequiredService<ServiceHubContext>();
+            return ActivatorUtilities.CreateInstance<ServiceHubContextImpl>(host.Services, hubName);
         }
 
         public async Task<ServiceHubContext<T>> CreateAsync<T>(string hubName, CancellationToken cancellationToken) where T : class
         {
-            _hostBuilder.ConfigureServices(services => services.AddHub<Hub<T>, T>(hubName));
+            _hostBuilder.ConfigureServices(services => services.AddHub<Hub<T>>(hubName));
             var host = await CreateAndStartHost(cancellationToken);
-            return host.Services.GetRequiredService<ServiceHubContext<T>>();
+            return ActivatorUtilities.CreateInstance<ServiceHubContextImpl<T>>(host.Services, hubName);
         }
 
         private async Task<IHost> CreateAndStartHost(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl`T.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl`T.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.SignalR.Management
 {
@@ -18,6 +18,10 @@ namespace Microsoft.Azure.SignalR.Management
         private bool _disposing;
 
         internal IServiceProvider ServiceProvider { get; }
+
+        internal ServiceHubContext NonGenericHubContext { get; private set; }
+
+        public static implicit operator ServiceHubContext(ServiceHubContextImpl<T> c) => c.NonGenericHubContext;
 
         public override IHubClients<T> Clients { get; }
 
@@ -36,6 +40,7 @@ namespace Microsoft.Azure.SignalR.Management
             Groups = new GroupManagerAdapter(typedHubContext.Groups);
             UserGroups = new UserGroupsManagerAdapter(lifetimeManager);
             ClientManager = new ClientManagerAdapter(lifetimeManager);
+            NonGenericHubContext = ActivatorUtilities.CreateInstance<ServiceHubContextImpl>(ServiceProvider, _hubName);
         }
 
         public override ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default) => new(_negotiateProcessor.NegotiateAsync(_hubName, negotiationOptions, cancellationToken));
@@ -43,12 +48,10 @@ namespace Microsoft.Azure.SignalR.Management
         public override async ValueTask DisposeAsync()
         {
             // check _disposed to avoid being dispose twice.
-            // when _baseHubContext dispose, it will dispose all the disposable services including this class.
             if (!_disposing)
             {
                 _disposing = true;
-                using var host = ServiceProvider.GetRequiredService<IHost>();
-                await host.StopAsync();
+                await NonGenericHubContext.DisposeAsync();
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/StronglyTypedServiceHubContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/StronglyTypedServiceHubContextFacts.cs
@@ -234,6 +234,16 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             public Task NewMessage(string message);
         }
 
+        [Fact]
+        public async Task TestTypedHubContextImplictConversionToUntypedHubContext()
+        {
+            using var serviceManager = new ServiceManagerBuilder()
+                .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
+                .BuildServiceManager();
+            using var typedHubContext = await serviceManager.CreateHubContextAsync<IChat>("hub", default);
+            using ServiceHubContext hubContext = typedHubContext as ServiceHubContextImpl<IChat>;
+        }
+
         private Task<ServiceHubContext<IChat>> Create(ServiceTransportType transportType, IServiceCollection services = null)
         {
             var builder = services == null ? new ServiceManagerBuilder() : new ServiceManagerBuilder(services);


### PR DESCRIPTION
In SignalR Functions extensions, `ServerlessHub<T>` is suggested being derived from `ServerlessHub`, which requires that we can get a `ServiceHubContext` out of a `ServiceHubContext<T>`. 

Why don't we make `ServiceHubContext<T>` derived from `ServiceHubContext`? 
I am not sure whether we should expose the inheritance to users. Currently it's only required for Functions extensions.

* Refactor: `ServiceHubContext` and `ServiceHubContext<T>` are no more injected, so that they won't get disposed twice when `IServiceProvider` is disposed.
Consider this usage:
```
using ServiceHubContext<T> c = serviceManager.CreateHubContextAsync<T>("hubName",cancellationToken);
using ServiceHubContext c1 = c as ServiceHubContextImpl<T>;
```
