### PR TITLE
Rebrand AAD to Microsoft Entra

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/EndpointProvider/ServiceEndpointProvider.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Azure.SignalR.AspNet
 
         public IAccessTokenProvider GetServerAccessTokenProvider(string hubName, string serverId)
         {
-            if (_accessKey is AadAccessKey aadAccessKey)
+            if (_accessKey is AccessKeyForMicrosoftEntra key)
             {
-                return new AadTokenProvider(aadAccessKey);
+                return new MicrosoftEntraTokenProvider(key);
             }
             else if (_accessKey is not null)
             {

--- a/src/Microsoft.Azure.SignalR.Common/Auth/MicrosoftEntraTokenProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Auth/MicrosoftEntraTokenProvider.cs
@@ -6,15 +6,15 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR
 {
-    internal class AadTokenProvider : IAccessTokenProvider
+    internal class MicrosoftEntraTokenProvider : IAccessTokenProvider
     {
-        private readonly AadAccessKey _accessKey;
+        private readonly AccessKeyForMicrosoftEntra _accessKey;
 
-        public AadTokenProvider(AadAccessKey accessKey)
+        public MicrosoftEntraTokenProvider(AccessKeyForMicrosoftEntra accessKey)
         {
             _accessKey = accessKey ?? throw new ArgumentNullException(nameof(accessKey));
         }
 
-        public Task<string> ProvideAsync() => _accessKey.GenerateAadTokenAsync();
+        public Task<string> ProvideAsync() => _accessKey.GetMicrosoftEntraTokenAsync();
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKeySynchronizer.Log.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/AccessKeySynchronizer.Log.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR
         private static class Log
         {
             private static readonly Action<ILogger, string, Exception> _failedAuthorize =
-                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(2, "FailedAuthorizeAccessKey"), "Failed in authorizing AccessKey for '{endpoint}', will retry in " + AadAccessKey.AuthorizeRetryIntervalInSec + " seconds");
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(2, "FailedAuthorizeAccessKey"), "Failed in authorizing AccessKey for '{endpoint}', will retry in " + SignalR.AccessKeyForMicrosoftEntra.GetAccessKeyRetryIntervalInSec + " seconds");
 
             private static readonly Action<ILogger, string, Exception> _succeedAuthorize =
                 LoggerMessage.Define<string>(LogLevel.Information, new EventId(3, "SucceedAuthorizeAccessKey"), "Succeed in authorizing AccessKey for '{endpoint}'");

--- a/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Endpoints/ServiceEndpoint.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.SignalR
                 {
                     lock (_lock)
                     {
-                        _accessKey ??= new AadAccessKey(_serviceEndpoint, _tokenCredential, ServerEndpoint);
+                        _accessKey ??= new AccessKeyForMicrosoftEntra(_serviceEndpoint, _tokenCredential, ServerEndpoint);
                     }
                 }
                 return _accessKey;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Azure.SignalR
                     TimerAwaitable syncTimer = null;
                     try
                     {
-                        if (HubEndpoint != null && HubEndpoint.AccessKey is AccessKeyForMicrosoftEntra aadKey)
+                        if (HubEndpoint != null && HubEndpoint.AccessKey is AccessKeyForMicrosoftEntra key)
                         {
                             syncTimer = new TimerAwaitable(TimeSpan.Zero, DefaultSyncAzureIdentityInterval);
-                            _ = UpdateAzureIdentityAsync(aadKey, syncTimer);
+                            _ = UpdateAzureIdentityAsync(key, syncTimer);
                         }
                         await ProcessIncomingAsync(connection);
                     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.SignalR
                     TimerAwaitable syncTimer = null;
                     try
                     {
-                        if (HubEndpoint != null && HubEndpoint.AccessKey is AadAccessKey aadKey)
+                        if (HubEndpoint != null && HubEndpoint.AccessKey is AccessKeyForMicrosoftEntra aadKey)
                         {
                             syncTimer = new TimerAwaitable(TimeSpan.Zero, DefaultSyncAzureIdentityInterval);
                             _ = UpdateAzureIdentityAsync(aadKey, syncTimer);
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.SignalR
 
         private Task OnAccessKeyMessageAsync(AccessKeyResponseMessage keyMessage)
         {
-            if (HubEndpoint.AccessKey is AadAccessKey key)
+            if (HubEndpoint.AccessKey is AccessKeyForMicrosoftEntra key)
             {
                 if (string.IsNullOrEmpty(keyMessage.ErrorType))
                 {
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
-        private async Task UpdateAzureIdentityAsync(AadAccessKey key, TimerAwaitable timer)
+        private async Task UpdateAzureIdentityAsync(AccessKeyForMicrosoftEntra key, TimerAwaitable timer)
         {
             using (timer)
             {
@@ -486,12 +486,12 @@ namespace Microsoft.Azure.SignalR
             }
         }
 
-        private async Task SendAccessKeyRequestMessageAsync(AadAccessKey key)
+        private async Task SendAccessKeyRequestMessageAsync(AccessKeyForMicrosoftEntra key)
         {
             try
             {
-                var source = new CancellationTokenSource(AadAccessKey.AuthorizeTimeout);
-                var token = await key.GenerateAadTokenAsync(source.Token);
+                var source = new CancellationTokenSource(AccessKeyForMicrosoftEntra.GetAccessKeyTimeout);
+                var token = await key.GetMicrosoftEntraTokenAsync(source.Token);
                 var message = new AccessKeyRequestMessage(token);
                 await SafeWriteAsync(message);
             }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/ConnectionStringParser.cs
@@ -169,11 +169,11 @@ namespace Microsoft.Azure.SignalR
                 {
                     if (dict.TryGetValue(ClientSecretProperty, out var clientSecret))
                     {
-                        return new AadAccessKey(uri, new ClientSecretCredential(tenantId, clientId, clientSecret), serverEndpointUri);
+                        return new AccessKeyForMicrosoftEntra(uri, new ClientSecretCredential(tenantId, clientId, clientSecret), serverEndpointUri);
                     }
                     else if (dict.TryGetValue(ClientCertProperty, out var clientCertPath))
                     {
-                        return new AadAccessKey(uri, new ClientCertificateCredential(tenantId, clientId, clientCertPath), serverEndpointUri);
+                        return new AccessKeyForMicrosoftEntra(uri, new ClientCertificateCredential(tenantId, clientId, clientCertPath), serverEndpointUri);
                     }
                     else
                     {
@@ -182,12 +182,12 @@ namespace Microsoft.Azure.SignalR
                 }
                 else
                 {
-                    return new AadAccessKey(uri, new ManagedIdentityCredential(clientId), serverEndpointUri);
+                    return new AccessKeyForMicrosoftEntra(uri, new ManagedIdentityCredential(clientId), serverEndpointUri);
                 }
             }
             else
             {
-                return new AadAccessKey(uri, new ManagedIdentityCredential(), serverEndpointUri);
+                return new AccessKeyForMicrosoftEntra(uri, new ManagedIdentityCredential(), serverEndpointUri);
             }
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.SignalR
 
         private static AccessKey BuildAzureAccessKey(Uri uri, Uri serverEndpointUri, Dictionary<string, string> dict)
         {
-            return new AadAccessKey(uri, new DefaultAzureCredential(), serverEndpointUri);
+            return new AccessKeyForMicrosoftEntra(uri, new DefaultAzureCredential(), serverEndpointUri);
         }
 
         private static AccessKey BuildAzureAppAccessKey(Uri uri, Uri serverEndpointUri, Dictionary<string, string> dict)
@@ -217,11 +217,11 @@ namespace Microsoft.Azure.SignalR
 
             if (dict.TryGetValue(ClientSecretProperty, out var clientSecret))
             {
-                return new AadAccessKey(uri, new ClientSecretCredential(tenantId, clientId, clientSecret), serverEndpointUri);
+                return new AccessKeyForMicrosoftEntra(uri, new ClientSecretCredential(tenantId, clientId, clientSecret), serverEndpointUri);
             }
             else if (dict.TryGetValue(ClientCertProperty, out var clientCertPath))
             {
-                return new AadAccessKey(uri, new ClientCertificateCredential(tenantId, clientId, clientCertPath), serverEndpointUri);
+                return new AccessKeyForMicrosoftEntra(uri, new ClientCertificateCredential(tenantId, clientId, clientCertPath), serverEndpointUri);
             }
             throw new ArgumentException(MissingClientSecretProperty, ClientSecretProperty);
         }
@@ -229,8 +229,8 @@ namespace Microsoft.Azure.SignalR
         private static AccessKey BuildAzureMsiAccessKey(Uri uri, Uri serverEndpointUri, Dictionary<string, string> dict)
         {
             return dict.TryGetValue(ClientIdProperty, out var clientId)
-                ? new AadAccessKey(uri, new ManagedIdentityCredential(clientId), serverEndpointUri)
-                : new AadAccessKey(uri, new ManagedIdentityCredential(), serverEndpointUri);
+                ? new AccessKeyForMicrosoftEntra(uri, new ManagedIdentityCredential(clientId), serverEndpointUri)
+                : new AccessKeyForMicrosoftEntra(uri, new ManagedIdentityCredential(), serverEndpointUri);
         }
 
         private static Dictionary<string, string> ToDictionary(string connectionString)

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/RestApiAccessTokenGenerator.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/RestApiAccessTokenGenerator.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Azure.SignalR
 
         public Task<string> Generate(string audience, TimeSpan? lifetime = null)
         {
-            if (_accessKey is AadAccessKey key)
+            if (_accessKey is AccessKeyForMicrosoftEntra key)
             {
-                return key.GenerateAadTokenAsync();
+                return key.GetMicrosoftEntraTokenAsync();
             }
 
             return _accessKey.GenerateAccessTokenAsync(

--- a/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
+++ b/src/Microsoft.Azure.SignalR/EndpointProvider/ServiceEndpointProvider.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Azure.SignalR
 
         public IAccessTokenProvider GetServerAccessTokenProvider(string hubName, string serverId)
         {
-            if (_accessKey is AadAccessKey aadAccessKey)
+            if (_accessKey is AccessKeyForMicrosoftEntra key)
             {
-                return new AadTokenProvider(aadAccessKey);
+                return new MicrosoftEntraTokenProvider(key);
             }
             else if (_accessKey is not null)
             {

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyForMicrosoftEntraTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyForMicrosoftEntraTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 {
     [Collection("Auth")]
-    public class AadAccessKeyTests
+    public class AccessKeyForMicrosoftEntraTests
     {
         private const string SigningKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         [InlineData("https://a.bc:443", "https://a.bc/api/v1/auth/accessKey")]
         public void TestConstructor(string endpoint, string expectedAuthorizeUrl)
         {
-            var key = new AadAccessKey(new Uri(endpoint), new DefaultAzureCredential());
-            Assert.Equal(expectedAuthorizeUrl, key.AuthorizeUrl);
+            var key = new AccessKeyForMicrosoftEntra(new Uri(endpoint), new DefaultAzureCredential());
+            Assert.Equal(expectedAuthorizeUrl, key.GetAccessKeyUrl);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
                 It.IsAny<TokenRequestContext>(),
                 It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Mock GetTokenAsync throws an exception"));
-            var key = new AadAccessKey(new Uri("http://localhost"), mockCredential.Object);
+            var key = new AccessKeyForMicrosoftEntra(new Uri("http://localhost"), mockCredential.Object);
 
             var audience = "http://localhost/chat";
             var claims = Array.Empty<Claim>();
@@ -66,16 +66,16 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
                 It.IsAny<TokenRequestContext>(),
                 It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Mock GetTokenAsync throws an exception"));
-            var key = new AadAccessKey(new Uri("http://localhost"), mockCredential.Object);
-            var isAuthorizedField = typeof(AadAccessKey).GetField("_isAuthorized", BindingFlags.NonPublic | BindingFlags.Instance);
+            var key = new AccessKeyForMicrosoftEntra(new Uri("http://localhost"), mockCredential.Object);
+            var isAuthorizedField = typeof(AccessKeyForMicrosoftEntra).GetField("_isAuthorized", BindingFlags.NonPublic | BindingFlags.Instance);
             isAuthorizedField.SetValue(key, isAuthorized);
             Assert.Equal(isAuthorized, (bool)isAuthorizedField.GetValue(key));
 
             var lastUpdatedTime = DateTime.UtcNow - TimeSpan.FromMinutes(timeElapsed);
-            var lastUpdatedTimeField = typeof(AadAccessKey).GetField("_lastUpdatedTime", BindingFlags.NonPublic | BindingFlags.Instance);
+            var lastUpdatedTimeField = typeof(AccessKeyForMicrosoftEntra).GetField("_lastUpdatedTime", BindingFlags.NonPublic | BindingFlags.Instance);
             lastUpdatedTimeField.SetValue(key, lastUpdatedTime);
 
-            var initializedTcsField = typeof(AadAccessKey).GetField("_initializedTcs", BindingFlags.NonPublic | BindingFlags.Instance);
+            var initializedTcsField = typeof(AccessKeyForMicrosoftEntra).GetField("_initializedTcs", BindingFlags.NonPublic | BindingFlags.Instance);
             var initializedTcs = (TaskCompletionSource<object>)initializedTcsField.GetValue(key);
 
             var source = new CancellationTokenSource(TimeSpan.FromSeconds(1));
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
                 It.IsAny<TokenRequestContext>(),
                 It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new InvalidOperationException("Mock GetTokenAsync throws an exception"));
-            var key = new AadAccessKey(new Uri("http://localhost"), mockCredential.Object);
+            var key = new AccessKeyForMicrosoftEntra(new Uri("http://localhost"), mockCredential.Object);
 
             var audience = "http://localhost/chat";
             var claims = Array.Empty<Claim>();

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using Azure.Identity;
-using Microsoft.IdentityModel.Tokens;
 
 using Xunit;
 
@@ -19,7 +16,9 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
     public class AuthUtilityTests
     {
         private const string Audience = "https://localhost/aspnetclient?hub=testhub";
+
         private const string SigningKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
         private static readonly TimeSpan DefaultLifetime = TimeSpan.FromHours(1);
 
         [Fact]
@@ -42,7 +41,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             public IEnumerator<object[]> GetEnumerator()
             {
                 yield return new object[] { new AccessKey("http://localhost:443", SigningKey), true };
-                var key = new AadAccessKey(new Uri("http://localhost"), new DefaultAzureCredential());
+                var key = new AccessKeyForMicrosoftEntra(new Uri("http://localhost"), new DefaultAzureCredential());
                 key.UpdateAccessKey("foo", SigningKey);
                 yield return new object[] { key, false };
             }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         {
             var r = ConnectionStringParser.Parse(connectionString);
 
-            var key = Assert.IsType<AadAccessKey>(r.AccessKey);
+            var key = Assert.IsType<AccessKeyForMicrosoftEntra>(r.AccessKey);
             Assert.IsType<ClientSecretCredential>(key.TokenCredential);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
             Assert.Null(r.Version);
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             var r = ConnectionStringParser.Parse(connectionString);
 
             Assert.Equal(expectedEndpoint, r.Endpoint.AbsoluteUri.TrimEnd('/'));
-            var key = Assert.IsType<AadAccessKey>(r.AccessKey);
+            var key = Assert.IsType<AccessKeyForMicrosoftEntra>(r.AccessKey);
             Assert.IsType<DefaultAzureCredential>(key.TokenCredential);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
         }
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             var r = ConnectionStringParser.Parse(connectionString);
 
             Assert.Equal(expectedEndpoint, r.Endpoint.AbsoluteUri.TrimEnd('/'));
-            var key = Assert.IsType<AadAccessKey>(r.AccessKey);
+            var key = Assert.IsType<AccessKeyForMicrosoftEntra>(r.AccessKey);
             Assert.IsType<ManagedIdentityCredential>(key.TokenCredential);
             Assert.Same(r.Endpoint, r.AccessKey.Endpoint);
             Assert.Null(r.ClientEndpoint);
@@ -180,8 +180,8 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
         internal void TestAzureADWithServerEndpoint(string connectionString, string expectedAuthorizeUrl)
         {
             var r = ConnectionStringParser.Parse(connectionString);
-            var key = Assert.IsType<AadAccessKey>(r.AccessKey);
-            Assert.Equal(expectedAuthorizeUrl, key.AuthorizeUrl, StringComparer.OrdinalIgnoreCase);
+            var key = Assert.IsType<AccessKeyForMicrosoftEntra>(r.AccessKey);
+            Assert.Equal(expectedAuthorizeUrl, key.GetAccessKeyUrl, StringComparer.OrdinalIgnoreCase);
         }
 
         public class ClientEndpointTestData : IEnumerable<object[]>

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraApplicationTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraApplicationTests.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
-
 using Azure.Core;
 using Azure.Identity;
-
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
-
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 {
     [Collection("Auth")]
-    public class AzureActiveDirectoryTests
+    public class MicrosoftEntraApplicationTests
     {
         private const string IssuerEndpoint = "https://sts.windows.net/";
 
@@ -25,21 +22,21 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
 
         private static readonly string[] DefaultScopes = new string[] { "https://signalr.azure.com/.default" };
 
-        [Fact(Skip = "Provide valid aad options")]
+        [Fact(Skip = "Provide valid Microsoft Entra application options")]
         public async Task TestAcquireAccessToken()
         {
             var options = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
-            var key = new AadAccessKey(new Uri("https://localhost:8080"), options);
-            var token = await key.GenerateAadTokenAsync();
+            var key = new AccessKeyForMicrosoftEntra(new Uri("https://localhost:8080"), options);
+            var token = await key.GetMicrosoftEntraTokenAsync();
             Assert.NotNull(token);
         }
 
-        [Fact(Skip = "Provide valid aad options")]
-        public async Task TestGetAzureAdTokenAndAuthenticate()
+        [Fact(Skip = "Provide valid Microsoft Entra application options")]
+        public async Task TestGetMicrosoftEntraTokenAndAuthenticate()
         {
             var credential = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
 
-            ConfigurationManager<OpenIdConnectConfiguration> configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
                 new OpenIdConnectConfigurationRetriever()
             );
@@ -72,11 +69,11 @@ namespace Microsoft.Azure.SignalR.Common.Tests.Auth
             Assert.NotNull(validToken);
         }
 
-        [Fact(Skip = "Provide valid aad options")]
+        [Fact(Skip = "Provide valid Microsoft Entra application options")]
         internal async Task TestAuthenticateAsync()
         {
             var options = new ClientSecretCredential(TestTenantId, TestClientId, TestClientSecret);
-            var key = new AadAccessKey(new Uri("https://localhost:8080"), options);
+            var key = new AccessKeyForMicrosoftEntra(new Uri("https://localhost:8080"), options);
             await key.UpdateAccessKeyAsync();
 
             Assert.True(key.Authorized);

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/AccessKeySynchronizerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/AccessKeySynchronizerFacts.cs
@@ -46,16 +46,16 @@ namespace Microsoft.Azure.SignalR.Common
             var endpoint2 = new ServiceEndpoint($"Endpoint=http://endpoint2.net;AuthType=aad;ClientId=foo;ClientSecret=bar;TenantId={tenantId};Version=1.0");
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint1 });
-            Assert.Empty(synchronizer.FilterAccessKeyForMicrosoftEntra());
+            Assert.Empty(synchronizer.AccessKeyForMicrosoftEntraList);
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint1, endpoint2 });
-            Assert.Single(synchronizer.FilterAccessKeyForMicrosoftEntra());
+            Assert.Single(synchronizer.AccessKeyForMicrosoftEntraList);
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint2 });
-            Assert.Single(synchronizer.FilterAccessKeyForMicrosoftEntra());
+            Assert.Single(synchronizer.AccessKeyForMicrosoftEntraList);
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { });
-            Assert.Empty(synchronizer.FilterAccessKeyForMicrosoftEntra());
+            Assert.Empty(synchronizer.AccessKeyForMicrosoftEntraList);
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/AccessKeySynchronizerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/AccessKeySynchronizerFacts.cs
@@ -46,16 +46,16 @@ namespace Microsoft.Azure.SignalR.Common
             var endpoint2 = new ServiceEndpoint($"Endpoint=http://endpoint2.net;AuthType=aad;ClientId=foo;ClientSecret=bar;TenantId={tenantId};Version=1.0");
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint1 });
-            Assert.Empty(synchronizer.FilterAadAccessKeys());
+            Assert.Empty(synchronizer.FilterAccessKeyForMicrosoftEntra());
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint1, endpoint2 });
-            Assert.Single(synchronizer.FilterAadAccessKeys());
+            Assert.Single(synchronizer.FilterAccessKeyForMicrosoftEntra());
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { endpoint2 });
-            Assert.Single(synchronizer.FilterAadAccessKeys());
+            Assert.Single(synchronizer.FilterAccessKeyForMicrosoftEntra());
 
             synchronizer.UpdateServiceEndpoints(new List<ServiceEndpoint>() { });
-            Assert.Empty(synchronizer.FilterAadAccessKeys());
+            Assert.Empty(synchronizer.FilterAccessKeyForMicrosoftEntra());
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         {
             var uri = new Uri(url);
             var serviceEndpoint = new ServiceEndpoint(uri, new DefaultAzureCredential());
-            Assert.IsType<AadAccessKey>(serviceEndpoint.AccessKey);
+            Assert.IsType<AccessKeyForMicrosoftEntra>(serviceEndpoint.AccessKey);
             Assert.Equal(expectedEndpoint, serviceEndpoint.Endpoint);
             Assert.Equal("", serviceEndpoint.Name);
             Assert.Equal(port, serviceEndpoint.AccessKey.Endpoint.Port);
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         {
             var uri = new Uri("http://localhost");
             var serviceEndpoint = new ServiceEndpoint(key, uri, new DefaultAzureCredential());
-            Assert.IsType<AadAccessKey>(serviceEndpoint.AccessKey);
+            Assert.IsType<AccessKeyForMicrosoftEntra>(serviceEndpoint.AccessKey);
             Assert.Equal(name, serviceEndpoint.Name);
             Assert.Equal(type, serviceEndpoint.EndpointType);
             TestCopyConstructor(serviceEndpoint);
@@ -166,22 +166,22 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             {
                 ServerEndpoint = serverEndpoint1
             };
-            var key = Assert.IsType<AadAccessKey>(endpoint.AccessKey);
+            var key = Assert.IsType<AccessKeyForMicrosoftEntra>(endpoint.AccessKey);
             Assert.Same(key, endpoint.AccessKey);
-            Assert.Equal("http://serverEndpoint:123/api/v1/auth/accessKey", key.AuthorizeUrl, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("http://serverEndpoint:123/api/v1/auth/accessKey", key.GetAccessKeyUrl, StringComparer.OrdinalIgnoreCase);
 
             endpoint = new ServiceEndpoint(new Uri(serviceEndpoint), new DefaultAzureCredential(), serverEndpoint: serverEndpoint2);
-            key = Assert.IsType<AadAccessKey>(endpoint.AccessKey);
+            key = Assert.IsType<AccessKeyForMicrosoftEntra>(endpoint.AccessKey);
             Assert.Same(key, endpoint.AccessKey);
-            Assert.Equal("http://serverEndpoint:123/path/api/v1/auth/accessKey", key.AuthorizeUrl, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("http://serverEndpoint:123/path/api/v1/auth/accessKey", key.GetAccessKeyUrl, StringComparer.OrdinalIgnoreCase);
 
             endpoint = new ServiceEndpoint(new Uri(serviceEndpoint), new DefaultAzureCredential(), serverEndpoint: serverEndpoint1)
             {
                 ServerEndpoint = serverEndpoint2 // property initialize should override constructor param.
             };
-            key = Assert.IsType<AadAccessKey>(endpoint.AccessKey);
+            key = Assert.IsType<AccessKeyForMicrosoftEntra>(endpoint.AccessKey);
             Assert.Same(key, endpoint.AccessKey);
-            Assert.Equal("http://serverEndpoint:123/path/api/v1/auth/accessKey", key.AuthorizeUrl, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("http://serverEndpoint:123/path/api/v1/auth/accessKey", key.GetAccessKeyUrl, StringComparer.OrdinalIgnoreCase);
         }
 
         [Theory]

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [InlineData(typeof(AccessKey))]
-        [InlineData(typeof(AadAccessKey))]
+        [InlineData(typeof(AccessKeyForMicrosoftEntra))]
         public async Task TestAccessKeyRequestMessage(Type keyType)
         {
             var endpoint = MockServiceEndpoint(keyType.Name);
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.SignalR.Tests
 
         [Theory]
         [InlineData(typeof(AccessKey))]
-        [InlineData(typeof(AadAccessKey))]
+        [InlineData(typeof(AccessKeyForMicrosoftEntra))]
         public async Task TestAccessKeyResponseMessage(Type keyType)
         {
             var endpoint = MockServiceEndpoint(keyType.Name);
@@ -222,9 +222,9 @@ namespace Microsoft.Azure.SignalR.Tests
             {
                 var endpoint = new TestHubServiceEndpoint(endpoint: new TestServiceEndpoint(new DefaultAzureCredential()));
 
-                if (endpoint.AccessKey is AadAccessKey key)
+                if (endpoint.AccessKey is AccessKeyForMicrosoftEntra key)
                 {
-                    var field = typeof(AadAccessKey).GetField("_lastUpdatedTime", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var field = typeof(AccessKeyForMicrosoftEntra).GetField("_lastUpdatedTime", BindingFlags.NonPublic | BindingFlags.Instance);
                     field.SetValue(key, DateTime.UtcNow - TimeSpan.FromMinutes(minutesElapsed));
                 }
 
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.SignalR.Tests
                 case nameof(AccessKey):
                     return new ServiceEndpoint(_keyConnectionString);
 
-                case nameof(AadAccessKey):
+                case nameof(AccessKeyForMicrosoftEntra):
                     var endpoint = new ServiceEndpoint(_aadConnectionString);
                     var p = typeof(ServiceEndpoint).GetProperty("AccessKey", BindingFlags.NonPublic | BindingFlags.Instance);
                     p.SetValue(endpoint, new TestAadAccessKey());
@@ -324,7 +324,7 @@ namespace Microsoft.Azure.SignalR.Tests
             }
         }
 
-        private class TestAadAccessKey : AadAccessKey
+        private class TestAadAccessKey : AccessKeyForMicrosoftEntra
         {
             public string Token { get; } = Guid.NewGuid().ToString();
 
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.SignalR.Tests
             {
             }
 
-            public override Task<string> GenerateAadTokenAsync(CancellationToken ctoken = default)
+            public override Task<string> GetMicrosoftEntraTokenAsync(CancellationToken ctoken = default)
             {
                 return Task.FromResult(Token);
             }


### PR DESCRIPTION
[Azure AD is being renamed to Microsoft Entra ID](https://devblogs.microsoft.com/identity/aad-rebrand/)

Rename classes and method names to **Microsoft Entra** series.