### PR TITLE
Support client results in sharding mode

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
@@ -15,11 +15,12 @@ namespace Microsoft.Azure.SignalR
         /// Add a invocation which is directly called by current server
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <param name="hub"></param>
         /// <param name="connectionId"></param>
         /// <param name="invocationId"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<T> AddInvocation<T>(string connectionId, string invocationId, CancellationToken cancellationToken);
+        Task<T> AddInvocation<T>(string hub, string connectionId, string invocationId, CancellationToken cancellationToken);
 
         void AddServiceMapping(ServiceMappingMessage serviceMappingMessage);
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -231,13 +231,13 @@ namespace Microsoft.Azure.SignalR
                     return _router.GetEndpointsForConnection(closeConnectionMessage.ConnectionId, endpoints);
 
                 case ClientInvocationMessage clientInvocationMessage:
-                    return SingleOrNotSupported(_router.GetEndpointsForConnection(clientInvocationMessage.ConnectionId, endpoints), clientInvocationMessage);
+                    return _router.GetEndpointsForBroadcast(endpoints);
 
                 case ServiceMappingMessage serviceMappingMessage:
-                    return SingleOrNotSupported(_router.GetEndpointsForConnection(serviceMappingMessage.ConnectionId, endpoints), serviceMappingMessage);
+                    return _router.GetEndpointsForBroadcast(endpoints);
 
                 case ServiceCompletionMessage serviceCompletionMessage:
-                    return SingleOrNotSupported(_router.GetEndpointsForConnection(serviceCompletionMessage.ConnectionId, endpoints), serviceCompletionMessage);
+                    return _router.GetEndpointsForBroadcast(endpoints);
 
                 default:
                     throw new NotSupportedException(message.GetType().Name);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.SignalR
                     return _router.GetEndpointsForConnection(closeConnectionMessage.ConnectionId, endpoints);
 
                 case ClientInvocationMessage clientInvocationMessage:
-                    return _router.GetEndpointsForBroadcast(endpoints);
+                    return _router.GetEndpointsForConnection(clientInvocationMessage.ConnectionId, endpoints);
 
                 case ServiceMappingMessage serviceMappingMessage:
                     return _router.GetEndpointsForBroadcast(endpoints);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -233,11 +233,10 @@ namespace Microsoft.Azure.SignalR
                 case ClientInvocationMessage clientInvocationMessage:
                     return _router.GetEndpointsForConnection(clientInvocationMessage.ConnectionId, endpoints);
 
-                case ServiceMappingMessage serviceMappingMessage:
-                    return _router.GetEndpointsForBroadcast(endpoints);
-
                 case ServiceCompletionMessage serviceCompletionMessage:
-                    return _router.GetEndpointsForBroadcast(endpoints);
+                    return _router.GetEndpointsForConnection(serviceCompletionMessage.ConnectionId, endpoints);
+
+                // ServiceMappingMessage should never be sent to the service
 
                 default:
                     throw new NotSupportedException(message.GetType().Name);

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -12,8 +12,6 @@ using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Azure.SignalR
 {
     internal sealed class CallerClientResultsManager : ICallerClientResultsManager, IInvocationBinder
@@ -32,7 +30,6 @@ namespace Microsoft.Azure.SignalR
             _hubProtocolResolver = hubProtocolResolver ?? throw new ArgumentNullException(nameof(hubProtocolResolver));
             _serviceEndpointManager = serviceEndpointManager ?? throw new ArgumentNullException(nameof(serviceEndpointManager));
             _endpointRouter = endpointRouter ?? throw new ArgumentNullException(nameof(endpointRouter));
-            
         }
 
         public string GenerateInvocationId(string connectionId)
@@ -68,7 +65,7 @@ namespace Microsoft.Azure.SignalR
                         var tcs = (TaskCompletionSourceWithCancellation<T>)state;
                         if (completionMessage.HasResult)
                         {
-                            tcs.TrySetResult((T)completionMessage.Result!);
+                            tcs.TrySetResult((T)completionMessage.Result);
                         }
                         else
                         {
@@ -122,7 +119,7 @@ namespace Microsoft.Azure.SignalR
 
         public bool TryCompleteResult(string connectionId, CompletionMessage message)
         {
-            if (_pendingInvocations.TryGetValue(message.InvocationId!, out var item))
+            if (_pendingInvocations.TryGetValue(message.InvocationId, out var item))
             {
                 if (item.ConnectionId != connectionId)
                 {
@@ -139,7 +136,7 @@ namespace Microsoft.Azure.SignalR
                     // if false the connection disconnected right after the above TryGetValue
                     // or someone else completed the invocation (likely a bad client)
                     // we'll ignore both cases
-                    if (_pendingInvocations.TryRemove(message.InvocationId!, out _))
+                    if (_pendingInvocations.TryRemove(message.InvocationId, out _))
                     {
                         item.Complete(item.Tcs, message);
                         return true;
@@ -203,7 +200,7 @@ namespace Microsoft.Azure.SignalR
                 type = item.Type;
                 return true;
             }
-            type = null!;
+            type = null;
             return false;
         }
 
@@ -220,7 +217,7 @@ namespace Microsoft.Azure.SignalR
 
         private record PendingInvocation(Type Type, string ConnectionId, object Tcs, int AckId, Task ackTask, Action<object, CompletionMessage> Complete)
         {
-            public string? RouterInstanceId { get; set; }
+            public string RouterInstanceId { get; set; }
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -43,11 +43,8 @@ namespace Microsoft.Azure.SignalR
                 cancellationToken,
                 () => TryCompleteResult(connectionId, CompletionMessage.WithError(invocationId, "Canceled")));
 
-            var ackNumber = 1;
-            if (_serviceEndpointManager != null && _endpointRouter != null) {
-                var serviceEndpoints = _serviceEndpointManager.GetEndpoints(hub);
-                ackNumber = _endpointRouter.GetEndpointsForConnection(connectionId, serviceEndpoints).Count();
-            }
+            var serviceEndpoints = _serviceEndpointManager.GetEndpoints(hub);
+            var ackNumber = _endpointRouter.GetEndpointsForConnection(connectionId, serviceEndpoints).Count();
 
             var multiAck = _ackHandler.CreateMultiAck(out var ackId);
 

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -23,17 +23,15 @@ namespace Microsoft.Azure.SignalR
         private long _lastInvocationId = 0;
 
         private readonly IHubProtocolResolver _hubProtocolResolver;
-        private IEndpointRouter? _endpointRouter { get; }
-        private IServiceEndpointManager? _serviceEndpointManager { get; }
+        private IEndpointRouter _endpointRouter { get; }
+        private IServiceEndpointManager _serviceEndpointManager { get; }
         private readonly AckHandler _ackHandler = new();
 
-        public CallerClientResultsManager(IHubProtocolResolver hubProtocolResolver, IServiceEndpointManager? serviceEndpointManager = null, IEndpointRouter? endpointRouter = null)
+        public CallerClientResultsManager(IHubProtocolResolver hubProtocolResolver, IServiceEndpointManager serviceEndpointManager, IEndpointRouter endpointRouter)
         {
             _hubProtocolResolver = hubProtocolResolver ?? throw new ArgumentNullException(nameof(hubProtocolResolver));
-            if (serviceEndpointManager == null && endpointRouter != null) throw new ArgumentNullException(nameof(serviceEndpointManager));
-            if (serviceEndpointManager != null && endpointRouter == null) throw new ArgumentNullException(nameof(endpointRouter));
-            _serviceEndpointManager = serviceEndpointManager;
-            _endpointRouter = endpointRouter;
+            _serviceEndpointManager = serviceEndpointManager ?? throw new ArgumentNullException(nameof(serviceEndpointManager));
+            _endpointRouter = endpointRouter ?? throw new ArgumentNullException(nameof(endpointRouter));
             
         }
 
@@ -134,7 +132,7 @@ namespace Microsoft.Azure.SignalR
                 
                 // Considering multiple endpoints, wait until 
                 // 1. Received a non-error CompletionMessage
-                // or 2. Receved messages from all endpoints
+                // or 2. Received messages from all endpoints
                 _ackHandler.TriggerAck(item.AckId);
                 if (message.HasResult || item.ackTask.IsCompletedSuccessfully)
                 {

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/ClientInvocationManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/ClientInvocationManager.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.AspNetCore.SignalR;
 
+#nullable enable
+
 namespace Microsoft.Azure.SignalR
 {
     internal sealed class ClientInvocationManager : IClientInvocationManager
@@ -11,9 +13,15 @@ namespace Microsoft.Azure.SignalR
         public ICallerClientResultsManager Caller { get; }
         public IRoutedClientResultsManager Router { get; }
 
-        public ClientInvocationManager(IHubProtocolResolver hubProtocolResolver)
+        public ClientInvocationManager(IHubProtocolResolver hubProtocolResolver, IServiceEndpointManager? serviceEndpointManager = null, IEndpointRouter? endpointRouter = null)
         {
-            Caller = new CallerClientResultsManager(hubProtocolResolver ?? throw new ArgumentNullException(nameof(hubProtocolResolver)));
+            if (serviceEndpointManager == null && endpointRouter != null) throw new ArgumentNullException(nameof(serviceEndpointManager));
+            if (serviceEndpointManager != null && endpointRouter == null) throw new ArgumentNullException(nameof(endpointRouter));
+            Caller = new CallerClientResultsManager(
+                hubProtocolResolver ?? throw new ArgumentNullException(nameof(hubProtocolResolver)),
+                serviceEndpointManager,
+                endpointRouter
+            );
             Router = new RoutedClientResultsManager();
         }
 

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/ClientInvocationManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/ClientInvocationManager.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Azure.SignalR
         public ICallerClientResultsManager Caller { get; }
         public IRoutedClientResultsManager Router { get; }
 
-        public ClientInvocationManager(IHubProtocolResolver hubProtocolResolver, IServiceEndpointManager? serviceEndpointManager = null, IEndpointRouter? endpointRouter = null)
+        public ClientInvocationManager(IHubProtocolResolver hubProtocolResolver, IServiceEndpointManager serviceEndpointManager, IEndpointRouter endpointRouter)
         {
-            if (serviceEndpointManager == null && endpointRouter != null) throw new ArgumentNullException(nameof(serviceEndpointManager));
-            if (serviceEndpointManager != null && endpointRouter == null) throw new ArgumentNullException(nameof(endpointRouter));
             Caller = new CallerClientResultsManager(
                 hubProtocolResolver ?? throw new ArgumentNullException(nameof(hubProtocolResolver)),
-                serviceEndpointManager,
-                endpointRouter
+                serviceEndpointManager ?? throw new ArgumentNullException(nameof(serviceEndpointManager)),
+                endpointRouter ?? throw new ArgumentNullException(nameof(endpointRouter))
             );
             Router = new RoutedClientResultsManager();
         }

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // If a custom service event handler is added, do not add the default handler.
             builder.Services.TryAddSingleton<IServiceEventHandler, DefaultServiceEventHandler>();
 
-            // IEndpointRouter is required to build IClientInvocationManager.
+            // IEndpointRouter and IAccessKeySynchronizer is required to build ClientInvocationManager.
             builder.Services
 #if NET7_0_OR_GREATER
                 .AddSingleton<IClientInvocationManager, ClientInvocationManager>();

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -88,11 +88,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<IClientConnectionFactory, ClientConnectionFactory>()
                 .AddSingleton<IHostedService, HeartBeat>()
                 .AddSingleton<IAccessKeySynchronizer, AccessKeySynchronizer>()
-#if NET7_0_OR_GREATER
-                .AddSingleton<IClientInvocationManager, ClientInvocationManager>()
-#else
-                .AddSingleton<IClientInvocationManager, DummyClientInvocationManager>()
-#endif
                 .AddSingleton(typeof(NegotiateHandler<>));
 
             // If a custom router is added, do not add the default router
@@ -101,6 +96,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // If a custom service event handler is added, do not add the default handler.
             builder.Services.TryAddSingleton<IServiceEventHandler, DefaultServiceEventHandler>();
+
+            // IEndpointRouter is required to build IClientInvocationManager.
+            builder.Services
+#if NET7_0_OR_GREATER
+                .AddSingleton<IClientInvocationManager, ClientInvocationManager>();
+#else
+                .AddSingleton<IClientInvocationManager, DummyClientInvocationManager>();
+#endif
 
 #if !NETSTANDARD2_0
             builder.Services.TryAddSingleton<AzureSignalRHostedService>();

--- a/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR
@@ -35,16 +36,10 @@ namespace Microsoft.Azure.SignalR
 
         private static ClientInvocationManager GetTestClientInvocationManager(int endpointCount = 1)
         {
-            if (endpointCount < 2)
-            {
-                return new ClientInvocationManager(HubProtocolResolver);
-            }
-
             var services = new ServiceCollection();
-
             var endpoints = Enumerable.Range(0, endpointCount)
-                            .Select(i => new ServiceEndpoint($"Endpoint=https://test{i}connectionstring;AccessKey=1"))
-                            .ToArray();
+                .Select(i => new ServiceEndpoint($"Endpoint=https://test{i}connectionstring;AccessKey=1"))
+                .ToArray();
 
             var config = new ConfigurationBuilder().Build();
 
@@ -55,8 +50,9 @@ namespace Microsoft.Azure.SignalR
                 .BuildServiceProvider();
 
             var manager = serviceProvider.GetService<IServiceEndpointManager>();
+            var endpointRouter = serviceProvider.GetService<IEndpointRouter>();
 
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver, manager, new DefaultEndpointRouter());
+            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver, manager, endpointRouter);
             return clientInvocationManager;
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Azure.SignalR
@@ -26,8 +27,11 @@ namespace Microsoft.Azure.SignalR
                         new MessagePackHubProtocol() 
                     },
                     NullLogger<DefaultHubProtocolResolver>.Instance);
-
-            Caller = new CallerClientResultsManager(hubProtocolResolver);
+            var loggerFactory = new NullLoggerFactory();
+            var accessKeySynchronizer = new AccessKeySynchronizer(loggerFactory);
+            var optionsMonitor = new TestOptionsMonitor();
+            var serviceEndpointManager = new ServiceEndpointManager(accessKeySynchronizer, optionsMonitor, loggerFactory);
+            Caller = new CallerClientResultsManager(hubProtocolResolver, serviceEndpointManager, new DefaultEndpointRouter());
             Router = new RoutedClientResultsManager();
         }
 

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests;
@@ -28,9 +23,11 @@ namespace Microsoft.Azure.SignalR
                     },
                     NullLogger<DefaultHubProtocolResolver>.Instance);
             var loggerFactory = new NullLoggerFactory();
-            var accessKeySynchronizer = new AccessKeySynchronizer(loggerFactory);
-            var optionsMonitor = new TestOptionsMonitor();
-            var serviceEndpointManager = new ServiceEndpointManager(accessKeySynchronizer, optionsMonitor, loggerFactory);
+            var serviceEndpointManager = new ServiceEndpointManager(
+                new AccessKeySynchronizer(loggerFactory),
+                new TestOptionsMonitor(), 
+                loggerFactory
+            );
             Caller = new CallerClientResultsManager(hubProtocolResolver, serviceEndpointManager, new DefaultEndpointRouter());
             Router = new RoutedClientResultsManager();
         }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -59,11 +59,8 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             ConnectionFactory = connectionFactoryCallback?.Invoke(ConnectionFactoryCallbackAsync) ?? new TestConnectionFactory(ConnectionFactoryCallbackAsync);
             ClientConnectionManager = new ClientConnectionManager();
-            ClientInvocationManager = new ClientInvocationManager(new DefaultHubProtocolResolver(new IHubProtocol[]
-                {
-                    new JsonHubProtocol(),
-                    new MessagePackHubProtocol(),
-                }, NullLogger<DefaultHubProtocolResolver>.Instance));
+            
+            ClientInvocationManager = new DefaultClientInvocationManager();
             _clientPipeOptions = clientPipeOptions;
             ConnectionDelegateCallback = callback ?? OnConnectionAsync;
 

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
@@ -2,20 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.AspNetCore.SignalR;
-
 
 namespace Microsoft.Azure.SignalR.Tests
 {

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.SignalR;
+
+
+namespace Microsoft.Azure.SignalR.Tests
+{
+    internal class TestOptionsMonitor : IOptionsMonitor<ServiceOptions>
+    {
+        private readonly IOptionsMonitor<ServiceOptions> _monitor;
+
+        public TestOptionsMonitor()
+        {
+            var config = new ConfigurationBuilder().Build();
+
+            var services = new ServiceCollection();
+            var endpoints = new List<ServiceEndpoint>() { new ServiceEndpoint($"Endpoint=https://testconnectionstring;AccessKey=1") };
+            var serviceProvider = services.AddLogging()
+                .AddSignalR().AddAzureSignalR(o => o.Endpoints = endpoints.ToArray())
+                .Services
+                .AddSingleton<IConfiguration>(config)
+                .BuildServiceProvider();
+            _monitor = serviceProvider.GetRequiredService<IOptionsMonitor<ServiceOptions>>();
+        }
+
+        public ServiceOptions CurrentValue => _monitor.CurrentValue;
+
+        public ServiceOptions Get(string name) => _monitor.Get(name);
+
+        public IDisposable OnChange(Action<ServiceOptions, string> listener) => _monitor.OnChange(listener);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
             var blazorDetector = new DefaultBlazorDetector();
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
             var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
                 new ClientConnectionManager(), HubProtocolResolver, Logger, Marker, _globalHubOptions, _localHubOptions, blazorDetector, new DefaultServerNameProvider(), clientInvocationManager);
 
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.SignalR.Tests
         {
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
             var blazorDetector = new DefaultBlazorDetector();
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
             var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(
                 serviceConnectionManager,
                 new ClientConnectionManager(),
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
             var serviceConnectionManager = new ServiceConnectionManager<TestHub>();
             serviceConnectionManager.SetServiceConnection(proxy.ServiceConnectionContainer);
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
 
             var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
                 proxy.ClientConnectionManager, HubProtocolResolver, Logger, Marker, _globalHubOptions, _localHubOptions, blazorDetector, new DefaultServerNameProvider(), clientInvocationManager);
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.SignalR.Tests
             IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { "json", "messagepack", MockProtocol, "json" } });
             IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { "json", "messagepack", MockProtocol } });
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
             var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
                 new ClientConnectionManager(), protocolResolver, Logger, Marker, globalHubOptions, localHubOptions, blazorDetector, new DefaultServerNameProvider(), clientInvocationManager);
 
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.SignalR.Tests
             IOptions<HubOptions> globalHubOptions = Options.Create(new HubOptions() { SupportedProtocols = new List<string>() { MockProtocol } });
             IOptions<HubOptions<TestHub>> localHubOptions = Options.Create(new HubOptions<TestHub>() { SupportedProtocols = new List<string>() { MockProtocol } });
 
-            var clientInvocationManager = new ClientInvocationManager(protocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
 
             return new ServiceLifetimeManager<TestHub>(
                 serviceConnectionManager,
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.SignalR.Tests
             ServiceConnectionBase serviceConnection, 
             IServiceConnectionManager<TestHub> serviceConnectionManager, 
             ClientConnectionManager clientConnectionManager, 
-            ClientInvocationManager clientInvocationManager = null,
+            IClientInvocationManager clientInvocationManager = null,
             ClientConnectionContext clientConnectionContext = null,
             string protocol = "json"
             )
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
             // Create ServiceLifetimeManager
             return new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
-                clientConnectionManager, HubProtocolResolver, Logger, Marker, _globalHubOptions, _localHubOptions, null, new DefaultServerNameProvider(), clientInvocationManager ?? new ClientInvocationManager(HubProtocolResolver));
+                clientConnectionManager, HubProtocolResolver, Logger, Marker, _globalHubOptions, _localHubOptions, null, new DefaultServerNameProvider(), clientInvocationManager ?? new DefaultClientInvocationManager());
         }
 
         private static ClientConnectionContext GetClientConnectionContextWithConnection(string connectionId = null, string protocol = null)
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var serviceConnection = new TestServiceConnection();
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
 
-            var clientInvocationManager = new ClientInvocationManager(HubProtocolResolver);
+            var clientInvocationManager = new DefaultClientInvocationManager();
             var clientConnectionContext = GetClientConnectionContextWithConnection(TestConnectionIds[1], protocol);
 
             var serviceLifetimeManager = GetTestClientInvocationServiceLifetimeManager(serviceConnection, serviceConnectionManager, new ClientConnectionManager(), clientInvocationManager, clientConnectionContext, protocol);
@@ -380,9 +380,9 @@ namespace Microsoft.Azure.SignalR.Tests
             var clientConnectionManager = new ClientConnectionManager();
 
             var serviceConnectionManager = new TestServiceConnectionManager<TestHub>();
-            var clientInvocationManagers = new List<ClientInvocationManager>() {
-                new ClientInvocationManager(HubProtocolResolver),
-                new ClientInvocationManager(HubProtocolResolver)
+            var clientInvocationManagers = new List<IClientInvocationManager>() {
+                new DefaultClientInvocationManager(),
+                new DefaultClientInvocationManager()
             };
 
             var serviceLifetimeManagers = new List<ServiceLifetimeManager<TestHub>>() {


### PR DESCRIPTION
Support client result (also called "client invocation") in sharding mode (multiple endpoints)

Ref: Partial Support PR https://github.com/Azure/azure-signalr/pull/1828