### PR TITLE
Fix for Dockerfile smell DL3003

### DIFF
--- a/samples/ChatSample/ChatSample.NetCore31/Dockerfile
+++ b/samples/ChatSample/ChatSample.NetCore31/Dockerfile
@@ -6,8 +6,8 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0
 
 COPY ./ /home/signalr-src
 
-RUN cd /home/signalr-src/samples/ChatSample/ChatSample && \
-    dotnet build && \
+WORKDIR /home/signalr-src/samples/ChatSample/ChatSample 
+RUN dotnet build && \
     dotnet publish -r ubuntu.16.04-x64 -c Release -o /home/build/
 
 ##################################################


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - Refactor for Dockerfile writing best practices

Fixes NONE

### Description
Hi!
The Dockerfile placed at "samples/ChatSample/ChatSample.NetCore31/Dockerfile" contains the best practice violation [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3003 occurs if the pattern `RUN cd ...` is used to change directories instead of the dedicated WORKDIR instruction.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the pattern `RUN cd ...` is replaced with the equivalent WORKDIR instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance