### PR TITLE
Add HttpClientTimeout options to management SDK

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.SignalR
             }
             catch (HttpRequestException ex)
             {
-                throw new AzureSignalRInaccessibleEndpointException(request.RequestUri.ToString(), ex);
+                throw new AzureSignalRException($"An error happened when making request to {request.RequestUri}", ex);
             }
         }
 

--- a/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/Configuration/ServiceManagerOptions.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Azure.SignalR.Management
         public ServiceTransportType ServiceTransportType { get; set; } = ServiceTransportType.Transient;
 
         /// <summary>
+        /// Gets or sets the timespan to wait before the HTTP request times out. The default value is 100 seconds.
+        /// </summary>
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        /// <summary>
         /// Gets the json serializer settings that will be used to serialize content sent to Azure SignalR Service.
         /// </summary>
         [Obsolete("Use ServiceManagerBuilder.WithNewtonsoftJson instead.")]

--- a/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR.Management/DependencyInjectionExtensions.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.SignalR.Management
         }
 
         private static IServiceCollection AddRestClientFactory(this IServiceCollection services) => services
-            .AddHttpClient(Options.DefaultName)
+            .AddHttpClient(Options.DefaultName, (sp, client) => client.Timeout = sp.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.HttpClientTimeout)
             .ConfigurePrimaryHttpMessageHandler(sp => new HttpClientHandler() { Proxy = sp.GetRequiredService<IOptions<ServiceManagerOptions>>().Value.Proxy }).Services
             .AddSingleton(sp =>
             {

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -281,7 +281,9 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             var requestStartTime = DateTime.UtcNow;
             var serviceHubContext = await serviceManager.CreateHubContextAsync("hub", default);
             await Assert.ThrowsAsync<TaskCanceledException>(() => serviceHubContext.Clients.All.SendCoreAsync("method", null));
-            Assert.True(DateTime.UtcNow - requestStartTime > TimeSpan.FromSeconds(1));
+            var elapsed = DateTime.UtcNow - requestStartTime;
+            _outputHelper.WriteLine("Request elapsed time: {0}", elapsed);
+            Assert.True(elapsed >= TimeSpan.FromSeconds(1));
         }
 
         private class WaitInfinitelyHandler : DelegatingHandler

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -282,7 +282,21 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             var serviceHubContext = await serviceManager.CreateHubContextAsync("hub", default);
             await Assert.ThrowsAsync<TaskCanceledException>(() => serviceHubContext.Clients.All.SendCoreAsync("method", null));
             var elapsed = DateTime.UtcNow - requestStartTime;
-            _outputHelper.WriteLine("Request elapsed time: {0}", elapsed);
+            _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
+            Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task TimeOut()
+        {
+            var requestStartTime = DateTime.UtcNow;
+            var httpClient = new HttpClient(new WaitInfinitelyHandler())
+            {
+                Timeout = TimeSpan.FromSeconds(1)
+            };
+            await Assert.ThrowsAsync<TaskCanceledException>(() => httpClient.GetAsync("http://abc"));
+            var elapsed = DateTime.UtcNow - requestStartTime;
+            _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
             Assert.True(elapsed >= TimeSpan.FromSeconds(1));
         }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -269,9 +269,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         [Fact]
         public async Task CustomizeHttpClientTimeoutTestAsync()
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
             {
-
                 using var serviceManager = new ServiceManagerBuilder()
                     .WithOptions(o =>
                     {
@@ -286,25 +285,9 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 await Assert.ThrowsAsync<TaskCanceledException>(() => serviceHubContext.Clients.All.SendCoreAsync("method", null));
                 var elapsed = DateTime.UtcNow - requestStartTime;
                 _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
-                Assert.True(elapsed >= TimeSpan.FromSeconds(1));
-            }
-        }
-
-        [Fact]
-        public async Task TimeOut()
-        {
-            for (int i = 0; i < 100; i++)
-            {
-
-                var requestStartTime = DateTime.UtcNow;
-                var httpClient = new HttpClient(new WaitInfinitelyHandler())
-                {
-                    Timeout = TimeSpan.FromSeconds(1)
-                };
-                await Assert.ThrowsAsync<TaskCanceledException>(() => httpClient.GetAsync("http://abc"));
-                var elapsed = DateTime.UtcNow - requestStartTime;
-                _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
-                Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+                // Don't know why, the elapsed time sometimes is shorter than 1 second, but it should be close to 1 second.
+                Assert.True(elapsed >= TimeSpan.FromSeconds(0.8));
+                Assert.True(elapsed < TimeSpan.FromSeconds(1.2));
             }
         }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -269,35 +269,43 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         [Fact]
         public async Task CustomizeHttpClientTimeoutTestAsync()
         {
-            using var serviceManager = new ServiceManagerBuilder()
-                .WithOptions(o =>
-                {
-                    // use http schema to avoid SSL handshake
-                    o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
-                    o.HttpClientTimeout = TimeSpan.FromSeconds(1);
-                })
-                .ConfigureServices(services => services.AddHttpClient(Options.DefaultName).AddHttpMessageHandler(sp => new WaitInfinitelyHandler()))
-                .BuildServiceManager();
-            var requestStartTime = DateTime.UtcNow;
-            var serviceHubContext = await serviceManager.CreateHubContextAsync("hub", default);
-            await Assert.ThrowsAsync<TaskCanceledException>(() => serviceHubContext.Clients.All.SendCoreAsync("method", null));
-            var elapsed = DateTime.UtcNow - requestStartTime;
-            _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
-            Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+            for (int i = 0; i < 100; i++)
+            {
+
+                using var serviceManager = new ServiceManagerBuilder()
+                    .WithOptions(o =>
+                    {
+                        // use http schema to avoid SSL handshake
+                        o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+                        o.HttpClientTimeout = TimeSpan.FromSeconds(1);
+                    })
+                    .ConfigureServices(services => services.AddHttpClient(Options.DefaultName).AddHttpMessageHandler(sp => new WaitInfinitelyHandler()))
+                    .BuildServiceManager();
+                var requestStartTime = DateTime.UtcNow;
+                var serviceHubContext = await serviceManager.CreateHubContextAsync("hub", default);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => serviceHubContext.Clients.All.SendCoreAsync("method", null));
+                var elapsed = DateTime.UtcNow - requestStartTime;
+                _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
+                Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+            }
         }
 
         [Fact]
         public async Task TimeOut()
         {
-            var requestStartTime = DateTime.UtcNow;
-            var httpClient = new HttpClient(new WaitInfinitelyHandler())
+            for (int i = 0; i < 100; i++)
             {
-                Timeout = TimeSpan.FromSeconds(1)
-            };
-            await Assert.ThrowsAsync<TaskCanceledException>(() => httpClient.GetAsync("http://abc"));
-            var elapsed = DateTime.UtcNow - requestStartTime;
-            _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
-            Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+
+                var requestStartTime = DateTime.UtcNow;
+                var httpClient = new HttpClient(new WaitInfinitelyHandler())
+                {
+                    Timeout = TimeSpan.FromSeconds(1)
+                };
+                await Assert.ThrowsAsync<TaskCanceledException>(() => httpClient.GetAsync("http://abc"));
+                var elapsed = DateTime.UtcNow - requestStartTime;
+                _outputHelper.WriteLine($"Request elapsed time: {elapsed.Ticks}");
+                Assert.True(elapsed >= TimeSpan.FromSeconds(1));
+            }
         }
 
         private class WaitInfinitelyHandler : DelegatingHandler

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests
@@ -29,6 +30,28 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         public void AllowSingleEndpointInTransientModeFact()
         {
             new ServiceManagerOptions { ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray() }.ValidateOptions();
+        }
+
+        [Fact]
+        public void OptionsBindingFact()
+        {
+            var configuration = new ConfigurationBuilder()
+                               .AddInMemoryCollection()
+                               .Build();
+            var connectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+            configuration["ApplicationName"] = "applicationName";
+            configuration["ConnectionCount"] = "3";
+            configuration["ConnectionString"] = connectionString;
+            configuration["ServiceTransportType"] = "Persistent";
+            configuration["HttpClientTimeout"] = "00:00:10";
+
+            var options = new ServiceManagerOptions();
+            configuration.Bind(options);
+            Assert.Equal("applicationName", options.ApplicationName);
+            Assert.Equal(3, options.ConnectionCount);
+            Assert.Equal(connectionString, options.ConnectionString);
+            Assert.Equal(ServiceTransportType.Persistent, options.ServiceTransportType);
+            Assert.Equal(TimeSpan.FromSeconds(10), options.HttpClientTimeout);
         }
     }
 }


### PR DESCRIPTION
1. Add `HttpClientTimeout` options
2. Throw `AzureSignalRException` instead of  `AzureSignalRInaccessibleEndpointException` when `HttpRequestException` happens. `HttpRequestException` is a general exception thrown by `HttpClient` or `HttpMessageHandler` and it's not necessarily due to DNS error or incorrect endpoint. Telling the customer to check DNS or endpoint sometimes is misleading.