### PR TITLE
Support different EndpointRoutingMode

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointRoutingMode.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/EndpointRoutingMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR
+{
+    public enum EndpointRoutingMode
+    {
+        /// <summary>
+        ///  Choose endpoint randomly by weight. 
+        ///  The weight is defined as (the remaining connection quota / the connection capacity).
+        ///  This is the default mode.
+        /// </summary>
+        Weighted,
+        
+        /// <summary>
+        /// Choose the endpoint with least connection count.
+        /// This mode distributes connections evenly among endpoints.
+        /// </summary>
+        LeastConnection,
+        
+        /// <summary>
+        /// Choose the endpoint randomly
+        /// </summary>
+        Random,
+    }
+}

--- a/src/Microsoft.Azure.SignalR/EndpointRouters/EndpointRouterDecorator.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointRouters/EndpointRouterDecorator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.SignalR
 
         public EndpointRouterDecorator(IEndpointRouter router = null)
         {
-            _inner = router ?? new DefaultEndpointRouter();
+            _inner = router ?? new DefaultEndpointRouter(null);
         }
 
         public virtual ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -121,5 +121,11 @@ namespace Microsoft.Azure.SignalR
         /// Gets or sets a function which accepts <see cref="HttpContext"/> and returns a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the service should use to receive HTTP requests.
         /// </summary>
         public Func<HttpContext, HttpTransportType> TransportTypeDetector { get; set; } = null;
+        
+        /// <summary>
+        /// Gets or sets the default endpoint routing mode when using multiple endpoints.
+        /// <see cref="EndpointRoutingMode.Weighted"/> by default.
+        /// </summary>
+        public EndpointRoutingMode EndpointRoutingMode { get; set; } = EndpointRoutingMode.Weighted;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 var endpoint = new ServiceEndpoint(ConnectionString1);
                 var sem = new TestServiceEndpointManager(endpoint);
-                var router = new DefaultEndpointRouter();
+                var router = new DefaultEndpointRouter(null);
 
                 var container = new TestMultiEndpointServiceConnectionContainer("hub",
                     e => new TestServiceConnectionContainer(new List<IServiceConnection> {


### PR DESCRIPTION
### Summary of the changes 
 - Add different endpoint routing mode: `Weighted`, `LeastConnection`, `Random`
 - For weighted mode: change the weight definition from _remaining connection quota_ to ( _remaining connection quota / connection capacity)_