### PR TITLE
Update `Serverless.Protocols` version to 1.9.0

### DIFF
--- a/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
+++ b/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Azure.SignalR.Serverless.Protocols</RootNamespace>
     <!--Override the global version prefix-->
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.9.0</VersionPrefix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
   </PropertyGroup>
   


### PR DESCRIPTION
The next function extensions version is 1.9.0 . Skip 1.8.0 and 1.7.0
