### PR TITLE
Support the customization of endpoint for server to connect to ASRS

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.SignalR.AspNet
 
             // Version is ignored for aspnet signalr case
             _audienceBaseUrl = endpoint.AudienceBaseUrl;
-            _clientEndpoint = endpoint.ClientEndpoint;
-            _serverEndpoint = endpoint.Endpoint;
+            _clientEndpoint = endpoint.ClientEndpoint.AbsoluteUri;
+            _serverEndpoint = endpoint.ServerEndpoint.AbsoluteUri;
             _accessKey = endpoint.AccessKey;
             _appName = options.ApplicationName;
             _algorithm = options.AccessTokenAlgorithm;
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         public Task<string> GenerateClientAccessTokenAsync(string hubName = null, IEnumerable<Claim> claims = null, TimeSpan? lifetime = null)
         {
-            var audience = $"{_audienceBaseUrl}/{ClientPath}";
+            var audience = $"{_audienceBaseUrl}{ClientPath}";
 
             return _accessKey.GenerateAccessTokenAsync(audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.SignalR.AspNet
                 };
             }
 
-            var audience = $"{_audienceBaseUrl}/{ServerPath}/?hub={GetPrefixedHubName(_appName, hubName)}";
+            var audience = $"{_audienceBaseUrl}{ServerPath}/?hub={GetPrefixedHubName(_appName, hubName)}";
 
             return _accessKey.GenerateAccessTokenAsync(audience, claims, lifetime ?? _accessTokenLifetime, _algorithm);
         }
@@ -107,12 +107,12 @@ namespace Microsoft.Azure.SignalR.AspNet
                     .Append(WebUtility.UrlEncode(originalPath));
             }
 
-            return $"{_clientEndpoint}/{ClientPath}{queryBuilder}";
+            return $"{_clientEndpoint}{ClientPath}{queryBuilder}";
         }
 
         public string GetServerEndpoint(string hubName)
         {
-            return $"{_serverEndpoint}/{ServerPath}/?hub={GetPrefixedHubName(_appName, hubName)}";
+            return $"{_serverEndpoint}{ServerPath}/?hub={GetPrefixedHubName(_appName, hubName)}";
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.SignalR
         /// <summary>
         /// Enriched endpoint metrics for customized routing.
         /// </summary>
-        public EndpointMetrics EndpointMetrics { get; } = new EndpointMetrics();
+        public EndpointMetrics EndpointMetrics { get; internal set; } = new EndpointMetrics();
 
         public string Endpoint { get; }
 
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.SignalR
 
         internal string Version { get; }
 
-        internal AccessKey AccessKey { get; set; }
+        internal AccessKey AccessKey { get; private set; }
 
         /// <summary>
         /// Connection string constructor with nameWithEndpointType

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.SignalR
 
         public EndpointType EndpointType { get; } = EndpointType.Primary;
 
-        public virtual string Name { get; } = "";
+        public virtual string Name { get; internal set; } = "";
 
         /// <summary>
         /// Gets or initializes the custom endpoint for SignalR server to connect to SignalR service.
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.SignalR
 
         internal string Version { get; }
 
-        internal AccessKey AccessKey { get; }
+        internal AccessKey AccessKey { get; set; }
 
         /// <summary>
         /// Connection string constructor with nameWithEndpointType
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.SignalR
                 ClientEndpoint = other.ClientEndpoint;
                 ServerEndpoint = other.ServerEndpoint;
                 AudienceBaseUrl = other.AudienceBaseUrl;
-                _serviceEndpoint = new Uri(other.Endpoint);
+                _serviceEndpoint = other._serviceEndpoint;
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/RestClients/RestClientFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/RestClients/RestClientFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.SignalR
             var credentials = new JwtTokenCredentials(endpoint.AccessKey, _serverName);
             var restClient = new SignalRServiceRestClient(_userAgent, credentials, httpClient, true)
             {
-                BaseUri = new Uri(endpoint.Endpoint)
+                BaseUri = endpoint.ServerEndpoint
             };
             return restClient;
         }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.SignalR
         private const string ClientIdProperty = "clientId";
         private const string ClientSecretProperty = "clientSecret";
         private const string EndpointProperty = "endpoint";
+        private const string ServerEndpoint = "ServerEndpoint";
         private const string InvalidVersionValueFormat = "Version {0} is not supported.";
         private const string PortProperty = "port";
         // For SDK 1.x, only support Azure SignalR Service 1.x
@@ -115,12 +116,21 @@ namespace Microsoft.Azure.SignalR
                 "aad" => BuildAadAccessKey(builder.Uri, dict),
                 _ => BuildAccessKey(builder.Uri, dict),
             };
+
+            if (dict.TryGetValue(ServerEndpoint, out var serverEndpoint))
+            {
+                if (!ValidateEndpoint(serverEndpoint))
+                {
+                    throw new ArgumentException($"{ServerEndpoint} property in connection string is not a valid URI: {serverEndpoint}.");
+                }
+            }
             return new ParsedConnectionString()
             {
                 Endpoint = builder.Uri,
-                ClientEndpoint = clientEndpoint,
+                ClientEndpoint = clientEndpoint == null ? null : new Uri(clientEndpoint),
                 AccessKey = accessKey,
                 Version = version,
+                ServerEndpoint = serverEndpoint == null ? null : new Uri(serverEndpoint)
             };
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Azure.SignalR
             }
             endpoint = endpoint.TrimEnd('/');
 
-            if (!ValidateEndpoint(endpoint))
+            if (!ValidateEndpoint(endpoint, out var endpointUri))
             {
                 throw new ArgumentException($"Endpoint property in connection string is not a valid URI: {dict[EndpointProperty]}.");
             }
-            var builder = new UriBuilder(endpoint);
+            var builder = new UriBuilder(endpointUri);
 
             // parse and validate version.
             string version = null;
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR
             // parse and validate clientEndpoint.
             if (dict.TryGetValue(ClientEndpointProperty, out var clientEndpoint))
             {
-                if (!ValidateEndpoint(clientEndpoint))
+                if (!ValidateEndpoint(clientEndpoint, out _))
                 {
                     throw new ArgumentException($"{ClientEndpointProperty} property in connection string is not a valid URI: {clientEndpoint}.");
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.SignalR
 
             if (dict.TryGetValue(ServerEndpoint, out var serverEndpoint))
             {
-                if (!ValidateEndpoint(serverEndpoint))
+                if (!ValidateEndpoint(serverEndpoint, out _))
                 {
                     throw new ArgumentException($"{ServerEndpoint} property in connection string is not a valid URI: {serverEndpoint}.");
                 }
@@ -134,9 +134,9 @@ namespace Microsoft.Azure.SignalR
             };
         }
 
-        internal static bool ValidateEndpoint(string endpoint)
+        internal static bool ValidateEndpoint(string endpoint, out Uri uriResult)
         {
-            return Uri.TryCreate(endpoint, UriKind.Absolute, out var uriResult) &&
+            return Uri.TryCreate(endpoint, UriKind.Absolute, out uriResult) &&
                    (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.SignalR
             }
             endpoint = endpoint.TrimEnd('/');
 
-            if (!ValidateEndpoint(endpoint, out var endpointUri))
+            if (!TryGetEndpointUri(endpoint, out var endpointUri))
             {
                 throw new ArgumentException($"Endpoint property in connection string is not a valid URI: {dict[EndpointProperty]}.");
             }
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR
             // parse and validate clientEndpoint.
             if (dict.TryGetValue(ClientEndpointProperty, out var clientEndpoint))
             {
-                if (!ValidateEndpoint(clientEndpoint, out _))
+                if (!TryGetEndpointUri(clientEndpoint, out _))
                 {
                     throw new ArgumentException($"{ClientEndpointProperty} property in connection string is not a valid URI: {clientEndpoint}.");
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.SignalR
 
             if (dict.TryGetValue(ServerEndpoint, out var serverEndpoint))
             {
-                if (!ValidateEndpoint(serverEndpoint, out _))
+                if (!TryGetEndpointUri(serverEndpoint, out _))
                 {
                     throw new ArgumentException($"{ServerEndpoint} property in connection string is not a valid URI: {serverEndpoint}.");
                 }
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.SignalR
             };
         }
 
-        internal static bool ValidateEndpoint(string endpoint, out Uri uriResult)
+        internal static bool TryGetEndpointUri(string endpoint, out Uri uriResult)
         {
             return Uri.TryCreate(endpoint, UriKind.Absolute, out uriResult) &&
                    (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -101,10 +101,11 @@ namespace Microsoft.Azure.SignalR
                 }
             }
 
+            Uri clientEndpointUri = null;
             // parse and validate clientEndpoint.
             if (dict.TryGetValue(ClientEndpointProperty, out var clientEndpoint))
             {
-                if (!TryGetEndpointUri(clientEndpoint, out _))
+                if (!TryGetEndpointUri(clientEndpoint, out clientEndpointUri))
                 {
                     throw new ArgumentException($"{ClientEndpointProperty} property in connection string is not a valid URI: {clientEndpoint}.");
                 }
@@ -117,9 +118,10 @@ namespace Microsoft.Azure.SignalR
                 _ => BuildAccessKey(builder.Uri, dict),
             };
 
+            Uri serverEndpointUri = null;
             if (dict.TryGetValue(ServerEndpoint, out var serverEndpoint))
             {
-                if (!TryGetEndpointUri(serverEndpoint, out _))
+                if (!TryGetEndpointUri(serverEndpoint, out serverEndpointUri))
                 {
                     throw new ArgumentException($"{ServerEndpoint} property in connection string is not a valid URI: {serverEndpoint}.");
                 }
@@ -127,10 +129,10 @@ namespace Microsoft.Azure.SignalR
             return new ParsedConnectionString()
             {
                 Endpoint = builder.Uri,
-                ClientEndpoint = clientEndpoint == null ? null : new Uri(clientEndpoint),
+                ClientEndpoint = clientEndpointUri,
                 AccessKey = accessKey,
                 Version = version,
-                ServerEndpoint = serverEndpoint == null ? null : new Uri(serverEndpoint)
+                ServerEndpoint = serverEndpointUri
             };
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/IsExternalInit.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/IsExternalInit.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETSTANDARD2_0 || NETCOREAPP3_0
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    /// <remarks>A class originally defined in .NET 5. Copy here to use "init" accessor on target frameworks below .NET 5.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ParsedConnectionString.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ParsedConnectionString.cs
@@ -11,8 +11,11 @@ namespace Microsoft.Azure.SignalR
 
         internal Uri Endpoint { get; set; }
 
-        internal string ClientEndpoint { get; set; }
+        internal Uri ClientEndpoint { get; set; }
+
+        internal Uri ServerEndpoint { get; set; }
 
         internal string Version { get; set; }
+
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.SignalR.Management
         public RestApiProvider(ServiceEndpoint endpoint)
         {
             _audienceBaseUrl = endpoint.AudienceBaseUrl;
-            _serverEndpoint = endpoint.Endpoint;
+            _serverEndpoint = endpoint.ServerEndpoint.AbsoluteUri;
             _restApiAccessTokenGenerator = new RestApiAccessTokenGenerator(endpoint.AccessKey);
         }
 
@@ -33,8 +33,8 @@ namespace Microsoft.Azure.SignalR.Management
 
         public async Task<RestApiEndpoint> GetServiceHealthEndpointAsync()
         {
-            var url = $"{_serverEndpoint}/api/{Version}/health";
-            var audience = $"{_audienceBaseUrl}/api/{Version}/health";
+            var url = $"{_serverEndpoint}api/{Version}/health";
+            var audience = $"{_audienceBaseUrl}api/{Version}/health";
             var token = await _restApiAccessTokenGenerator.Generate(audience);
             return new RestApiEndpoint(url, token);
         }
@@ -99,9 +99,9 @@ namespace Microsoft.Azure.SignalR.Management
 
         private async Task<RestApiEndpoint> GenerateRestApiEndpointAsync(string appName, string hubName, string pathAfterHub, TimeSpan? lifetime = null, IDictionary<string, StringValues> queries = null)
         {
-            var requestPrefixWithHub = $"{_serverEndpoint}/api/{Version}/hubs/{Uri.EscapeDataString(GetPrefixedHubName(appName, hubName))}";
+            var requestPrefixWithHub = $"{_serverEndpoint}api/{Version}/hubs/{Uri.EscapeDataString(GetPrefixedHubName(appName, hubName))}";
             // todo: should be same with `requestPrefixWithHub`, need to confirm with emulator.
-            var audiencePrefixWithHub = $"{_audienceBaseUrl}/api/{Version}/hubs/{Uri.EscapeDataString(GetPrefixedHubName(appName, hubName))}";
+            var audiencePrefixWithHub = $"{_audienceBaseUrl}api/{Version}/hubs/{Uri.EscapeDataString(GetPrefixedHubName(appName, hubName))}";
             var token = await _restApiAccessTokenGenerator.Generate($"{audiencePrefixWithHub}{pathAfterHub}", lifetime);
             return new RestApiEndpoint($"{requestPrefixWithHub}{pathAfterHub}", token) { Query = queries };
         }

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/DefaultServiceEndpointGenerator.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/DefaultServiceEndpointGenerator.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.SignalR
         {
             Version = endpoint.Version;
             AudienceBaseUrl = endpoint.AudienceBaseUrl;
-            ClientEndpoint = endpoint.ClientEndpoint;
-            ServerEndpoint = endpoint.Endpoint;
+            ClientEndpoint = endpoint.ClientEndpoint.AbsoluteUri;
+            ServerEndpoint = endpoint.ServerEndpoint.AbsoluteUri;
         }
 
         public string GetClientAudience(string hubName, string applicationName) =>
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.SignalR
 
         private string InternalGetUri(string path, string hubName, string applicationName, string target)
         {
-            return $"{target}/{path}/?hub={GetPrefixedHubName(applicationName, hubName)}";
+            return $"{target}{path}/?hub={GetPrefixedHubName(applicationName, hubName)}";
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
@@ -92,22 +92,24 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 
         [Theory]
         [ClassData(typeof(ClientEndpointTestData))]
-        public void TestClientEndpoint(string connectionString, string expectedClientEndpoint)
+        public void TestClientEndpoint(string connectionString, string expectedClientEndpoint, int? expectedPort)
         {
             var r = ConnectionStringParser.Parse(connectionString);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
             var expectedUri = expectedClientEndpoint == null ? null : new Uri(expectedClientEndpoint);
             Assert.Equal(expectedUri, r.ClientEndpoint);
+            Assert.Equal(expectedPort, r.ClientEndpoint?.Port);
         }
 
         [Theory]
         [MemberData(nameof(ServerEndpointTestData))]
-        public void TestServerEndpoint(string connectionString, string expectedServerEndpoint)
+        public void TestServerEndpoint(string connectionString, string expectedServerEndpoint, int? expectedPort)
         {
             var r = ConnectionStringParser.Parse(connectionString);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
             var expectedUri = expectedServerEndpoint == null ? null : new Uri(expectedServerEndpoint);
             Assert.Equal(expectedUri, r.ServerEndpoint);
+            Assert.Equal(expectedPort, r.ServerEndpoint?.Port);
         }
 
         [Theory]
@@ -170,11 +172,11 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey}", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;clientEndpoint={ClientEndpoint}", ClientEndpoint };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;clientEndpoint={ClientEndpoint}:500", $"{ClientEndpoint}:500" };
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey}", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;clientEndpoint={ClientEndpoint}", ClientEndpoint, 80 };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;clientEndpoint={ClientEndpoint}:500", $"{ClientEndpoint}:500", 500 };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -184,11 +186,11 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         {
             get
             {
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey}", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400", null };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}", ServerEndpoint };
-                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}:500", $"{ServerEndpoint}:500" };
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey}", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400", null, null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}", ServerEndpoint, 80 };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}:500", $"{ServerEndpoint}:500", 500 };
             }
         }
     }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 
         private const string ClientEndpoint = "http://bbb";
 
+        private const string ServerEndpoint = "http://ccc";
+
         private const string DefaultKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
         [Theory]
@@ -94,7 +96,18 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         {
             var r = ConnectionStringParser.Parse(connectionString);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
-            Assert.Equal(expectedClientEndpoint, r.ClientEndpoint);
+            var expectedUri = expectedClientEndpoint == null ? null : new Uri(expectedClientEndpoint);
+            Assert.Equal(expectedUri, r.ClientEndpoint);
+        }
+
+        [Theory]
+        [MemberData(nameof(ServerEndpointTestData))]
+        public void TestServerEndpoint(string connectionString, string expectedServerEndpoint)
+        {
+            var r = ConnectionStringParser.Parse(connectionString);
+            Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
+            var expectedUri = expectedServerEndpoint == null ? null : new Uri(expectedServerEndpoint);
+            Assert.Equal(expectedUri, r.ServerEndpoint);
         }
 
         [Theory]
@@ -128,32 +141,32 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             Assert.Null(r.ClientEndpoint);
         }
 
-        public class EndpointEndWithSlash: IEnumerable<object[]>
+        public class EndpointEndWithSlash : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", HttpEndpoint};
-                yield return new object[] { $"endpoint={HttpEndpoint}/;accesskey={DefaultKey}", HttpEndpoint};
-                yield return new object[] { $"endpoint={HttpsEndpoint};accesskey={DefaultKey}", HttpsEndpoint};
-                yield return new object[] { $"endpoint={HttpsEndpoint}/;accesskey={DefaultKey}", HttpsEndpoint};
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", HttpEndpoint };
+                yield return new object[] { $"endpoint={HttpEndpoint}/;accesskey={DefaultKey}", HttpEndpoint };
+                yield return new object[] { $"endpoint={HttpsEndpoint};accesskey={DefaultKey}", HttpsEndpoint };
+                yield return new object[] { $"endpoint={HttpsEndpoint}/;accesskey={DefaultKey}", HttpsEndpoint };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
-        public class VersionTestData: IEnumerable<object[]>
+        public class VersionTestData : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null};
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey};version=1.0", "1.0"};
-                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey};version=1.1-preview", "1.1-preview"};
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null };
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey};version=1.0", "1.0" };
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey};version=1.1-preview", "1.1-preview" };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
-        public class ClientEndpointTestData: IEnumerable<object[]>
+        public class ClientEndpointTestData : IEnumerable<object[]>
         {
             public IEnumerator<object[]> GetEnumerator()
             {
@@ -165,6 +178,18 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public static IEnumerable<object[]> ServerEndpointTestData
+        {
+            get
+            {
+                yield return new object[] { $"endpoint={HttpEndpoint};accesskey={DefaultKey}", null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey}", null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400", null };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}", ServerEndpoint };
+                yield return new object[] { $"endpoint={HttpEndpoint}:500;accesskey={DefaultKey};port=400;serverEndpoint={ServerEndpoint}:500", $"{ServerEndpoint}:500" };
+            }
         }
     }
 }


### PR DESCRIPTION
Users have two ways to set `serverEndpoint`.
* Option 1: in connection string: `serverEndpoint=...`
* Option 2: in the ctor of `ServiceEndpoint`:
    ```cs
    new ServiceEndpoint(new Uri(endpoint), new DefaultAzureCredential())
    {
        ClientEndpoint = new Uri("https://client-endpoint.com/path"),
        ServerEndpoint = new Uri("https://server-endpoint.com/path"),
    }
    ```

Other changes:
* `ServiceEndpoint.AudienceBaseUrl` now ends with slash.
