### PR TITLE
Timeout has been increased to 100 seconds

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AadAccessKey.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AadAccessKey.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.SignalR
 
         internal const int GetTokenMaxRetryTimes = 3;
 
-        internal static readonly TimeSpan AuthorizeTimeout = TimeSpan.FromSeconds(10);
+        internal static readonly TimeSpan AuthorizeTimeout = TimeSpan.FromSeconds(100);
 
         private const string DefaultScope = "https://signalr.azure.com/.default";
 


### PR DESCRIPTION
Current timeout of 10 seconds is insufficient for generating a token and calling the AccessKey endpoint with ServerEndpoint proxy. Running it through Visual Studio, a task cancellation error occurs consistently. To resolve this issue, the timeout has been increased to 100 seconds, which is the default HTTP timeout.

### Summary of the changes (Less than 80 chars)
 - AuthorizeTimeout has been increased to 100 seconds

Fixes #1802
