### PR TITLE
Update swagger 20220601

### DIFF
--- a/docs/swagger/V20220601.json
+++ b/docs/swagger/V20220601.json
@@ -18,8 +18,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
@@ -40,9 +39,7 @@
         "summary": "Close all of the connections in the hub.",
         "operationId": "SignalR_CloseConnections",
         "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
+          "application/json"
         ],
         "parameters": [
           {
@@ -81,13 +78,12 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
           "204": {
-            "description": "Success"
+            "description": "No Content"
           },
           "default": {
             "description": "Error response",
@@ -153,8 +149,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           },
           {
             "in": "body",
@@ -168,7 +163,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Success",
+            "description": "Accepted",
             "schema": {
               "$ref": "#/definitions/ServiceResponse"
             }
@@ -190,71 +185,6 @@
       }
     },
     "/api/hubs/{hub}/connections/{connectionId}": {
-      "head": {
-        "tags": [
-          "signalr"
-        ],
-        "summary": "Check if the connection with the given connectionId exists",
-        "operationId": "SignalR_CheckConnectionExistence",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "hub",
-            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "required": true,
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "connectionId",
-            "description": "The connection Id.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "application",
-            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "query",
-            "name": "api-version",
-            "description": "The version of the REST APIs.",
-            "required": true,
-            "type": "string",
-            "default": "2022-06-01"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
-          },
-          "default": {
-            "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
-            "x-ms-error-response": true,
-            "headers": {
-              "x-ms-error-code": {
-                "x-ms-client-name": "ErrorCode",
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
       "delete": {
         "tags": [
           "signalr"
@@ -300,8 +230,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
@@ -316,6 +245,59 @@
             "schema": {
               "$ref": "#/definitions/ErrorDetail"
             },
+            "x-ms-error-response": true,
+            "headers": {
+              "x-ms-error-code": {
+                "x-ms-client-name": "ErrorCode",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "signalr"
+        ],
+        "summary": "Check if the connection with the given connectionId exists",
+        "operationId": "SignalR_CheckConnectionExistence",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hub",
+            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "path",
+            "name": "connectionId",
+            "description": "The connection Id.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "application",
+            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "description": "The version of the REST APIs.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "default": {
+            "description": "Error response",
             "x-ms-error-response": true,
             "headers": {
               "x-ms-error-code": {
@@ -372,8 +354,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           },
           {
             "in": "body",
@@ -387,6 +368,73 @@
         ],
         "responses": {
           "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/ServiceResponse"
+            }
+          },
+          "default": {
+            "description": "Error response",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetail"
+            },
+            "x-ms-error-response": true,
+            "headers": {
+              "x-ms-error-code": {
+                "x-ms-client-name": "ErrorCode",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hubs/{hub}/connections/{connectionId}/groups": {
+      "delete": {
+        "tags": [
+          "signalr"
+        ],
+        "summary": "Remove a connection from all groups",
+        "operationId": "SignalR_RemoveConnectionFromAllGroups",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hub",
+            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "path",
+            "name": "connectionId",
+            "description": "Target connection Id",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "in": "query",
+            "name": "application",
+            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "description": "The version of the REST APIs.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
             "description": "Success",
             "schema": {
               "$ref": "#/definitions/ServiceResponse"
@@ -415,11 +463,6 @@
         ],
         "summary": "Check if there are any client connections inside the given group",
         "operationId": "SignalR_CheckGroupExistence",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
         "parameters": [
           {
             "in": "path",
@@ -436,7 +479,8 @@
             "required": true,
             "type": "string",
             "maxLength": 1024,
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
           },
           {
             "in": "query",
@@ -450,25 +494,18 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
+            "description": "Success"
           },
           "404": {
             "description": "Not Found"
           },
           "default": {
             "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
             "x-ms-error-response": true,
             "headers": {
               "x-ms-error-code": {
@@ -488,9 +525,7 @@
         "summary": "Close connections in the specific group.",
         "operationId": "SignalR_CloseGroupConnections",
         "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
+          "application/json"
         ],
         "parameters": [
           {
@@ -508,7 +543,8 @@
             "required": true,
             "type": "string",
             "maxLength": 1024,
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
           },
           {
             "in": "query",
@@ -538,13 +574,12 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
           "204": {
-            "description": "Success"
+            "description": "No Content"
           },
           "default": {
             "description": "Error response",
@@ -619,8 +654,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           },
           {
             "in": "body",
@@ -634,7 +668,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Success",
+            "description": "Accepted",
             "schema": {
               "$ref": "#/definitions/ServiceResponse"
             }
@@ -656,83 +690,6 @@
       }
     },
     "/api/hubs/{hub}/groups/{group}/connections/{connectionId}": {
-      "put": {
-        "tags": [
-          "signalr"
-        ],
-        "summary": "Add a connection to the target group.",
-        "operationId": "SignalR_AddConnectionToGroup",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "hub",
-            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "required": true,
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "group",
-            "description": "Target group name, which length should be greater than 0 and less than 1025.",
-            "required": true,
-            "type": "string",
-            "maxLength": 1024,
-            "minLength": 1
-          },
-          {
-            "in": "path",
-            "name": "connectionId",
-            "description": "Target connection Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "application",
-            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "query",
-            "name": "api-version",
-            "description": "The version of the REST APIs.",
-            "required": true,
-            "type": "string",
-            "default": "2022-06-01"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "default": {
-            "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
-            "x-ms-error-response": true,
-            "headers": {
-              "x-ms-error-code": {
-                "x-ms-client-name": "ErrorCode",
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
       "delete": {
         "tags": [
           "signalr"
@@ -782,8 +739,84 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ServiceResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "default": {
+            "description": "Error response",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetail"
+            },
+            "x-ms-error-response": true,
+            "headers": {
+              "x-ms-error-code": {
+                "x-ms-client-name": "ErrorCode",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "signalr"
+        ],
+        "summary": "Add a connection to the target group.",
+        "operationId": "SignalR_AddConnectionToGroup",
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hub",
+            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "required": true,
             "type": "string",
-            "default": "2022-06-01"
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "path",
+            "name": "group",
+            "description": "Target group name, which length should be greater than 0 and less than 1025.",
+            "required": true,
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
+          },
+          {
+            "in": "path",
+            "name": "connectionId",
+            "description": "Target connection Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "application",
+            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "description": "The version of the REST APIs.",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -812,74 +845,6 @@
         }
       }
     },
-    "/api/hubs/{hub}/connections/{connectionId}/groups": {
-      "delete": {
-        "tags": [
-          "signalr"
-        ],
-        "summary": "Remove a connection from all groups",
-        "operationId": "SignalR_RemoveConnectionFromAllGroups",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "hub",
-            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "required": true,
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "connectionId",
-            "description": "Target connection Id",
-            "required": true,
-            "type": "string",
-            "minLength": 1
-          },
-          {
-            "in": "query",
-            "name": "application",
-            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "query",
-            "name": "api-version",
-            "description": "The version of the REST APIs.",
-            "required": true,
-            "type": "string",
-            "default": "2022-06-01"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
-          },
-          "default": {
-            "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
-            "x-ms-error-response": true,
-            "headers": {
-              "x-ms-error-code": {
-                "x-ms-client-name": "ErrorCode",
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/hubs/{hub}/users/{user}": {
       "head": {
         "tags": [
@@ -887,11 +852,6 @@
         ],
         "summary": "Check if there are any client connections connected for the given user",
         "operationId": "SignalR_CheckUserExistence",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
         "parameters": [
           {
             "in": "path",
@@ -920,25 +880,18 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
+            "description": "Success"
           },
           "404": {
             "description": "Not Found"
           },
           "default": {
             "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
             "x-ms-error-response": true,
             "headers": {
               "x-ms-error-code": {
@@ -958,9 +911,7 @@
         "summary": "Close connections for the specific user.",
         "operationId": "SignalR_CloseUserConnections",
         "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
+          "application/json"
         ],
         "parameters": [
           {
@@ -1008,13 +959,12 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
           "204": {
-            "description": "Success"
+            "description": "No Content"
           },
           "default": {
             "description": "Error response",
@@ -1077,8 +1027,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           },
           {
             "in": "body",
@@ -1092,7 +1041,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Success",
+            "description": "Accepted",
             "schema": {
               "$ref": "#/definitions/ServiceResponse"
             }
@@ -1113,17 +1062,15 @@
         }
       }
     },
-    "/api/hubs/{hub}/users/{user}/groups/{group}": {
-      "head": {
+    "/api/hubs/{hub}/users/{user}/groups": {
+      "delete": {
         "tags": [
           "signalr"
         ],
-        "summary": "Check whether a user exists in the target group.",
-        "operationId": "SignalR_CheckUserExistenceInGroup",
+        "summary": "Remove a user from all groups.",
+        "operationId": "SignalR_RemoveUserFromAllGroups",
         "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
+          "application/json"
         ],
         "parameters": [
           {
@@ -1133,15 +1080,6 @@
             "required": true,
             "type": "string",
             "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "group",
-            "description": "Target group name, which length should be greater than 0 and less than 1025.",
-            "required": true,
-            "type": "string",
-            "maxLength": 1024,
-            "minLength": 1
           },
           {
             "in": "path",
@@ -1162,25 +1100,155 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ServiceResponse"
-            }
-          },
-          "404": {
-            "description": "Not Found"
+          "204": {
+            "description": "No Content"
           },
           "default": {
             "description": "Error response",
             "schema": {
               "$ref": "#/definitions/ErrorDetail"
             },
+            "x-ms-error-response": true,
+            "headers": {
+              "x-ms-error-code": {
+                "x-ms-client-name": "ErrorCode",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hubs/{hub}/users/{user}/groups/{group}": {
+      "delete": {
+        "tags": [
+          "signalr"
+        ],
+        "summary": "Remove a user from the target group.",
+        "operationId": "SignalR_RemoveUserFromGroup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hub",
+            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "path",
+            "name": "group",
+            "description": "Target group name, which length should be greater than 0 and less than 1025.",
+            "required": true,
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "description": "Target user Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "application",
+            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "description": "The version of the REST APIs.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Error response",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetail"
+            },
+            "x-ms-error-response": true,
+            "headers": {
+              "x-ms-error-code": {
+                "x-ms-client-name": "ErrorCode",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "signalr"
+        ],
+        "summary": "Check whether a user exists in the target group.",
+        "operationId": "SignalR_CheckUserExistenceInGroup",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hub",
+            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "path",
+            "name": "group",
+            "description": "Target group name, which length should be greater than 0 and less than 1025.",
+            "required": true,
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "description": "Target user Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "application",
+            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
+          },
+          {
+            "in": "query",
+            "name": "api-version",
+            "description": "The version of the REST APIs.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "default": {
+            "description": "Error response",
             "x-ms-error-response": true,
             "headers": {
               "x-ms-error-code": {
@@ -1218,7 +1286,8 @@
             "required": true,
             "type": "string",
             "maxLength": 1024,
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?!\\s+$).+$"
           },
           {
             "in": "path",
@@ -1246,8 +1315,7 @@
             "name": "api-version",
             "description": "The version of the REST APIs.",
             "required": true,
-            "type": "string",
-            "default": "2022-06-01"
+            "type": "string"
           }
         ],
         "responses": {
@@ -1271,154 +1339,10 @@
             }
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "signalr"
-        ],
-        "summary": "Remove a user from the target group.",
-        "operationId": "SignalR_RemoveUserFromGroup",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "hub",
-            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "required": true,
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "group",
-            "description": "Target group name, which length should be greater than 0 and less than 1025.",
-            "required": true,
-            "type": "string",
-            "maxLength": 1024,
-            "minLength": 1
-          },
-          {
-            "in": "path",
-            "name": "user",
-            "description": "Target user Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "application",
-            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "query",
-            "name": "api-version",
-            "description": "The version of the REST APIs.",
-            "required": true,
-            "type": "string",
-            "default": "2022-06-01"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
-          },
-          "default": {
-            "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
-            "x-ms-error-response": true,
-            "headers": {
-              "x-ms-error-code": {
-                "x-ms-client-name": "ErrorCode",
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/hubs/{hub}/users/{user}/groups": {
-      "delete": {
-        "tags": [
-          "signalr"
-        ],
-        "summary": "Remove a user from all groups.",
-        "operationId": "SignalR_RemoveUserFromAllGroups",
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "hub",
-            "description": "Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "required": true,
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "path",
-            "name": "user",
-            "description": "Target user Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "application",
-            "description": "Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore.",
-            "type": "string",
-            "pattern": "^[A-Za-z][A-Za-z0-9_`,.[\\]]{0,127}$"
-          },
-          {
-            "in": "query",
-            "name": "api-version",
-            "description": "The version of the REST APIs.",
-            "required": true,
-            "type": "string",
-            "default": "2022-06-01"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
-          },
-          "default": {
-            "description": "Error response",
-            "schema": {
-              "$ref": "#/definitions/ErrorDetail"
-            },
-            "x-ms-error-response": true,
-            "headers": {
-              "x-ms-error-code": {
-                "x-ms-client-name": "ErrorCode",
-                "type": "string"
-              }
-            }
-          }
-        }
       }
     }
   },
   "definitions": {
-    "CodeLevel": {
-      "format": "int32",
-      "enum": [
-        0,
-        1,
-        2
-      ],
-      "type": "integer"
-    },
     "ErrorDetail": {
       "description": "The error object.",
       "type": "object",
@@ -1447,24 +1371,70 @@
         }
       }
     },
-    "ErrorKind": {
+    "HttpStatusCode": {
       "format": "int32",
       "enum": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "type": "integer"
-    },
-    "ErrorScope": {
-      "format": "int32",
-      "enum": [
-        0,
-        1,
-        2,
-        3,
-        4
+        100,
+        101,
+        102,
+        103,
+        200,
+        201,
+        202,
+        203,
+        204,
+        205,
+        206,
+        207,
+        208,
+        226,
+        300,
+        301,
+        302,
+        303,
+        304,
+        305,
+        306,
+        307,
+        308,
+        400,
+        401,
+        402,
+        403,
+        404,
+        405,
+        406,
+        407,
+        408,
+        409,
+        410,
+        411,
+        412,
+        413,
+        414,
+        415,
+        416,
+        417,
+        421,
+        422,
+        423,
+        424,
+        426,
+        428,
+        429,
+        431,
+        451,
+        500,
+        501,
+        502,
+        503,
+        504,
+        505,
+        506,
+        507,
+        508,
+        510,
+        511
       ],
       "type": "integer"
     },
@@ -1487,6 +1457,7 @@
       "type": "object",
       "properties": {
         "target": {
+          "minLength": 1,
           "type": "string"
         },
         "arguments": {
@@ -1512,17 +1483,38 @@
     "ServiceResponse": {
       "type": "object",
       "properties": {
+        "statusCode": {
+          "$ref": "#/definitions/HttpStatusCode"
+        },
         "code": {
           "type": "string"
         },
         "level": {
-          "$ref": "#/definitions/CodeLevel"
+          "enum": [
+            "Info",
+            "Warning",
+            "Error"
+          ],
+          "type": "string"
         },
         "scope": {
-          "$ref": "#/definitions/ErrorScope"
+          "enum": [
+            "Unknown",
+            "Request",
+            "Connection",
+            "User",
+            "Group"
+          ],
+          "type": "string"
         },
         "errorKind": {
-          "$ref": "#/definitions/ErrorKind"
+          "enum": [
+            "Unknown",
+            "NotExisted",
+            "NotInGroup",
+            "Invalid"
+          ],
+          "type": "string"
         },
         "message": {
           "type": "string"

--- a/docs/swagger/V20220601.md
+++ b/docs/swagger/V20220601.md
@@ -8,22 +8,22 @@
 | [Get service health status.](#head-get-service-health-status) | `HEAD /api/health` |
 | [Close all of the connections in the hub.](#post-close-all-of-the-connections-in-the-hub) | `POST /api/hubs/{hub}/:closeConnections` |
 | [Broadcast a message to all clients connected to target hub.](#post-broadcast-a-message-to-all-clients-connected-to-target-hub) | `POST /api/hubs/{hub}/:send` |
-| [Check if the connection with the given connectionId exists](#head-check-if-the-connection-with-the-given-connectionid-exists) | `HEAD /api/hubs/{hub}/connections/{connectionId}` |
 | [Close the client connection](#delete-close-the-client-connection) | `DELETE /api/hubs/{hub}/connections/{connectionId}` |
+| [Check if the connection with the given connectionId exists](#head-check-if-the-connection-with-the-given-connectionid-exists) | `HEAD /api/hubs/{hub}/connections/{connectionId}` |
 | [Send message to the specific connection.](#post-send-message-to-the-specific-connection) | `POST /api/hubs/{hub}/connections/{connectionId}/:send` |
+| [Remove a connection from all groups](#delete-remove-a-connection-from-all-groups) | `DELETE /api/hubs/{hub}/connections/{connectionId}/groups` |
 | [Check if there are any client connections inside the given group](#head-check-if-there-are-any-client-connections-inside-the-given-group) | `HEAD /api/hubs/{hub}/groups/{group}` |
 | [Close connections in the specific group.](#post-close-connections-in-the-specific-group) | `POST /api/hubs/{hub}/groups/{group}/:closeConnections` |
 | [Broadcast a message to all clients within the target group.](#post-broadcast-a-message-to-all-clients-within-the-target-group) | `POST /api/hubs/{hub}/groups/{group}/:send` |
-| [Add a connection to the target group.](#put-add-a-connection-to-the-target-group) | `PUT /api/hubs/{hub}/groups/{group}/connections/{connectionId}` |
 | [Remove a connection from the target group.](#delete-remove-a-connection-from-the-target-group) | `DELETE /api/hubs/{hub}/groups/{group}/connections/{connectionId}` |
-| [Remove a connection from all groups](#delete-remove-a-connection-from-all-groups) | `DELETE /api/hubs/{hub}/connections/{connectionId}/groups` |
+| [Add a connection to the target group.](#put-add-a-connection-to-the-target-group) | `PUT /api/hubs/{hub}/groups/{group}/connections/{connectionId}` |
 | [Check if there are any client connections connected for the given user](#head-check-if-there-are-any-client-connections-connected-for-the-given-user) | `HEAD /api/hubs/{hub}/users/{user}` |
 | [Close connections for the specific user.](#post-close-connections-for-the-specific-user) | `POST /api/hubs/{hub}/users/{user}/:closeConnections` |
 | [Broadcast a message to all clients belong to the target user.](#post-broadcast-a-message-to-all-clients-belong-to-the-target-user) | `POST /api/hubs/{hub}/users/{user}/:send` |
+| [Remove a user from all groups.](#delete-remove-a-user-from-all-groups) | `DELETE /api/hubs/{hub}/users/{user}/groups` |
+| [Remove a user from the target group.](#delete-remove-a-user-from-the-target-group) | `DELETE /api/hubs/{hub}/users/{user}/groups/{group}` |
 | [Check whether a user exists in the target group.](#head-check-whether-a-user-exists-in-the-target-group) | `HEAD /api/hubs/{hub}/users/{user}/groups/{group}` |
 | [Add a user to the target group.](#put-add-a-user-to-the-target-group) | `PUT /api/hubs/{hub}/users/{user}/groups/{group}` |
-| [Remove a user from the target group.](#delete-remove-a-user-from-the-target-group) | `DELETE /api/hubs/{hub}/users/{user}/groups/{group}` |
-| [Remove a user from all groups.](#delete-remove-a-user-from-all-groups) | `DELETE /api/hubs/{hub}/users/{user}/groups` |
 ### /api/health
 
 #### HEAD
@@ -73,7 +73,7 @@ Close all of the connections in the hub.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | Success |  |
+| 204 | No Content |  |
 | default | Error response | [ErrorDetail](#errordetail) |
 
 ### /api/hubs/{hub}/:send
@@ -101,35 +101,10 @@ Broadcast a message to all clients connected to target hub.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 202 | Success | [ServiceResponse](#serviceresponse) |
+| 202 | Accepted | [ServiceResponse](#serviceresponse) |
 | default | Error response | [ErrorDetail](#errordetail) |
 
 ### /api/hubs/{hub}/connections/{connectionId}
-
-#### HEAD
-##### Summary
-
-Check if the connection with the given connectionId exists
-
-<a name="head-check-if-the-connection-with-the-given-connectionid-exists"></a>
-### Check if the connection with the given connectionId exists
-
-`HEAD /api/hubs/{hub}/connections/{connectionId}`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| connectionId | path | The connection Id. | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| default | Error response | [ErrorDetail](#errordetail) |
 
 #### DELETE
 ##### Summary
@@ -157,6 +132,31 @@ Close the client connection
 | 200 | Success | [ServiceResponse](#serviceresponse) |
 | default | Error response | [ErrorDetail](#errordetail) |
 
+#### HEAD
+##### Summary
+
+Check if the connection with the given connectionId exists
+
+<a name="head-check-if-the-connection-with-the-given-connectionid-exists"></a>
+### Check if the connection with the given connectionId exists
+
+`HEAD /api/hubs/{hub}/connections/{connectionId}`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| connectionId | path | The connection Id. | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| default | Error response |
+
 ### /api/hubs/{hub}/connections/{connectionId}/:send
 
 #### POST
@@ -182,149 +182,7 @@ Send message to the specific connection.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 202 | Success | [ServiceResponse](#serviceresponse) |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-### /api/hubs/{hub}/groups/{group}
-
-#### HEAD
-##### Summary
-
-Check if there are any client connections inside the given group
-
-<a name="head-check-if-there-are-any-client-connections-inside-the-given-group"></a>
-### Check if there are any client connections inside the given group
-
-`HEAD /api/hubs/{hub}/groups/{group}`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| 404 | Not Found |  |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-### /api/hubs/{hub}/groups/{group}/:closeConnections
-
-#### POST
-##### Summary
-
-Close connections in the specific group.
-
-<a name="post-close-connections-in-the-specific-group"></a>
-### Close connections in the specific group
-
-`POST /api/hubs/{hub}/groups/{group}/:closeConnections`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| excluded | query | Exclude these connectionIds when closing the connections in the hub. | No | [ string ] |
-| reason | query | The reason closing the client connections. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | Success |  |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-### /api/hubs/{hub}/groups/{group}/:send
-
-#### POST
-##### Summary
-
-Broadcast a message to all clients within the target group.
-
-<a name="post-broadcast-a-message-to-all-clients-within-the-target-group"></a>
-### Broadcast a message to all clients within the target group
-
-`POST /api/hubs/{hub}/groups/{group}/:send`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| excluded | query | Excluded connection Ids | No | [ string ] |
-| api-version | query | The version of the REST APIs. | Yes | string |
-| message | body | The payload message. | Yes | [PayloadMessage](#payloadmessage) |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 202 | Success | [ServiceResponse](#serviceresponse) |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-### /api/hubs/{hub}/groups/{group}/connections/{connectionId}
-
-#### PUT
-##### Summary
-
-Add a connection to the target group.
-
-<a name="put-add-a-connection-to-the-target-group"></a>
-### Add a connection to the target group
-
-`PUT /api/hubs/{hub}/groups/{group}/connections/{connectionId}`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| connectionId | path | Target connection Id | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| 404 | Not Found |  |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-#### DELETE
-##### Summary
-
-Remove a connection from the target group.
-
-<a name="delete-remove-a-connection-from-the-target-group"></a>
-### Remove a connection from the target group
-
-`DELETE /api/hubs/{hub}/groups/{group}/connections/{connectionId}`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| connectionId | path | Target connection Id | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| 404 | Not Found |  |
+| 202 | Accepted | [ServiceResponse](#serviceresponse) |
 | default | Error response | [ErrorDetail](#errordetail) |
 
 ### /api/hubs/{hub}/connections/{connectionId}/groups
@@ -354,6 +212,148 @@ Remove a connection from all groups
 | 200 | Success | [ServiceResponse](#serviceresponse) |
 | default | Error response | [ErrorDetail](#errordetail) |
 
+### /api/hubs/{hub}/groups/{group}
+
+#### HEAD
+##### Summary
+
+Check if there are any client connections inside the given group
+
+<a name="head-check-if-there-are-any-client-connections-inside-the-given-group"></a>
+### Check if there are any client connections inside the given group
+
+`HEAD /api/hubs/{hub}/groups/{group}`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 404 | Not Found |
+| default | Error response |
+
+### /api/hubs/{hub}/groups/{group}/:closeConnections
+
+#### POST
+##### Summary
+
+Close connections in the specific group.
+
+<a name="post-close-connections-in-the-specific-group"></a>
+### Close connections in the specific group
+
+`POST /api/hubs/{hub}/groups/{group}/:closeConnections`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| excluded | query | Exclude these connectionIds when closing the connections in the hub. | No | [ string ] |
+| reason | query | The reason closing the client connections. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 204 | No Content |  |
+| default | Error response | [ErrorDetail](#errordetail) |
+
+### /api/hubs/{hub}/groups/{group}/:send
+
+#### POST
+##### Summary
+
+Broadcast a message to all clients within the target group.
+
+<a name="post-broadcast-a-message-to-all-clients-within-the-target-group"></a>
+### Broadcast a message to all clients within the target group
+
+`POST /api/hubs/{hub}/groups/{group}/:send`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| excluded | query | Excluded connection Ids | No | [ string ] |
+| api-version | query | The version of the REST APIs. | Yes | string |
+| message | body | The payload message. | Yes | [PayloadMessage](#payloadmessage) |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 202 | Accepted | [ServiceResponse](#serviceresponse) |
+| default | Error response | [ErrorDetail](#errordetail) |
+
+### /api/hubs/{hub}/groups/{group}/connections/{connectionId}
+
+#### DELETE
+##### Summary
+
+Remove a connection from the target group.
+
+<a name="delete-remove-a-connection-from-the-target-group"></a>
+### Remove a connection from the target group
+
+`DELETE /api/hubs/{hub}/groups/{group}/connections/{connectionId}`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| connectionId | path | Target connection Id | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | [ServiceResponse](#serviceresponse) |
+| 404 | Not Found |  |
+| default | Error response | [ErrorDetail](#errordetail) |
+
+#### PUT
+##### Summary
+
+Add a connection to the target group.
+
+<a name="put-add-a-connection-to-the-target-group"></a>
+### Add a connection to the target group
+
+`PUT /api/hubs/{hub}/groups/{group}/connections/{connectionId}`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| connectionId | path | Target connection Id | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | [ServiceResponse](#serviceresponse) |
+| 404 | Not Found |  |
+| default | Error response | [ErrorDetail](#errordetail) |
+
 ### /api/hubs/{hub}/users/{user}
 
 #### HEAD
@@ -376,11 +376,11 @@ Check if there are any client connections connected for the given user
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| 404 | Not Found |  |
-| default | Error response | [ErrorDetail](#errordetail) |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 404 | Not Found |
+| default | Error response |
 
 ### /api/hubs/{hub}/users/{user}/:closeConnections
 
@@ -408,7 +408,7 @@ Close connections for the specific user.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 204 | Success |  |
+| 204 | No Content |  |
 | default | Error response | [ErrorDetail](#errordetail) |
 
 ### /api/hubs/{hub}/users/{user}/:send
@@ -436,10 +436,63 @@ Broadcast a message to all clients belong to the target user.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 202 | Success | [ServiceResponse](#serviceresponse) |
+| 202 | Accepted | [ServiceResponse](#serviceresponse) |
+| default | Error response | [ErrorDetail](#errordetail) |
+
+### /api/hubs/{hub}/users/{user}/groups
+
+#### DELETE
+##### Summary
+
+Remove a user from all groups.
+
+<a name="delete-remove-a-user-from-all-groups"></a>
+### Remove a user from all groups
+
+`DELETE /api/hubs/{hub}/users/{user}/groups`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| user | path | Target user Id | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 204 | No Content |  |
 | default | Error response | [ErrorDetail](#errordetail) |
 
 ### /api/hubs/{hub}/users/{user}/groups/{group}
+
+#### DELETE
+##### Summary
+
+Remove a user from the target group.
+
+<a name="delete-remove-a-user-from-the-target-group"></a>
+### Remove a user from the target group
+
+`DELETE /api/hubs/{hub}/users/{user}/groups/{group}`
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
+| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
+| user | path | Target user Id | Yes | string |
+| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
+| api-version | query | The version of the REST APIs. | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 204 | No Content |  |
+| default | Error response | [ErrorDetail](#errordetail) |
 
 #### HEAD
 ##### Summary
@@ -462,11 +515,11 @@ Check whether a user exists in the target group.
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | [ServiceResponse](#serviceresponse) |
-| 404 | Not Found |  |
-| default | Error response | [ErrorDetail](#errordetail) |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 404 | Not Found |
+| default | Error response |
 
 #### PUT
 ##### Summary
@@ -495,66 +548,7 @@ Add a user to the target group.
 | 200 | Success | [ServiceResponse](#serviceresponse) |
 | default | Error response | [ErrorDetail](#errordetail) |
 
-#### DELETE
-##### Summary
-
-Remove a user from the target group.
-
-<a name="delete-remove-a-user-from-the-target-group"></a>
-### Remove a user from the target group
-
-`DELETE /api/hubs/{hub}/users/{user}/groups/{group}`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| group | path | Target group name, which length should be greater than 0 and less than 1025. | Yes | string |
-| user | path | Target user Id | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | Success |  |
-| default | Error response | [ErrorDetail](#errordetail) |
-
-### /api/hubs/{hub}/users/{user}/groups
-
-#### DELETE
-##### Summary
-
-Remove a user from all groups.
-
-<a name="delete-remove-a-user-from-all-groups"></a>
-### Remove a user from all groups
-
-`DELETE /api/hubs/{hub}/users/{user}/groups`
-##### Parameters
-
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| hub | path | Target hub name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | Yes | string |
-| user | path | Target user Id | Yes | string |
-| application | query | Target application name, which should start with alphabetic characters and only contain alpha-numeric characters or underscore. | No | string |
-| api-version | query | The version of the REST APIs. | Yes | string |
-
-##### Responses
-
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 204 | Success |  |
-| default | Error response | [ErrorDetail](#errordetail) |
-
 ### Models
-
-#### CodeLevel
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| CodeLevel | integer |  |  |
 
 #### ErrorDetail
 
@@ -568,17 +562,11 @@ The error object.
 | details | [ [ErrorDetail](#errordetail) ] | An array of details about specific errors that led to this reported error. | No |
 | inner | [InnerError](#innererror) |  | No |
 
-#### ErrorKind
+#### HttpStatusCode
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| ErrorKind | integer |  |  |
-
-#### ErrorScope
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| ErrorScope | integer |  |  |
+| HttpStatusCode | integer |  |  |
 
 #### InnerError
 
@@ -600,10 +588,11 @@ The error object.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
+| statusCode | [HttpStatusCode](#httpstatuscode) |  | No |
 | code | string |  | No |
-| level | [CodeLevel](#codelevel) |  | No |
-| scope | [ErrorScope](#errorscope) |  | No |
-| errorKind | [ErrorKind](#errorkind) |  | No |
+| level | string | _Enum:_ `"Info"`, `"Warning"`, `"Error"` | No |
+| scope | string | _Enum:_ `"Unknown"`, `"Request"`, `"Connection"`, `"User"`, `"Group"` | No |
+| errorKind | string | _Enum:_ `"Unknown"`, `"NotExisted"`, `"NotInGroup"`, `"Invalid"` | No |
 | message | string |  | No |
 | jsonObject |  |  | No |
 | isSuccess | boolean |  | No |


### PR DESCRIPTION
### Summary of the changes
 - A swagger generation bug in runtime was fixed. See [here](https://msazure.visualstudio.com/One/_git/OSSServices-SignalR-Service/pullrequest/7767515). 
#### Modification to swagger generated by service
 - All `x-ms-examples` are removed to generate markdown successfully, such as
```
"x-ms-examples": {
          "HealthApi_GetServiceStatus": {
            "$ref": "./examples/HealthApi_GetServiceStatus.json"
          }
}
```
- No change to any other part.