### PR TITLE
Add connection FlowControl messages

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -7,7 +7,7 @@ using MessagePack;
 
 namespace Microsoft.Azure.SignalR.Protocol
 {
-    public enum OutgoingTaskControlState
+    public enum FlowControlState
     {
         /// <summary>
         /// Send from ASRS to the app server.
@@ -192,19 +192,14 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// The ASRS send it to the source server connection to initiate a client connection migration.
     /// Indicates that incoming messages are blocked.
     /// </summary>
-    public class OutgoingTaskControlMessage : ConnectionMessage
+    /// <remarks>
+    ///
+    /// </remarks>
+    /// <param name="connectionId">The client connection ID</param>
+    /// <param name="state">The state of control message</param>
+    public class FlowControlMessage(string connectionId, FlowControlState state) : ConnectionMessage(connectionId)
     {
-        public OutgoingTaskControlState State { get; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="connectionId">The client connection ID</param>
-        /// <param name="state">The state of control message</param>
-        public OutgoingTaskControlMessage(string connectionId, OutgoingTaskControlState state) : base(connectionId)
-        {
-            State = state;
-        }
+        public FlowControlState State { get; } = state;
     }
 
     /// <summary>

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -165,6 +165,50 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
+    /// The ASRS send it to the source server connection to initiate a client connection migration.
+    /// Indicates that incoming messages are blocked.
+    /// The app server should block outgoing messages and reply with a <see cref="MigrateConnectionAckMessage"/>.
+    /// </summary>
+    public class MigrateConnectionRequestMessage : ConnectionMessage
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId">The client connection ID</param>
+        public MigrateConnectionRequestMessage(string connectionId) : base(connectionId)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The source server connection send it to the ASRS to confirm the client connection migration.
+    /// Indicates that outgoing messages are being blocked.
+    /// The ASRS should unblock incoming messages and reply with a <see cref="MigrateConnectionFinAckMessage"/>
+    /// </summary>
+    public class MigrateConnectionAckMessage : ConnectionMessage
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId">The client connection ID</param>
+        public MigrateConnectionAckMessage(string connectionId) : base(connectionId)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The ASRS send it to the target server connection to complete the client connection migration.
+    /// Indicates that incoming messages are unblocked.
+    /// The target server connection should unblock outgoing messages.
+    /// </summary>
+    public class MigrateConnectionFinAckMessage : ConnectionMessage
+    {
+        public MigrateConnectionFinAckMessage(string connectionId) : base(connectionId)
+        {
+        }
+    }
+
+    /// <summary>
     /// An access key request message.
     /// </summary>
     public class AccessKeyRequestMessage : ExtensibleServiceMessage

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -7,25 +7,43 @@ using MessagePack;
 
 namespace Microsoft.Azure.SignalR.Protocol
 {
-    public enum FlowControlState
+    public enum ConnectionFlowControlOperation
     {
         /// <summary>
         /// Send from ASRS to the app server.
         /// Asking the client connection to pause sending messages towards ASRS.
         /// </summary>
-        Pause,
+        Pause = 1,
 
         /// <summary>
         /// Reply from the app server to ASRS.
         /// Ackknowledge that the message sending towards ASRS has been pasued.
         /// </summary>
-        PauseAck,
+        PauseAck = 2,
 
         /// <summary>
         /// Send from ASRS to the app server.
         /// Asking the client connection to resume sending messages towards ASRS.
         /// </summary>
-        Resume,
+        Resume = 3,
+
+        /// <summary>
+        /// Send from ASRS to the app server.
+        /// Asking the app server to send messages through other server connections.
+        /// </summary>
+        Offline = 4,
+    }
+
+    public enum ConnectionType
+    {
+        /// <summary>
+        /// Client connection
+        /// </summary>
+        Client = 1,
+        /// <summary>
+        /// Server connection
+        /// </summary>
+        Server = 2,
     }
 
     /// <summary>
@@ -192,14 +210,14 @@ namespace Microsoft.Azure.SignalR.Protocol
     /// The ASRS send it to the source server connection to initiate a client connection migration.
     /// Indicates that incoming messages are blocked.
     /// </summary>
-    /// <remarks>
-    ///
-    /// </remarks>
     /// <param name="connectionId">The client connection ID</param>
-    /// <param name="state">The state of control message</param>
-    public class FlowControlMessage(string connectionId, FlowControlState state) : ConnectionMessage(connectionId)
+    /// <param name="op">The operation</param>
+    /// <param name="type">The connection type</param>
+    public class ConnectionFlowControlMessage(string connectionId, ConnectionFlowControlOperation op, ConnectionType type = ConnectionType.Client) : ConnectionMessage(connectionId)
     {
-        public FlowControlState State { get; } = state;
+        public ConnectionFlowControlOperation Operation { get; } = op;
+
+        public ConnectionType ConnectionType { get; } = type;
     }
 
     /// <summary>

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -43,5 +43,6 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int ErrorCompletionMessageType = 36;
         public const int ServiceMappingMessageType = 37;
         public const int ConnectionReconnectMessageType = 38;
+        public const int ConnectionFlowControlMessageType = 39;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ConnectionFlowControlMessageFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ConnectionFlowControlMessageFacts.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Azure.SignalR.Protocol;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Protocols.Tests;
+
+public class ConnectionFlowControlMessageFacts
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData((int)ConnectionType.Server, 0)]
+    [InlineData(0, (int)ConnectionFlowControlOperation.Offline)]
+    public void TestThrowsInvalidDataException(int connectionType, int operation)
+    {
+        var message = new ConnectionFlowControlMessage(
+            "conn1",
+            (ConnectionFlowControlOperation)operation,
+            (ConnectionType)connectionType);
+        var protocol = new ServiceProtocol();
+        var bytes = protocol.GetMessageBytes(message);
+
+        var seq = new System.Buffers.ReadOnlySequence<byte>(bytes);
+        Assert.Throws<InvalidDataException>(() => protocol.TryParseMessage(ref seq, out var result));
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return ErrorCompletionMessageEqual(errorCompletionMessage, (ErrorCompletionMessage)y);
                 case ServiceMappingMessage serviceMappingMessage:
                     return ServiceMappingMessageEqual(serviceMappingMessage, (ServiceMappingMessage)y);
+                case ConnectionFlowControlMessage connectionFlowControlMessage:
+                    return ConnectionFlowControlMessageEqual(connectionFlowControlMessage, (ConnectionFlowControlMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -384,6 +386,13 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             return StringEqual(x.InvocationId, y.InvocationId) &&
                 StringEqual(x.ConnectionId, y.ConnectionId) &&
                 StringEqual(x.InstanceId, y.InstanceId);
+        }
+
+        private bool ConnectionFlowControlMessageEqual(ConnectionFlowControlMessage x, ConnectionFlowControlMessage y)
+        {
+            return StringEqual(x.ConnectionId, y.ConnectionId) &&
+                Equals(x.ConnectionType, y.ConnectionType) &&
+                Equals(x.Operation, y.Operation);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -283,6 +283,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         }.ToDictionary(t => t.Name);
 
 #pragma warning disable CS0618 // Type or member is obsolete
+
         public static IDictionary<string, ProtocolTestData> TestData => new[]
         {
             new ProtocolTestData(
@@ -693,7 +694,16 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "ServiceMappingMessage",
                 message: new ServiceMappingMessage("invocationId", "conn1", "instance1"),
                 binary: "lSWsaW52b2NhdGlvbklkpWNvbm4xqWluc3RhbmNlMYA="),
+            new ProtocolTestData(
+                name: nameof(ConnectionFlowControlMessage) + "-1",
+                message: new ConnectionFlowControlMessage("conn1", ConnectionFlowControlOperation.Pause, ConnectionType.Client),
+                binary: "lSelY29ubjHSAAAAAdIAAAABgA=="),
+            new ProtocolTestData(
+                name: nameof(ConnectionFlowControlMessage) + "-2",
+                message: new ConnectionFlowControlMessage("conn2", ConnectionFlowControlOperation.Offline, ConnectionType.Server),
+                binary: "lSelY29ubjLSAAAAAtIAAAAEgA=="),
         }.ToDictionary(t => t.Name);
+
 #pragma warning restore CS0618 // Type or member is obsolete
 
         [Theory]
@@ -840,7 +850,9 @@ Please verify the MsgPack output and update the baseline");
         public class ProtocolTestData
         {
             public string Name { get; private set; }
+
             public string Binary { get; private set; }
+
             public ServiceMessage Message { get; private set; }
 
             public ProtocolTestData(string name, ServiceMessage message, string binary)


### PR DESCRIPTION
Add messages for client connection migration.

`FlowControlMessage` with `Pause`, `PauseAck` and `Resume` state.

![image](https://github.com/user-attachments/assets/d4ef8da9-618a-4bca-94ac-5c06b6048245)
