### PR TITLE
Use ArrayDictionary to improve perf

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/SignalRMessageParser.cs
@@ -224,9 +224,9 @@ namespace Microsoft.Azure.SignalR.AspNet
             return filter.Split('|').Select(s => GetName(s, PrefixHelper.ConnectionIdPrefix)).ToArray();
         }
 
-        private static Dictionary<string, ReadOnlyMemory<byte>> GetPayloads(ReadOnlyMemory<byte> data)
+        private static IDictionary<string, ReadOnlyMemory<byte>> GetPayloads(ReadOnlyMemory<byte> data)
         {
-            return new Dictionary<string, ReadOnlyMemory<byte>>
+            return new ArrayDictionary<string, ReadOnlyMemory<byte>>(1)
             {
                 { "json", data }
             };

--- a/src/Microsoft.Azure.SignalR.Protocols/ArrayDictionary.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ArrayDictionary.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+
+namespace Microsoft.Azure.SignalR
+{
+    /// <summary>
+    /// Lightweight, read-only IDictionary implementation using two arrays
+    /// and O(n) lookup.
+    /// Requires specifying capacity at construction and does not
+    /// support reallocation to increase capacity.
+    /// ref: https://github.com/dotnet/dotnet/blob/main/src/msbuild/src/Build/Collections/ArrayDictionary.cs
+    /// </summary>
+    /// <typeparam name="TKey">Type of keys</typeparam>
+    /// <typeparam name="TValue">Type of values</typeparam>
+    public class ArrayDictionary<TKey, TValue>
+        : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
+        where TValue : struct
+    {
+        private readonly IEqualityComparer<TKey> _comparer;
+        private readonly TKey[] _keys;
+        private readonly TValue[] _values;
+
+        private int count;
+
+        public ArrayDictionary(int capacity, IEqualityComparer<TKey>? comparer = null)
+        {
+            _keys = new TKey[capacity];
+            _values = new TValue[capacity];
+            _comparer = comparer ?? EqualityComparer<TKey>.Default;
+        }
+
+        public static IDictionary<TKey, TValue> Create(int capacity) =>
+            new ArrayDictionary<TKey, TValue>(capacity);
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+                throw new KeyNotFoundException();
+            }
+            set
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    if (_comparer.Equals(key, _keys[i]))
+                    {
+                        _values[i] = value;
+                        return;
+                    }
+                }
+                Add(key, value);
+            }
+        }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => _keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => _values;
+
+        private IEqualityComparer<TKey> KeyComparer => _comparer;
+
+        private IEqualityComparer<TValue> ValueComparer => EqualityComparer<TValue>.Default;
+
+        public int Count => count;
+
+        public bool IsReadOnly => true;
+
+        public ICollection<TKey> Keys => _keys;
+
+        public ICollection<TValue> Values => _values;
+
+        public void Add(TKey key, TValue value)
+        {
+            if (count < _keys.Length)
+            {
+                _keys[count] = key;
+                _values[count] = value;
+                count += 1;
+            }
+            else
+            {
+                throw new InvalidOperationException($"ArrayDictionary is at capacity {_keys.Length}");
+            }
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item) =>
+            Add(item.Key, item.Value);
+
+        public void Clear() => throw new System.NotImplementedException();
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            var valueComparer = ValueComparer;
+            for (int i = 0; i < count; i++)
+            {
+                if (_comparer.Equals(item.Key, _keys[i]) && valueComparer.Equals(item.Value, _values[i]))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (_comparer.Equals(key, _keys[i]))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                array[arrayIndex + i] = new(_keys[i], _values[i]);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() =>
+            new Enumerator(this);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool Remove(TKey key) =>
+            throw new System.NotImplementedException();
+
+        public bool Remove(KeyValuePair<TKey, TValue> item) =>
+            throw new System.NotImplementedException();
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                if (_comparer.Equals(key, _keys[i]))
+                {
+                    value = _values[i];
+                    return true;
+                }
+            }
+            value = default;
+            return false;
+        }
+
+        private struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+        {
+            private readonly ArrayDictionary<TKey, TValue> _dictionary;
+            private int _position;
+
+            public Enumerator(ArrayDictionary<TKey, TValue> dictionary)
+            {
+                this._dictionary = dictionary;
+                this._position = -1;
+            }
+
+            public KeyValuePair<TKey, TValue> Current =>
+                new KeyValuePair<TKey, TValue>(
+                    _dictionary._keys[_position],
+                    _dictionary._values[_position]);
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                _position += 1;
+                return _position < _dictionary.Count;
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.Azure.SignalR.Protocol
             var payloadCount = ReadMapLength(ref reader, "payloads");
             if (payloadCount > 0)
             {
-                var payloads = new Dictionary<string, ReadOnlyMemory<byte>>((int)payloadCount);
+                var payloads = new ArrayDictionary<string, ReadOnlyMemory<byte>>((int)payloadCount);
                 for (var i = 0; i < payloadCount; i++)
                 {
                     var key = ReadString(ref reader, $"payloads[{i}].key");

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.SignalR
             IDictionary<string, ReadOnlyMemory<byte>> payloads;
             if (serviceConnectionContext.Protocol != null)
             {
-                payloads = new Dictionary<string, ReadOnlyMemory<byte>>()
+                payloads = new ArrayDictionary<string, ReadOnlyMemory<byte>>(1)
                 {
                     { serviceConnectionContext.Protocol, SerializeProtocol(serviceConnectionContext.Protocol, methodName, args) }
                 };

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -286,7 +286,6 @@ namespace Microsoft.Azure.SignalR
 
         protected IDictionary<string, ReadOnlyMemory<byte>> SerializeAllProtocols(string method, object[] args, string invocationId = null)
         {
-            var payloads = new Dictionary<string, ReadOnlyMemory<byte>>();
             InvocationMessage message;
             if (invocationId == null)
             {
@@ -297,6 +296,7 @@ namespace Microsoft.Azure.SignalR
                 message = new InvocationMessage(invocationId, method, args);
             }
             var serializedHubMessages = _messageSerializer.SerializeMessage(message);
+            var payloads = new ArrayDictionary<string, ReadOnlyMemory<byte>>(serializedHubMessages.Count);
             foreach (var serializedMessage in serializedHubMessages)
             {
                 payloads.Add(serializedMessage.ProtocolName, serializedMessage.Serialized);


### PR DESCRIPTION
Perf profiles indicate a significant overhead (both in terms of CPU usage and memory allocation per request) when using relatively heavyweight Dictionary to store message data. Replacing it with ArrayDictionary which is more suitable for keeping a very small number of items in this use case.
