### PR TITLE
Disable osx build due to invalid error

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,12 +2,7 @@ name: Gated-OSX
 on:
  push:
    branches: 
-    - master
-    - dev
- pull_request:
-   branches: 
-    - master
-    - dev
+    - disable
 jobs:
   build_osx:
     runs-on: macOS-latest


### PR DESCRIPTION
error  : .NET Core 2.0 requires macOS 10.12 or newer. Current version is 11.6.5.