### PR TITLE
Fix bug that Management SDK connection count is fixed to 3

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceManagerImpl.cs
@@ -43,14 +43,12 @@ namespace Microsoft.Azure.SignalR.Management
         public override Task<ServiceHubContext> CreateHubContextAsync(string hubName, CancellationToken cancellationToken)
         {
             var builder = new ServiceHubContextBuilder(_services);
-            builder.ConfigureServices(services => services.Configure<ServiceManagerOptions>(o => o.ConnectionCount = 3));
             return builder.CreateAsync(hubName, cancellationToken);
         }
 
         public override Task<ServiceHubContext<T>> CreateHubContextAsync<T>(string hubName, CancellationToken cancellation)
         {
             var builder = new ServiceHubContextBuilder(_services);
-            builder.ConfigureServices(services => services.Configure<ServiceManagerOptions>(o => o.ConnectionCount = 3));
             return builder.CreateAsync<T>(hubName, cancellation);
         }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -192,7 +192,23 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 .ConfigureServices(services => services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, HttpStatusCode.OK)))
                 .BuildServiceManager()
                 .CreateHubContextAsync(HubName, default);
-            Assert.Equal(3, (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ConnectionCount);
+            Assert.Equal(1, (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ConnectionCount);
+        }
+
+        [Fact]
+        public async Task TestConnectionCountCustomizable()
+        {
+            using var serviceHubContext = await new ServiceManagerBuilder()
+                .WithOptions(o =>
+                {
+                    o.ConnectionString = _testConnectionString;
+                    o.ConnectionCount = 5;
+                })
+                // avoid waiting for health check result for long time
+                .ConfigureServices(services => services.AddSingleton<RestClientFactory>(new TestRestClientFactory(UserAgent, HttpStatusCode.OK)))
+                .BuildServiceManager()
+                .CreateHubContextAsync(HubName, default);
+            Assert.Equal(5, (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.ConnectionCount);
         }
     }
 }


### PR DESCRIPTION
If users want to guarantee message order in persistent mode, they need to set the connection count to 1. 