### PR TITLE
Add ClientEndpoint/ServerEndpoint in multiple endpoints merging.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/HubServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/HubServiceEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,6 +31,7 @@ namespace Microsoft.Azure.SignalR
         public string Hub { get; }
 
         public override string Name => _endpoint.Name;
+        public override Uri ClientEndpoint => _endpoint.ClientEndpoint;
 
         public IServiceEndpointProvider Provider { get; }
 

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -169,6 +169,29 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
+        /// <summary>
+        /// Reload endpoint with changable properties.
+        /// </summary>
+        /// <param name="original"></param>
+        /// <param name="name"></param>
+        /// <param name="clientEndpoint"></param>
+        internal ServiceEndpoint(ServiceEndpoint original, string name, Uri clientEndpoint)
+        {
+            if (original != null)
+            {
+                ConnectionString = original.ConnectionString;
+                EndpointType = original.EndpointType;
+                Name = name ?? original.Name;
+                Version = original.Version;
+                AccessKey = original.AccessKey;
+                Endpoint = original.Endpoint;
+                ClientEndpoint = clientEndpoint ?? original.ClientEndpoint;
+                ServerEndpoint = original.ServerEndpoint;
+                AudienceBaseUrl = original.AudienceBaseUrl;
+                _serviceEndpoint = original._serviceEndpoint;
+            }
+        }
+
         public override string ToString()
         {
             var prefix = string.IsNullOrEmpty(Name) ? "" : $"[{Name}]";
@@ -178,7 +201,7 @@ namespace Microsoft.Azure.SignalR
         public override int GetHashCode()
         {
             // We consider ServiceEndpoint with the same Endpoint (https://{signalr.endpoint}) as the unique identity
-            return (Endpoint, EndpointType, Name).GetHashCode();
+            return (Endpoint, EndpointType, Name, ClientEndpoint, ServerEndpoint).GetHashCode();
         }
 
         public override bool Equals(object obj)
@@ -198,7 +221,7 @@ namespace Microsoft.Azure.SignalR
                 return false;
             }
 
-            return Endpoint == that.Endpoint && EndpointType == that.EndpointType && Name == that.Name;
+            return Endpoint == that.Endpoint && EndpointType == that.EndpointType && Name == that.Name && ClientEndpoint == that.ClientEndpoint && ServerEndpoint == that.ServerEndpoint;
         }
 
         private static string BuildAudienceBaseUrlEndWithSlash(Uri uri)

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR
     {
         private readonly Uri _serviceEndpoint;
         private readonly Uri _serverEndpoint;
-        private readonly Uri _clientEndpoint;
+        private Uri _clientEndpoint;
 
         public string ConnectionString { get; }
 
@@ -34,9 +34,10 @@ namespace Microsoft.Azure.SignalR
         /// <summary>
         /// Gets or initializes the custom endpoint for SignalR clients to connect to SignalR service.
         /// </summary>
-        public Uri ClientEndpoint
+        public virtual Uri ClientEndpoint
         {
-            get => _clientEndpoint ?? _serviceEndpoint; init
+            get =>_clientEndpoint ?? _serviceEndpoint;
+            internal set
             {
                 CheckScheme(value);
                 _clientEndpoint = value;
@@ -166,29 +167,6 @@ namespace Microsoft.Azure.SignalR
                 ServerEndpoint = other.ServerEndpoint;
                 AudienceBaseUrl = other.AudienceBaseUrl;
                 _serviceEndpoint = other._serviceEndpoint;
-            }
-        }
-
-        /// <summary>
-        /// Reload endpoint with changable properties.
-        /// </summary>
-        /// <param name="original"></param>
-        /// <param name="name"></param>
-        /// <param name="clientEndpoint"></param>
-        internal ServiceEndpoint(ServiceEndpoint original, string name, Uri clientEndpoint)
-        {
-            if (original != null)
-            {
-                ConnectionString = original.ConnectionString;
-                EndpointType = original.EndpointType;
-                Name = name ?? original.Name;
-                Version = original.Version;
-                AccessKey = original.AccessKey;
-                Endpoint = original.Endpoint;
-                ClientEndpoint = clientEndpoint ?? original.ClientEndpoint;
-                ServerEndpoint = original.ServerEndpoint;
-                AudienceBaseUrl = original.AudienceBaseUrl;
-                _serviceEndpoint = original._serviceEndpoint;
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -173,7 +173,9 @@ namespace Microsoft.Azure.SignalR
         public override string ToString()
         {
             var prefix = string.IsNullOrEmpty(Name) ? "" : $"[{Name}]";
-            return $"{prefix}({EndpointType}){Endpoint}";
+            var suffix = ClientEndpoint != _serviceEndpoint ? $";ClientEndpoint={ClientEndpoint}" : "";
+            suffix = ServerEndpoint != _serviceEndpoint ? $"{suffix};ServerEndpoint={ServerEndpoint}" : suffix;
+            return $"{prefix}({EndpointType}){Endpoint}{suffix}";
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -241,14 +241,19 @@ namespace Microsoft.Azure.SignalR
             foreach (var endpoint in updatedEndpoints)
             {
                 // search exist from old
-                if (Endpoints.TryGetValue(endpoint.Key, out var value))
+                if (Endpoints.TryGetValue(endpoint.Key, out var existing))
                 {
-                    // remained or renamed
-                    if (value.Name != endpoint.Key.Name)
+                    // Renamed
+                    if (existing.Name != endpoint.Key.Name)
                     {
-                        value.Name = endpoint.Key.Name;
+                        existing = new ServiceEndpoint(existing, endpoint.Key.Name, null);
                     }
-                    endpoints.Add(value, value);
+                    // ClientEndpoint updated
+                    if (existing.ClientEndpoint != endpoint.Key.ClientEndpoint)
+                    {
+                        existing = new ServiceEndpoint(existing, null, endpoint.Key.ClientEndpoint);
+                    }
+                    endpoints.Add(existing, existing);
                 }
                 else
                 {
@@ -279,12 +284,12 @@ namespace Microsoft.Azure.SignalR
         {
             public bool Equals(ServiceEndpoint x, ServiceEndpoint y)
             {
-                return x.Endpoint == y.Endpoint && x.EndpointType == y.EndpointType;
+                return x.Endpoint == y.Endpoint && x.EndpointType == y.EndpointType && x.ServerEndpoint == y.ServerEndpoint;
             }
 
             public int GetHashCode(ServiceEndpoint obj)
             {
-                return obj.Endpoint.GetHashCode() ^ obj.EndpointType.GetHashCode();
+                return obj.Endpoint.GetHashCode() ^ obj.EndpointType.GetHashCode() ^ obj.ServerEndpoint.GetHashCode();
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -241,14 +241,19 @@ namespace Microsoft.Azure.SignalR
             foreach (var endpoint in updatedEndpoints)
             {
                 // search exist from old
-                if (Endpoints.TryGetValue(endpoint.Key, out var existing))
+                if (Endpoints.TryGetValue(endpoint.Key, out var value))
                 {
-                    // Rename or clientEndpoint update
-                    if (existing.Name != endpoint.Key.Name || existing.ClientEndpoint != endpoint.Key.ClientEndpoint)
+                    // Rename
+                    if (value.Name != endpoint.Key.Name)
                     {
-                        existing = new ServiceEndpoint(existing, endpoint.Key.Name, endpoint.Key.ClientEndpoint);
+                        value.Name = endpoint.Key.Name;
                     }
-                    endpoints.Add(existing, existing);
+                    // clientEndpoint update
+                    if (value.ClientEndpoint != endpoint.Key.ClientEndpoint)
+                    {
+                        value.ClientEndpoint = endpoint.Key.ClientEndpoint;
+                    }
+                    endpoints.Add(value, value);
                 }
                 else
                 {

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpointManagerBase.cs
@@ -243,15 +243,10 @@ namespace Microsoft.Azure.SignalR
                 // search exist from old
                 if (Endpoints.TryGetValue(endpoint.Key, out var existing))
                 {
-                    // Renamed
-                    if (existing.Name != endpoint.Key.Name)
+                    // Rename or clientEndpoint update
+                    if (existing.Name != endpoint.Key.Name || existing.ClientEndpoint != endpoint.Key.ClientEndpoint)
                     {
-                        existing = new ServiceEndpoint(existing, endpoint.Key.Name, null);
-                    }
-                    // ClientEndpoint updated
-                    if (existing.ClientEndpoint != endpoint.Key.ClientEndpoint)
-                    {
-                        existing = new ServiceEndpoint(existing, null, endpoint.Key.ClientEndpoint);
+                        existing = new ServiceEndpoint(existing, endpoint.Key.Name, endpoint.Key.ClientEndpoint);
                     }
                     endpoints.Add(existing, existing);
                 }
@@ -297,12 +292,12 @@ namespace Microsoft.Azure.SignalR
         {
             public bool Equals(HubServiceEndpoint x, HubServiceEndpoint y)
             {
-                return x.Endpoint == y.Endpoint && x.EndpointType == y.EndpointType;
+                return x.Endpoint == y.Endpoint && x.EndpointType == y.EndpointType && x.ServerEndpoint == y.ServerEndpoint;
             }
 
             public int GetHashCode(HubServiceEndpoint obj)
             {
-                return obj.Endpoint.GetHashCode() ^ obj.EndpointType.GetHashCode();
+                return obj.Endpoint.GetHashCode() ^ obj.EndpointType.GetHashCode() ^ obj.ServerEndpoint.GetHashCode();
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.SignalR
         {
             try
             {
-                var container = _routerEndpoints.endpoints.FirstOrDefault(e => e.Endpoint == endpoint.Endpoint && e.EndpointType == endpoint.EndpointType);
+                var container = _routerEndpoints.endpoints.FirstOrDefault(e => e.Endpoint == endpoint.Endpoint && e.EndpointType == endpoint.EndpointType && e.ServerEndpoint == endpoint.ServerEndpoint);
                 if (container == null)
                 {
                     Log.EndpointNotExists(_logger, endpoint.ToString());
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.SignalR
                         }
                     case ScaleOperation.Remove:
                         {
-                            var newEndpoints = _routerEndpoints.endpoints.Where(e => e.Endpoint != endpoint.Endpoint || e.EndpointType != endpoint.EndpointType).ToList();
+                            var newEndpoints = _routerEndpoints.endpoints.Where(e => e.Endpoint != endpoint.Endpoint || e.EndpointType != endpoint.EndpointType || e.ServerEndpoint != endpoint.ServerEndpoint).ToList();
                             UpdateRoutedEndpoints(newEndpoints);
                             break;
                         }

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Azure.SignalR.Tests
     public class TestEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     {
         private const string ConnectionStringFormatter = "Endpoint={0};AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
-        private const string Url1 = "http://url1/";
-        private const string Url2 = "https://url2/";
-        private const string Url3 = "http://url3/";
+        private const string Url1 = "http://url1.com/";
+        private const string Url2 = "https://url2.com/";
+        private const string Url3 = "http://url3.com/";
         private readonly string ConnectionString1 = string.Format(ConnectionStringFormatter, Url1);
         private readonly string ConnectionString2 = string.Format(ConnectionStringFormatter, Url2);
         private readonly string ConnectionString3 = string.Format(ConnectionStringFormatter, Url3);

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -1283,6 +1283,110 @@ namespace Microsoft.Azure.SignalR.Tests
             Assert.Equal(EndpointType.Primary, hubEndpoints[1].EndpointType);
         }
 
+        [Fact]
+        public async Task TestEndpointManagerWithMultiHubsWithServerEndpointUpdate()
+        {
+            var sem = new TestServiceEndpointManager(
+                new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
+                new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "22")
+                );
+            var endpoints = sem.Endpoints.Keys.ToArray();
+            Assert.Equal(2, endpoints.Length);
+            Assert.Equal("1", endpoints[0].Name);
+            Assert.Equal("22", endpoints[1].Name);
+
+            var router = new TestEndpointRouter();
+            var writeTcs = new TaskCompletionSource<object>();
+            var container = new TestMultiEndpointServiceConnectionContainer("hub",
+                e => new TestServiceConnectionContainer(new List<IServiceConnection> {
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
+            }, e), sem, router, NullLoggerFactory.Instance);
+
+            var container1 = new TestMultiEndpointServiceConnectionContainer("hub11",
+                e => new TestServiceConnectionContainer(new List<IServiceConnection> {
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
+                new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
+            }, e), sem, router, NullLoggerFactory.Instance);
+
+            var hubEndpoints = container.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, hubEndpoints.Length);
+            Assert.Equal("1", hubEndpoints[0].Name);
+            Assert.Equal("22", hubEndpoints[1].Name);
+
+            // mock all active to emulate has clients
+            var containers = container.GetTestOnlineContainers();
+            await Task.WhenAll(containers.Select(x => x.MockReceivedStatusPing(true)));
+            var containers1 = container1.GetTestOnlineContainers();
+            await Task.WhenAll(containers1.Select(x => x.MockReceivedStatusPing(true)));
+
+            var testSe = "https://se.com/";
+            var con1Se = $"{ConnectionString1};ServerEndpoint={testSe};";
+            var newEndpoints = new ServiceEndpoint[]
+            {
+                new ServiceEndpoint(con1Se, EndpointType.Primary, "1"),
+                new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "22")
+            };
+            _ = sem.TestReloadServiceEndpoints(newEndpoints, 15);
+
+            // validate container side update with news and have 3
+            await Task.Delay(100);
+            hubEndpoints = container.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(3, hubEndpoints.Length);
+            var expectedNames = new string[] { "1", "1", "22" };
+            Assert.True(expectedNames.SequenceEqual(hubEndpoints.Select(e => e.Name).OrderBy(x => x)));
+            var expectedTypes = new EndpointType[] { EndpointType.Primary, EndpointType.Primary, EndpointType.Secondary };
+            Assert.True(expectedTypes.SequenceEqual(hubEndpoints.Select(e => e.EndpointType).OrderBy(x => x)));
+            var expectedSes = new string[] { Url1, testSe, Url2 };
+            Assert.True(expectedSes.SequenceEqual(hubEndpoints.Select(e => e.ServerEndpoint.AbsoluteUri).OrderBy(x => x)));
+
+            hubEndpoints = container1.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(3, hubEndpoints.Length);
+            Assert.True(expectedNames.SequenceEqual(hubEndpoints.Select(e => e.Name).OrderBy(x => x)));
+            Assert.True(expectedTypes.SequenceEqual(hubEndpoints.Select(e => e.EndpointType).OrderBy(x => x)));
+            Assert.True(expectedSes.SequenceEqual(hubEndpoints.Select(e => e.ServerEndpoint.AbsoluteUri).OrderBy(x => x)));
+
+            // validate endpoint manager side not updated yet
+            var ngoEps = sem.GetEndpoints("hub").OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, ngoEps.Length);
+            Assert.Equal(Url1, ngoEps[0].ServerEndpoint.AbsoluteUri);
+            Assert.Equal(Url2, ngoEps[1].ServerEndpoint.AbsoluteUri);
+            Assert.Equal(EndpointType.Secondary, ngoEps[1].EndpointType);
+
+            // Mock add sync and validate negotiation side updated
+            containers = container.GetTestOnlineContainers();
+            await Task.WhenAll(containers.Select(x => x.MockReceivedServersPing("aaa;bbb")));
+            containers1 = container1.GetTestOnlineContainers();
+            await Task.WhenAll(containers1.Select(x => x.MockReceivedServersPing("aaa;bbb")));
+            await Task.Delay(6000);
+
+            ngoEps = sem.GetEndpoints("hub").OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, ngoEps.Length);
+            Assert.Equal(testSe, ngoEps[0].ServerEndpoint.AbsoluteUri);
+            Assert.Equal(Url2, ngoEps[1].ServerEndpoint.AbsoluteUri);
+
+            // Mock status offlined
+            containers = container.GetTestOnlineContainers();
+            await Task.WhenAll(containers.Select(x => x.MockReceivedStatusPing(false)));
+            containers1 = container1.GetTestOnlineContainers();
+            await Task.WhenAll(containers1.Select(x => x.MockReceivedStatusPing(false)));
+            await Task.Delay(6000);
+
+            // validate container updated as well
+            hubEndpoints = container.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, hubEndpoints.Length);
+            Assert.Equal("1", hubEndpoints[0].Name);
+            Assert.Equal("22", hubEndpoints[1].Name);
+            Assert.Equal(testSe, hubEndpoints[0].ServerEndpoint.AbsoluteUri);
+            hubEndpoints = container1.GetOnlineEndpoints().OrderBy(x => x.Name).ToArray();
+            Assert.Equal(2, hubEndpoints.Length);
+            Assert.Equal("1", hubEndpoints[0].Name);
+            Assert.Equal("22", hubEndpoints[1].Name);
+            Assert.Equal(testSe, hubEndpoints[0].ServerEndpoint.AbsoluteUri);
+        }
+
         [Theory]
         [MemberData(nameof(TestReloadEndpointsData))]
         public void TestServiceEndpointManagerReloadEndpoints(ServiceEndpoint[] oldValue, ServiceEndpoint[] newValue)

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
                 Assert.Single(warns);
-                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1")));
+                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1.com")));
                 return true;
             }))
             {
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
                 Assert.Equal(2, warns.Count);
-                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1")));
+                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1.com")));
                 return true;
             }))
             {
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
                 Assert.Equal(2, warns.Count);
-                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1")));
+                Assert.Contains(warns, s => s.Write.Message.Contains(string.Format(MultiEndpointMessageWriter.Log.FailedWritingMessageToEndpointTemplate, "JoinGroupWithAckMessage", "(null)", "(Primary)http://url1.com")));
                 return true;
             }))
             {


### PR DESCRIPTION
1. Add ClientEndpoint/ServerEndpoint as comparable properties when distinct service endpoints
2. Respect `ClientEndpoint` change as instant change during endpoint reloads
3. Respect `ServerEndpoint` change as add new then remove old during endpoint reloads.
4. Minor update `ServiceEndpoint.ToString()` for easier checks.