### PR TITLE
Update pipeline: Don't test restore package if SDK core is not built

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -130,6 +130,21 @@ extends:
                     includesymbols: true
                     buildProperties: $(MSBuildProperties);SymbolPackageFormat=snupkg
                     verbosityPack: Normal
+                - task: CmdLine@2
+                  displayName: Clean Local Feed
+                  inputs:
+                    script: if exist $(LocalFeed)\ del /s /q $(LocalFeed)
+                - task: NuGetCommand@2
+                  displayName: Initialize Local Feed
+                  inputs:
+                    command: custom
+                    arguments: init artifacts $(LocalFeed)
+                - task: MSBuild@1
+                  displayName: Test Restoring Packages
+                  inputs:
+                    solution: build/package-test.3.proj
+                    msbuildArchitecture: x64
+                    msbuildArguments: /p:$(MSBuildProperties) /p:UseLocalFeed=true /p:LocalFeed=$(LocalFeed) /t:Restore
               - ${{ if or( eq(parameters.isFinalBuild, false),  eq(parameters.releaseEmulator, true)) }}:
                 - task: DotNetCoreCLI@2
                   displayName: dotnet pack emulator when only dev or release emulator
@@ -150,21 +165,6 @@ extends:
                     includesymbols: true
                     buildProperties: $(MSBuildProperties);SymbolPackageFormat=snupkg
                     verbosityPack: Normal
-              - task: CmdLine@2
-                displayName: Clean Local Feed
-                inputs:
-                  script: if exist $(LocalFeed)\ del /s /q $(LocalFeed)
-              - task: NuGetCommand@2
-                displayName: Initialize Local Feed
-                inputs:
-                  command: custom
-                  arguments: init artifacts $(LocalFeed)
-              - task: MSBuild@1
-                displayName: Test Restoring Packages
-                inputs:
-                  solution: build/package-test.3.proj
-                  msbuildArchitecture: x64
-                  msbuildArguments: /p:$(MSBuildProperties) /p:UseLocalFeed=true /p:LocalFeed=$(LocalFeed) /t:Restore
               - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
                 displayName: "Manifest Generator "
                 inputs:


### PR DESCRIPTION
No need to test it. Otherwise, the test is failed.