### PR TITLE
fix API RemoveFromGroupAsync

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -66,10 +66,12 @@ namespace Microsoft.Azure.SignalR.Management
                 throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionId));
             }
 
-            var api = groupName == null 
-                ? await _restApiProvider.GetRemoveConnectionFromAllGroupsAsync(_appName, _hubName, connectionId)
-                : await _restApiProvider.GetConnectionGroupManagementEndpointAsync(_appName, _hubName, connectionId, groupName);
+            if (string.IsNullOrEmpty(groupName))
+            {
+                throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(groupName));
+            }
 
+            var api = await _restApiProvider.GetConnectionGroupManagementEndpointAsync(_appName, _hubName, connectionId, groupName);
             await _restClient.SendAsync(api, HttpMethod.Delete, _productInfo, handleExpectedResponseAsync: null, cancellationToken: cancellationToken);
         }
 


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - remove logic for RemoveConnectionFromAllGroups inside the API method `RemoveFromGroupAsync`
 - Removed part should be an independent API in the future