### PR TITLE
Don't throw exception when add connection/user to group if not exist for management SDK transient mode.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -102,6 +102,12 @@ namespace Microsoft.Azure.SignalR
             public const string AsrsHeaderPrefix = "X-ASRS-";
             public const string AsrsServerId = AsrsHeaderPrefix + "Server-Id";
             public const string AsrsMessageTracingId = AsrsHeaderPrefix + "Message-Tracing-Id";
+            public const string MicrosoftErrorCode = "x-ms-error-code";
+        }
+
+        public static class ErrorCodes
+        {
+            public const string NotExisted = "NotExisted";
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
@@ -66,11 +66,10 @@ namespace Microsoft.Azure.SignalR
         {
             using var httpClient = _httpClientFactory.CreateClient();
             using var request = BuildRequest(api, httpMethod, productInfo, methodName, args);
-            HttpResponseMessage response = null;
 
             try
             {
-                response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 if (handleExpectedResponseAsync == null)
                 {
                     await ThrowExceptionOnResponseFailureAsync(response);
@@ -86,10 +85,6 @@ namespace Microsoft.Azure.SignalR
             catch (HttpRequestException ex)
             {
                 throw new AzureSignalRInaccessibleEndpointException(request.RequestUri.ToString(), ex);
-            }
-            finally
-            {
-                response?.Dispose();
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.SignalR.Management
             }
 
             var api = await _restApiProvider.GetConnectionGroupManagementEndpointAsync(_appName, _hubName, connectionId, groupName);
-            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: null, cancellationToken: cancellationToken);
+            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: HandleAddToGroupResponse, cancellationToken: cancellationToken);
         }
 
         public override Task OnConnectedAsync(HubConnectionContext connection)
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.SignalR.Management
             ValidateUserIdAndGroupName(userId, groupName);
 
             var api = await _restApiProvider.GetUserGroupManagementEndpointAsync(_appName, _hubName, userId, groupName);
-            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: null, cancellationToken: cancellationToken);
+            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: HandleAddToGroupResponse, cancellationToken: cancellationToken);
         }
 
         public async Task UserAddToGroupAsync(string userId, string groupName, TimeSpan ttl, CancellationToken cancellationToken = default)
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.SignalR.Management
             {
                 ["ttl"] = ((int)ttl.TotalSeconds).ToString(),
             };
-            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: null, cancellationToken: cancellationToken);
+            await _restClient.SendAsync(api, HttpMethod.Put, _productInfo, handleExpectedResponseAsync: HandleAddToGroupResponse, cancellationToken: cancellationToken);
         }
 
         public async Task UserRemoveFromGroupAsync(string userId, string groupName, CancellationToken cancellationToken = default)
@@ -344,5 +344,11 @@ namespace Microsoft.Azure.SignalR.Management
         }
 
         public Task DisposeAsync() => Task.CompletedTask;
+
+        private Task<bool> HandleAddToGroupResponse(HttpResponseMessage response) => response.IsSuccessStatusCode
+                ? Task.FromResult(true)
+                : response.StatusCode == HttpStatusCode.NotFound && response.Headers.TryGetValues(Constants.Headers.MicrosoftErrorCode, out var errorCodes) && errorCodes.First().EndsWith(Constants.ErrorCodes.NotExisted)
+                ? Task.FromResult(true)
+                : Task.FromResult(false);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/IInternalServiceHubContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/IInternalServiceHubContextFacts.cs
@@ -4,12 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -184,6 +189,62 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             await MockConnectionTestAsync(serviceTransportType, testAction, assertAction);
         }
 
+        [Fact]
+        public async Task AddNotExistedConnectionToGroup_NoError_Test()
+        {
+            using var disposable = StartLog(out var loggerFactory, LogLevel.Debug);
+            var hubContext = await new ServiceManagerBuilder()
+            .WithOptions(o =>
+            {
+                o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+                o.ServiceTransportType = ServiceTransportType.Transient;
+            })
+            .WithLoggerFactory(loggerFactory)
+            .ConfigureServices(services =>
+            {
+                services.AddHttpClient(string.Empty).AddHttpMessageHandler(sp =>
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.NotFound);
+                    response.Headers.Add(Constants.Headers.MicrosoftErrorCode, "Error.Connections.NotExisted");
+                    var mock = new Mock<DelegatingHandler>();
+                    mock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(response);
+                    return mock.Object;
+                });
+            })
+            .BuildServiceManager()
+            .CreateHubContextAsync(Hub, default);
+            await hubContext.Groups.AddToGroupAsync(Guid.NewGuid().ToString(), GroupName);
+        }
+
+        [Fact]
+        public async Task AddNotExistedUserToGroup_NoError_Test()
+        {
+            using var disposable = StartLog(out var loggerFactory, LogLevel.Debug);
+            var hubContext = await new ServiceManagerBuilder()
+            .WithOptions(o =>
+            {
+                o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+                o.ServiceTransportType = ServiceTransportType.Transient;
+            })
+            .WithLoggerFactory(loggerFactory)
+            .ConfigureServices(services =>
+            {
+                services.AddHttpClient(string.Empty).AddHttpMessageHandler(sp =>
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.NotFound);
+                    response.Headers.Add(Constants.Headers.MicrosoftErrorCode, "Error.User.NotExisted");
+                    var mock = new Mock<DelegatingHandler>();
+                    mock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(response);
+                    return mock.Object;
+                });
+            })
+            .BuildServiceManager()
+            .CreateHubContextAsync(Hub, default);
+            await hubContext.UserGroups.AddToGroupAsync(UserId, GroupName);
+        }
+
         private async Task MockConnectionTestAsync(ServiceTransportType serviceTransportType, Func<ServiceHubContext, Task> testAction, Action<Dictionary<HubServiceEndpoint, List<TestServiceConnection>>> assertAction)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
@@ -198,7 +259,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                     .WithLoggerFactory(loggerFactory)
                     .ConfigureServices(services => services.AddSingleton<IServiceConnectionFactory>(connectionFactory))
                     .BuildServiceManager();
-                var hubContext = await serviceManager.CreateHubContextAsync(Hub,default);
+                var hubContext = await serviceManager.CreateHubContextAsync(Hub, default);
 
                 await testAction.Invoke(hubContext);
 


### PR DESCRIPTION
Keep consistent with persistent mode.

