### PR TITLE
Update serverless protocol project for security

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,6 @@
     <SignedPackageFile Include="$(PublishDir)Microsoft.Identity.Client.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.Identity.Client.Extensions.Msal.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
     <SignedPackageFile Include="$(PublishDir)Microsoft.IdentityModel.Clients.ActiveDirectory.dll" Certificate="$(AssemblySigningCertName)" Visible="false"  />
-    <SignedPackageFile Include="$(PublishDir)Microsoft.IdentityModel.JsonWebTokens.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.IdentityModel.Logging.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Microsoft.IdentityModel.Protocols.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
@@ -77,7 +76,6 @@
     <SignedPackageFile Include="$(PublishDir)Newtonsoft.Json.Bson.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)Newtonsoft.Json.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.IO.Pipelines.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
-    <SignedPackageFile Include="$(PublishDir)System.IdentityModel.Tokens.Jwt.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Text.Encodings.Web.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Memory.Data.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />
     <SignedPackageFile Include="$(PublishDir)System.Net.WebSockets.WebSocketProtocol.dll" Certificate="$(AssemblySigningCertName)" Visible="false" />

--- a/src/Microsoft.Azure.SignalR.Serverless.Protocols/Directory.Build.props
+++ b/src/Microsoft.Azure.SignalR.Serverless.Protocols/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+    <!-- This file is used to exclude the impact of ..\Directory.Build.props -->
+	<Import Project="..\..\Directory.Build.props" />
+</Project>

--- a/version.props
+++ b/version.props
@@ -3,7 +3,7 @@
     <!-- major.minor.patch[.build] -->
     <VersionPrefix>1.25.0</VersionPrefix>
     <VersionPrefix Condition="'$(MSBuildProjectName)' == 'Microsoft.Azure.SignalR.Emulator'">1.1.0</VersionPrefix>
-    <VersionPrefix Condition="'$(MSBuildProjectName)' == 'Microsoft.Azure.SignalR.Serverless.Protocols'">1.9.0</VersionPrefix>
+    <VersionPrefix Condition="'$(MSBuildProjectName)' == 'Microsoft.Azure.SignalR.Serverless.Protocols'">1.10.0</VersionPrefix>
     <!-- Alphanumberic(+hyphen) string for PackageVersion and InformationalVersion-->
     <VersionSuffix>preview1</VersionSuffix>
     <!-- Version = VersionPrefix-VersionSuffix, for PackageVersion and AssemblyVersion -->


### PR DESCRIPTION
Previously the serverless project depended on some unused dependency because of the global `src\Directory.Build.props`.