### PR TITLE
use named templating in log messages

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Logging/MessageLog.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Logging/MessageLog.cs
@@ -9,26 +9,31 @@ namespace Microsoft.Azure.SignalR
 {
     internal static class MessageLog
     {
-        public const string StartToBroadcastMessageTemplate = "Start to broadcast message {0}.";
-        public const string StartToBroadcastMessageWithExcludedConnectionTemplate = "Start to broadcast message {0} except for {1} connections {2}.";
-        public const string StartToSendMessageToConnectionsTemplate = "Start to send message {0} to {1} connections {2}.";
-        public const string StartToSendMessageToConnectionTemplate = "Start to send message {0} to connection {1}.";
-        public const string StartToBroadcastMessageToGroupTemplate = "Start to broadcast message {0} to group {1}.";
-        public const string StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate = "Start to broadcast message {0} to group {1} except for {2} connections {3}.";
-        public const string StartToBroadcastMessageToGroupsTemplate = "Start to broadcast message {0} to {1} groups {2}.";
-        public const string StartToSendMessageToUserTemplate = "Start to send message {0} to user {1}.";
-        public const string StartToSendMessageToUsersTemplate = "Start to send message {0} to {1} users {2}.";
-        public const string StartToAddConnectionToGroupTemplate = "Start to send message {0} to add connection {1} to group {2}.";
-        public const string StartToRemoveConnectionFromGroupTemplate = "Start to send message {0} to remove connection {1} from group {2}.";
-        public const string StartToAddUserToGroupTemplate = "Start to send message {0} to add user {1} to group {2}.";
-        public const string StartToAddUserToGroupWithTtlTemplate = "Start to send message {0} to add user {1} to group {2} with TTL {3} seconds.";
-        public const string StartToRemoveUserFromGroupTemplate = "Start to send message {0} to remove user {1} from group {2}.";
-        public const string StartToRemoveUserFromAllGroupsTemplate = "Start to send message {0} to remove user {1} from all groups.";
-        public const string StartToRemoveConnectionFromAllGroupsTemplate = "Start to send message {0} to remove connection {1} from all groups.";
-        public const string StartToCheckIfUserInGroupTemplate = "Start to send message {0} to check if user {1} in group {2}.";
-        public const string FailedToSendMessageTemplate = "Failed to send message {0}.";
-        public const string SucceededToSendMessageTemplate = "Succeeded to send message {0}.";
-
+        public const string StartToBroadcastMessageTemplate = "Start to broadcast message {tracingId}.";
+        public const string StartToBroadcastMessageWithExcludedConnectionTemplate = "Start to broadcast message {tracingId} except for {excludedCount} connections {excludedList}.";
+        public const string StartToSendMessageToConnectionsTemplate = "Start to send message {tracingId} to {connectionsCount} connections {connectionsList}.";
+        public const string StartToSendMessageToConnectionTemplate = "Start to send message {tracingId} to connection {connectionId}.";
+        public const string StartToBroadcastMessageToGroupTemplate = "Start to broadcast message {tracingId} to group {group}.";
+        public const string StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate = "Start to broadcast message {tracingId} to group {group} except for {excludedCount} connections {connectionsList}.";
+        public const string StartToBroadcastMessageToGroupsTemplate = "Start to broadcast message {tracingId} to {groupsCount} groups {groupsList}.";
+        public const string StartToSendMessageToUserTemplate = "Start to send message {tracingId} to user {userId}.";
+        public const string StartToSendMessageToUsersTemplate = "Start to send message {tracingId} to {usersCount} users {usersList}.";
+        public const string StartToAddConnectionToGroupTemplate = "Start to send message {tracingId} to add connection {connectionId} to group {group}.";
+        public const string StartToRemoveConnectionFromGroupTemplate = "Start to send message {tracingId} to remove connection {connectionId} from group {group}.";
+        public const string StartToAddUserToGroupTemplate = "Start to send message {tracingId} to add user {userId} to group {group}.";
+        public const string StartToAddUserToGroupWithTtlTemplate = "Start to send message {tracingId} to add user {userId} to group {group} with TTL {timeToLive} seconds.";
+        public const string StartToRemoveUserFromGroupTemplate = "Start to send message {tracingId} to remove user {userId} from group {group}.";
+        public const string StartToRemoveUserFromAllGroupsTemplate = "Start to send message {tracingId} to remove user {userId} from all groups.";
+        public const string StartToRemoveConnectionFromAllGroupsTemplate = "Start to send message {tracingId} to remove connection {connectionId} from all groups.";
+        public const string StartToCheckIfUserInGroupTemplate = "Start to send message {tracingId} to check if user {userId} in group {group}.";
+        public const string FailedToSendMessageTemplate = "Failed to send message {tracingId}.";
+        public const string SucceededToSendMessageTemplate = "Succeeded to send message {tracingId}.";
+        public const string ReceivedMessageFromClientConnectionTemplate = "Received message {tracingId} from client connection {connectionId}.";
+        public const string StartToSendMessageToCloseConnectionTemplate = "Start to send message {tracingId} to close connection {connectionId} for reason: '{reason}'.";
+        public const string StartToSendMessageToCheckConnectionTemplate = "Start to send message {tracingId} to check if connection {connectionId} exists.";
+        public const string StartToSendMessageToCheckIfUserExistsTemplate = "Start to send message {tracingId} to check if user {userId} exists.";
+        public const string StartToSendMessageToCheckIfGroupExistsTemplate = "Start to send message {tracingId} to check if group {group} exists.";
+        
         private static readonly Action<ILogger, ulong?, Exception> _startToBroadcastMessage =
             LoggerMessage.Define<ulong?>(
                 LogLevel.Information,
@@ -141,7 +146,7 @@ namespace Microsoft.Azure.SignalR
                 LoggerMessage.Define<ulong?, string>(
                     LogLevel.Information,
                     new EventId(120, "RecieveMessageFromService"),
-                    "Received message {tracingId} from client connection {connectionId}.");
+                    ReceivedMessageFromClientConnectionTemplate);
 
         private static readonly Action<ILogger, ulong?, string, string, Exception> _startToCheckIfUserInGroup =
                 LoggerMessage.Define<ulong?, string, string>(
@@ -153,24 +158,25 @@ namespace Microsoft.Azure.SignalR
                 LoggerMessage.Define<ulong?, string, string>(
                     LogLevel.Information,
                     new EventId(140, "StartToCloseConnection"),
-                    "Start to send message {tracingId} to close connection {connectionId} for reason: '{reason}'.");
+                    StartToSendMessageToCloseConnectionTemplate);
 
-        private static readonly Action<ILogger, ulong?, string, Exception> _startToCheckIfConnectionExists = LoggerMessage.Define<ulong?, string>(
+        private static readonly Action<ILogger, ulong?, string, Exception> _startToCheckIfConnectionExists = 
+                LoggerMessage.Define<ulong?, string>(
                     LogLevel.Information,
                     new EventId(150, "StartToCheckIfConnectionExists"),
-                    "Start to send message {tracingId} to check if connection {connectionId} exists.");
+                    StartToSendMessageToCheckConnectionTemplate);
 
         private static readonly Action<ILogger, ulong?, string, Exception> _startToCheckIfUserExists =
                 LoggerMessage.Define<ulong?, string>(
                     LogLevel.Information,
                     new EventId(160, "StartToCheckIfUserExists"),
-                    "Start to send message {tracingId} to check if user {userId} exists.");
+                    StartToSendMessageToCheckIfUserExistsTemplate);
 
         private static readonly Action<ILogger, ulong?, string, Exception> _startToCheckIfGroupExists =
                 LoggerMessage.Define<ulong?, string>(
                     LogLevel.Information,
                     new EventId(170, "StartToCheckIfGroupExists"),
-                    "Start to send message {tracingId} to check if group {group} exists.");
+                    StartToSendMessageToCheckIfGroupExistsTemplate);
 
         public static void ReceiveMessageFromService(ILogger logger, ConnectionDataMessage message)
         {

--- a/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -19,76 +20,82 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 // broadcast
                 MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(null, 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
 
                 MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(new[] { "x", "y" }, new Dictionary<string, ReadOnlyMemory<byte>>(), 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
 
                 // send to connections
                 MessageLog.StartToSendMessageToConnection(logger, new ConnectionDataMessage("id1", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToConnectionTemplate, 123UL, "id1"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionTemplate, 123UL, "id1"), logger.LogStr);
                 
                 MessageLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
 
                 // send to user/users
                 MessageLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
 
                 MessageLog.FailedToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL), new Exception());
-                Assert.Equal(string.Format(MessageLog.FailedToSendMessageTemplate, 123UL), logger.LogStr);
+                Assert.Equal(Format(MessageLog.FailedToSendMessageTemplate, 123UL), logger.LogStr);
 
                 MessageLog.SucceededToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.SucceededToSendMessageTemplate, 123UL), logger.LogStr);
+                Assert.Equal(Format(MessageLog.SucceededToSendMessageTemplate, 123UL), logger.LogStr);
                 
                 MessageLog.ReceiveMessageFromService(logger, new ConnectionDataMessage("c", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.ReceivedMessageFromClientConnectionTemplate, 123UL, "c"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.ReceivedMessageFromClientConnectionTemplate, 123UL, "c"), logger.LogStr);
                 
                 MessageLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
 
                 // send to group/groups
                 MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
 
                 MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", new[] { "c1", "c2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
 
                 MessageLog.StartToBroadcastMessageToGroups(logger, new MultiGroupBroadcastDataMessage(new[] { "g1", "g2" }, null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
 
                 // connection join/leave group
                 MessageLog.StartToAddConnectionToGroup(logger, new JoinGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
                 MessageLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
                 
                 MessageLog.StartToCloseConnection(logger, new CloseConnectionMessage("c", "e") { TracingId = 123UL});
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCloseConnectionTemplate, 123UL, "c", "e"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToCloseConnectionTemplate, 123UL, "c", "e"), logger.LogStr);
                 
                 MessageLog.StartToCheckIfConnectionExists(logger, new CheckConnectionExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckConnectionTemplate, 123UL, "c"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckConnectionTemplate, 123UL, "c"), logger.LogStr);
                 
                 MessageLog.StartToCheckIfUserExists(logger, new CheckUserExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckIfUserExistsTemplate, 123UL, "c"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfUserExistsTemplate, 123UL, "c"), logger.LogStr);
                 
                 MessageLog.StartToCheckIfGroupExists(logger, new CheckGroupExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckIfGroupExistsTemplate, 123UL, "c"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfGroupExistsTemplate, 123UL, "c"), logger.LogStr);
                 
                 // user join/leave group
                 MessageLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
                 
                 MessageLog.StartToCheckIfUserInGroup(logger, new CheckUserInGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToCheckIfUserInGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToCheckIfUserInGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
                 MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
                 MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", null, tracingId: 123UL));
-                Assert.Equal(string.Format(MessageLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
+                Assert.Equal(Format(MessageLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
             }
+        }
+
+        private string Format(string logTemplate, params object[] values)
+        {
+            var index = 0;
+            return Regex.Replace(logTemplate, "{[^}]*}", _ => values[index++].ToString());
         }
 
         private class TestLogger : ILogger

--- a/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Azure.SignalR.Tests
                 Assert.Equal(string.Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
 
                 // send to connections
+                MessageLog.StartToSendMessageToConnection(logger, new ConnectionDataMessage("id1", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToConnectionTemplate, 123UL, "id1"), logger.LogStr);
+                
                 MessageLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
 
@@ -32,6 +35,15 @@ namespace Microsoft.Azure.SignalR.Tests
                 MessageLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
 
+                MessageLog.FailedToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL), new Exception());
+                Assert.Equal(string.Format(MessageLog.FailedToSendMessageTemplate, 123UL), logger.LogStr);
+
+                MessageLog.SucceededToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.SucceededToSendMessageTemplate, 123UL), logger.LogStr);
+                
+                MessageLog.ReceiveMessageFromService(logger, new ConnectionDataMessage("c", null, tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.ReceivedMessageFromClientConnectionTemplate, 123UL, "c"), logger.LogStr);
+                
                 MessageLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
 
@@ -51,10 +63,25 @@ namespace Microsoft.Azure.SignalR.Tests
 
                 MessageLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
-
+                
+                MessageLog.StartToCloseConnection(logger, new CloseConnectionMessage("c", "e") { TracingId = 123UL});
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCloseConnectionTemplate, 123UL, "c", "e"), logger.LogStr);
+                
+                MessageLog.StartToCheckIfConnectionExists(logger, new CheckConnectionExistenceWithAckMessage("c", 12, 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckConnectionTemplate, 123UL, "c"), logger.LogStr);
+                
+                MessageLog.StartToCheckIfUserExists(logger, new CheckUserExistenceWithAckMessage("c", 12, 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckIfUserExistsTemplate, 123UL, "c"), logger.LogStr);
+                
+                MessageLog.StartToCheckIfGroupExists(logger, new CheckGroupExistenceWithAckMessage("c", 12, 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToSendMessageToCheckIfGroupExistsTemplate, 123UL, "c"), logger.LogStr);
+                
                 // user join/leave group
                 MessageLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+                
+                MessageLog.StartToCheckIfUserInGroup(logger, new CheckUserInGroupWithAckMessage("c", "g", tracingId: 123UL));
+                Assert.Equal(string.Format(MessageLog.StartToCheckIfUserInGroupTemplate, 123UL, "c", "g"), logger.LogStr);
 
                 MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
                 Assert.Equal(string.Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);


### PR DESCRIPTION
When using log destructuration having logs with {0}, {1} in templates can be an issue as these have different types for each log messages