### PR TITLE
add server connection and connection quota for endpoint metrics

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointMetrics.cs
@@ -6,8 +6,18 @@ namespace Microsoft.Azure.SignalR
     public class EndpointMetrics
     {
         /// <summary>
-        /// <see cref="ServiceEndpoint" /> total concurrent client connection count on all hubs.
+        /// <see cref="ServiceEndpoint" /> total concurrent connected client connection count on all hubs.
         /// </summary>
         public int ClientConnectionCount { get; internal set; }
+
+        /// <summary>
+        /// <see cref="ServiceEndpoint" /> total concurrent connected server connection count on all hubs.
+        /// </summary>
+        public int ServerConnectionCount { get; internal set; }
+
+        /// <summary>
+        /// <see cref="ServiceEndpoint" /> connection quota for this instance, including client and server connections. 
+        /// </summary>
+        public int ConnectionCapacity { get; internal set; }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -192,7 +192,14 @@ namespace Microsoft.Azure.SignalR
             {
                 Endpoint.EndpointMetrics.ClientConnectionCount = clientCount;
             }
-
+            if (RuntimeServicePingMessage.TryGetServerCount(pingMessage, out var serverCount))
+            {
+                Endpoint.EndpointMetrics.ServerConnectionCount = serverCount;
+            }
+            if (RuntimeServicePingMessage.TryGetConnectionCapacity(pingMessage, out var connectionCapacity))
+            {
+                Endpoint.EndpointMetrics.ConnectionCapacity = connectionCapacity;
+            }
             if (RuntimeServicePingMessage.TryGetStatus(pingMessage, out var status))
             {
                 Log.ReceivedServiceStatusPing(Logger, status, Endpoint);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceMessages/RuntimeServicePingMessages.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.SignalR
         private const string ShutdownKey = "shutdown";
         private const string ServersKey = "servers";
         private const string ClientCountKey = "clientcount";
+        private const string ServerCountKey = "servercount";
+        private const string CapacityKey = "capacity";
         private const string DiagnosticLogsMessagingTypeKey = "d-m";
 
         private const string MessagingLogEnableValue = "1";
@@ -96,6 +98,28 @@ namespace Microsoft.Azure.SignalR
                 return false;
             }
             clientCount = count;
+            return true;
+        }   
+        
+        public static bool TryGetServerCount(this ServicePingMessage ping, out int serverCount)
+        {
+            if (!TryGetValue(ping, ServerCountKey, out var value) || !int.TryParse(value, out var count))
+            {
+                serverCount = 0;
+                return false;
+            }
+            serverCount = count;
+            return true;
+        }    
+        
+        public static bool TryGetConnectionCapacity(this ServicePingMessage ping, out int connectionCapacity)
+        {
+            if (!TryGetValue(ping, CapacityKey, out var value) || !int.TryParse(value, out var count))
+            {
+                connectionCapacity = 0;
+                return false;
+            }
+            connectionCapacity = count;
             return true;
         }
 


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
When using multible endpoint, this metrics will enable customer to route request according to the instance weight. 


