### PR TITLE
fix service protocol

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.Azure.SignalR.Protocol
             var payloadCount = ReadMapLength(ref reader, "payloads");
             if (payloadCount > 0)
             {
-                var payloads = new Dictionary<string, ReadOnlyMemory<byte>>((int)payloadCount);
+                var payloads = new Dictionary<string, ReadOnlyMemory<byte>>((int)payloadCount, StringComparer.OrdinalIgnoreCase);
                 for (var i = 0; i < payloadCount; i++)
                 {
                     var key = ReadString(ref reader, $"payloads[{i}].key");


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - payload hu protocol name should ignore case, which consistent to aspnet core signalr
 