### PR TITLE
Fix the "serverEndpoint","clientEndpoint" of `ServiceEndpoint` ctor problem

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -121,11 +121,14 @@ namespace Microsoft.Azure.SignalR
         /// <summary>
         /// Azure active directory constructor
         /// </summary>
-        /// <param name="endpoint"></param>
-        /// <param name="credential"></param>
-        /// <param name="endpointType"></param>
-        /// <param name="name"></param>
-        public ServiceEndpoint(Uri endpoint, TokenCredential credential, EndpointType endpointType = EndpointType.Primary, string name = "")
+        /// <param name="endpoint">SignalR Service endpoint.</param>
+        /// <param name="credential">The Azure Active Directory credential.</param>
+        /// <param name="endpointType">The endpoint type.</param>
+        /// <param name="name">The endpoint name.</param>
+        /// <param name="serverEndpoint">The endpoint for servers to connect to Azure SignalR.</param>
+        /// <param name="clientEndpoint">The endpoint for clients to connect to Azure SignalR.</param>
+        public ServiceEndpoint(Uri endpoint, TokenCredential credential, EndpointType endpointType = EndpointType.Primary, string name = "",
+            Uri serverEndpoint = null, Uri clientEndpoint = null)
         {
             _serviceEndpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
             CheckScheme(endpoint);
@@ -139,6 +142,8 @@ namespace Microsoft.Azure.SignalR
 
             AudienceBaseUrl = BuildAudienceBaseUrlEndWithSlash(_serviceEndpoint);
             Endpoint = BuildEndpointString(_serviceEndpoint);
+            ServerEndpoint = serverEndpoint;
+            ClientEndpoint = clientEndpoint;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-
+using System.ComponentModel;
 using Azure.Core;
 
 namespace Microsoft.Azure.SignalR
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.SignalR
         /// </summary>
         /// <param name="nameWithEndpointType"></param>
         /// <param name="connectionString"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ServiceEndpoint(string nameWithEndpointType, string connectionString) : this(connectionString)
         {
             (Name, EndpointType) = Parse(nameWithEndpointType);
@@ -113,6 +114,7 @@ namespace Microsoft.Azure.SignalR
         /// <param name="nameWithEndpointType"></param>
         /// <param name="endpoint"></param>
         /// <param name="credential"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ServiceEndpoint(string nameWithEndpointType, Uri endpoint, TokenCredential credential) : this(endpoint, credential)
         {
             (Name, EndpointType) = Parse(nameWithEndpointType);

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/IsExternalInit.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/IsExternalInit.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-#if NETSTANDARD2_0 || NETCOREAPP3_0
-
 using System.ComponentModel;
 
 namespace System.Runtime.CompilerServices
@@ -17,5 +14,3 @@ namespace System.Runtime.CompilerServices
     {
     }
 }
-
-#endif


### PR DESCRIPTION
1. Add "serverEndpoint", "clientEndpoint" to constructor parameter. Previously we only have `init` accessor, which is available only since C# 9 and Net Standard 2.0 and .Net Core 3.1 have to specify language version to use the accessor.

2. Make our internal `IsExternalInit` available on .NET 6. Due to unknown reasons, if .NET standard libraries (for example Functions extensions) try to use `init` accessor without our internal `IsExternalInit` class, they will get "set_ServerEndpoint" method not found exception.
