### PR TITLE
Partial support client results in sharding mode.

### DIFF
--- a/specs/ClientInvocation.md
+++ b/specs/ClientInvocation.md
@@ -62,9 +62,11 @@ Basically the process is similar and the major different is that service underst
 
 ### Transient Mode(TODO)
 
+## Limitations
+
 > NOTES
 > 
 > * Service cached pending invocations for at most __10 minutes__ for memory concerns and will notify server when timeout.
 > * Serverless is __NOT__ supporeted in the first stage.
 > * ASPNET SignalR is __NOT__ supported.
-> * Sharding is __NOT__ supported. Please use [Geo-Replication](https://learn.microsoft.com/azure/azure-signalr/howto-enable-geo-replication) for combined client invocation and large scale scenarios.
+> * Sharding is __NOT__ fully supported yet. Please use [Geo-Replication](https://learn.microsoft.com/azure/azure-signalr/howto-enable-geo-replication) for combined client invocation and large scale scenarios. Also see [this](https://github.com/Azure/azure-signalr/pull/1828) for planning.

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -427,7 +427,7 @@ namespace Microsoft.Azure.SignalR
 
         private IEnumerable<ServiceEndpoint> SingleOrNotSupported(IEnumerable<ServiceEndpoint> endpoints, ServiceMessage message)
         {
-            if (endpoints.Count() == 1)
+            if (endpoints.ToList().Count == 1)
             {
                 return endpoints;
             }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -230,6 +230,15 @@ namespace Microsoft.Azure.SignalR
                 case CloseConnectionMessage closeConnectionMessage:
                     return _router.GetEndpointsForConnection(closeConnectionMessage.ConnectionId, endpoints);
 
+                case ClientInvocationMessage clientInvocationMessage:
+                    return SingleOrNotSupported(_router.GetEndpointsForConnection(clientInvocationMessage.ConnectionId, endpoints), clientInvocationMessage);
+
+                case ServiceMappingMessage serviceMappingMessage:
+                    return SingleOrNotSupported(_router.GetEndpointsForConnection(serviceMappingMessage.ConnectionId, endpoints), serviceMappingMessage);
+
+                case ServiceCompletionMessage serviceCompletionMessage:
+                    return SingleOrNotSupported(_router.GetEndpointsForConnection(serviceCompletionMessage.ConnectionId, endpoints), serviceCompletionMessage);
+
                 default:
                     throw new NotSupportedException(message.GetType().Name);
             }
@@ -414,6 +423,15 @@ namespace Microsoft.Azure.SignalR
                 await Task.Delay(Constants.Periods.DefaultCloseDelayInterval);
             }
             Log.TimeoutWaitingClientsDisconnect(_logger, endpoint.ToString(), (int)_scaleTimeout.TotalSeconds);
+        }
+
+        private IEnumerable<ServiceEndpoint> SingleOrNotSupported(IEnumerable<ServiceEndpoint> endpoints, ServiceMessage message)
+        {
+            if (endpoints.Count() <= 1)
+            {
+                return endpoints;
+            }
+            throw new NotSupportedException(message.GetType().Name);
         }
 
         internal static class Log

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -427,9 +427,14 @@ namespace Microsoft.Azure.SignalR
 
         private IEnumerable<ServiceEndpoint> SingleOrNotSupported(IEnumerable<ServiceEndpoint> endpoints, ServiceMessage message)
         {
-            if (endpoints.ToList().Count == 1)
+            var endpointCnt = endpoints.ToList().Count;
+            if (endpointCnt == 1)
             {
                 return endpoints;
+            }
+            if (endpointCnt == 0)
+            {
+                throw new ArgumentException("Client invocation is not sent because no endpoint is returned from the endpoint router.");
             }
             throw new NotSupportedException("Client invocation to wait for multiple endpoints' results is not supported yet.");
         }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.SignalR
             {
                 return endpoints;
             }
-            throw new NotSupportedException(message.GetType().Name);
+            throw new NotSupportedException("Client invocation to wait for multiple endpoints' results is not supported yet.");
         }
 
         internal static class Log

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -427,7 +427,7 @@ namespace Microsoft.Azure.SignalR
 
         private IEnumerable<ServiceEndpoint> SingleOrNotSupported(IEnumerable<ServiceEndpoint> endpoints, ServiceMessage message)
         {
-            if (endpoints.Count() <= 1)
+            if (endpoints.Count() == 1)
             {
                 return endpoints;
             }


### PR DESCRIPTION
Make client invocation supported in sharding mode. Currently CI manager rely on single response from service side which make it not work in multiple endpoints scenarios that server side has to manage all the endpoints results before completion. 

- [X] Support CI ServiceMessages in routing. Limitation: server should have knowledge of client connection and endpoint mapping so custom router has to return __single__ endpoint always and won't get noise by irrelevant endpoints. Otherwise, throw exception before fully support.
- [ ] Make CI manager supports multiple endpoints results management.
