### PR TITLE
Obsolete UseAzureSignalR

### DIFF
--- a/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="configure">A callback to configure the <see cref="ServiceRouteBuilder"/>.</param>
         /// <returns>The same instance of the <see cref="IApplicationBuilder"/> for chaining.</returns>
 #if !NETSTANDARD2_0
-        [Obsolete("Use IApplicationBuilder.UseEndpoints() to replace IApplicationBuilder.UseAzureSignalR when .NET Core version >= 3.1")]
+        [Obsolete("IApplicationBuilder.UseAzureSignalR is obsoleted. Use IApplicationBuilder.UseEndpoints() to replace")]
 #endif
         public static IApplicationBuilder UseAzureSignalR(this IApplicationBuilder app, Action<ServiceRouteBuilder> configure)
         {

--- a/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="configure">A callback to configure the <see cref="ServiceRouteBuilder"/>.</param>
         /// <returns>The same instance of the <see cref="IApplicationBuilder"/> for chaining.</returns>
 #if !NETSTANDARD2_0
-        [Obsolete("IApplicationBuilder.UseAzureSignalR is obsoleted. Use IApplicationBuilder.UseEndpoints() to replace")]
+        [Obsolete("IApplicationBuilder.UseAzureSignalR is obsoleted, please use IApplicationBuilder.UseEndpoints() instead.")]
 #endif
         public static IApplicationBuilder UseAzureSignalR(this IApplicationBuilder app, Action<ServiceRouteBuilder> configure)
         {

--- a/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="configure">A callback to configure the <see cref="ServiceRouteBuilder"/>.</param>
         /// <returns>The same instance of the <see cref="IApplicationBuilder"/> for chaining.</returns>
-#if NETCOREAPP3_1_OR_GREATER || NET5_0_OR_GREATER
+#if !NETSTANDARD2_0
         [Obsolete("Use IApplicationBuilder.UseEndpoints() to replace IApplicationBuilder.UseAzureSignalR when .NET Core version >= 3.1")]
 #endif
         public static IApplicationBuilder UseAzureSignalR(this IApplicationBuilder app, Action<ServiceRouteBuilder> configure)

--- a/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/ApplicationBuilderExtensions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="configure">A callback to configure the <see cref="ServiceRouteBuilder"/>.</param>
         /// <returns>The same instance of the <see cref="IApplicationBuilder"/> for chaining.</returns>
+#if NETCOREAPP3_1_OR_GREATER || NET5_0_OR_GREATER
+        [Obsolete("Use IApplicationBuilder.UseEndpoints() to replace IApplicationBuilder.UseAzureSignalR when .NET Core version >= 3.1")]
+#endif
         public static IApplicationBuilder UseAzureSignalR(this IApplicationBuilder app, Action<ServiceRouteBuilder> configure)
         {
             var marker = app.ApplicationServices.GetService<AzureSignalRMarkerService>();

--- a/test/Microsoft.Azure.SignalR.E2ETests/SignalR/TestStartup.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/SignalR/TestStartup.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseAzureSignalR(configure =>
+            app.UseEndpoints(configure =>
             {
                 configure.MapHub<TestHub>($"/{nameof(TestHub)}");
             });


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - Obsolete IApplicationBuilder.UseAzureSignalR. Tell users to use IApplicationBuilder.UseEndpoints

Fixes #1602 