### PR TITLE
Add CloseConnections to ServiceConnection

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -97,6 +97,11 @@ internal partial class ServiceConnection : ServiceConnectionBase
         return Task.CompletedTask;
     }
 
+    public override Task CloseClientConnections(CancellationToken token)
+    {
+        throw new NotSupportedException();
+    }
+
     protected override Task OnClientConnectedAsync(OpenConnectionMessage openConnectionMessage)
     {
         // Create empty transport with only channel for async processing messages

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -83,22 +83,22 @@ internal class ServiceConnectionManager : IServiceConnectionManager
 
     public Task StartAsync()
     {
-        return Task.WhenAll(GetConnections().Select(s => s.StartAsync()));
+        return Task.WhenAll(GetConnections().Select(c => c.StartAsync()));
     }
 
     public Task StopAsync()
     {
-        return Task.WhenAll(GetConnections().Select(s => s.StopAsync()));
+        return Task.WhenAll(GetConnections().Select(c => c.StopAsync()));
     }
 
     public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token)
     {
-        return Task.WhenAll(GetConnections().Select(s => s.OfflineAsync(mode, token)));
+        return Task.WhenAll(GetConnections().Select(c => c.OfflineAsync(mode, token)));
     }
 
     public Task CloseClientConnections(CancellationToken token)
     {
-        return Task.WhenAll(GetConnections().Select(s => s.CloseClientConnections(token)));
+        return Task.WhenAll(GetConnections().Select(c => c.CloseClientConnections(token)));
     }
 
     public IServiceConnectionContainer WithHub(string hubName)

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -96,6 +96,11 @@ internal class ServiceConnectionManager : IServiceConnectionManager
         return Task.WhenAll(GetConnections().Select(s => s.OfflineAsync(mode, token)));
     }
 
+    public Task CloseClientConnections(CancellationToken token)
+    {
+        return Task.WhenAll(GetConnections().Select(s => s.CloseClientConnections(token)));
+    }
+
     public IServiceConnectionContainer WithHub(string hubName)
     {
         if (_hubConnections == null || !_hubConnections.TryGetValue(hubName, out var connection))

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnection.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -20,6 +21,8 @@ internal interface IServiceConnection
     Task ConnectionInitializedTask { get; }
 
     Task ConnectionOfflineTask { get; }
+
+    Task CloseClientConnections(CancellationToken token);
 
     event Action<StatusChange> ConnectionStatusChanged;
 

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionManager.cs
@@ -13,4 +13,6 @@ internal interface IServiceConnectionManager : IServiceMessageWriter
     Task StopAsync();
 
     Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token);
+
+    Task CloseClientConnections(CancellationToken token);
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Azure.SignalR
             return Task.WhenAll(_routerEndpoints.endpoints.Select(c => c.ConnectionContainer.OfflineAsync(mode, token)));
         }
 
+        public Task CloseClientConnections(CancellationToken token)
+        {
+            return Task.WhenAll(_routerEndpoints.endpoints.Select(c => c.ConnectionContainer.CloseClientConnections(token)));
+        }
+
         public Task WriteAsync(ServiceMessage serviceMessage)
         {
             return CreateMessageWriter(serviceMessage).WriteAsync(serviceMessage);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -431,6 +431,11 @@ internal abstract partial class ServiceConnectionBase : IServiceConnection
         return Task.CompletedTask;
     }
 
+    public virtual Task CloseClientConnections(CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
     private async Task PauseClientConnectionAsync(IClientConnection clientConnection)
     {
         await clientConnection.PauseAsync();

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -431,10 +431,7 @@ internal abstract partial class ServiceConnectionBase : IServiceConnection
         return Task.CompletedTask;
     }
 
-    public virtual Task CloseClientConnections(CancellationToken token)
-    {
-        return Task.CompletedTask;
-    }
+    public abstract Task CloseClientConnections(CancellationToken token);
 
     private async Task PauseClientConnectionAsync(IClientConnection clientConnection)
     {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -255,6 +255,11 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         return Task.WhenAll(ServiceConnections.Select(c => RemoveConnectionAsync(c, mode, token)));
     }
 
+    public virtual Task CloseClientConnections(CancellationToken token)
+    {
+        return Task.WhenAll(ServiceConnections.Select(c => c.CloseClientConnections(token)));
+    }
+
     public Task StartGetServersPing()
     {
         if (_serversPing.Start())

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -116,6 +116,8 @@ namespace Microsoft.Azure.SignalR.Management
 
             public Task StopGetServersPing() => throw new NotSupportedException();
 
+            public Task CloseClientConnections(CancellationToken token) => throw new NotSupportedException();
+
             #endregion Not supported method or properties
         }
     }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -113,7 +113,7 @@ internal partial class ServiceConnection : ServiceConnectionBase
 
     public override Task CloseClientConnections(CancellationToken token)
     {
-        return Task.WhenAll(_clientConnectionManager.ClientConnections.Select(i => ((ClientConnectionContext)i).PerformDisconnectAsync()));
+        return Task.WhenAll(_clientConnectionManager.ClientConnections.Select(c => ((ClientConnectionContext)c).PerformDisconnectAsync()));
     }
 
     protected override Task CleanupClientConnections(string fromInstanceId = null)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
@@ -108,6 +109,11 @@ internal partial class ServiceConnection : ServiceConnectionBase
     protected override Task DisposeConnection(ConnectionContext connection)
     {
         return _connectionFactory.DisposeAsync(connection);
+    }
+
+    public override Task CloseClientConnections(CancellationToken token)
+    {
+        return Task.WhenAll(_clientConnectionManager.ClientConnections.Select(i => ((ClientConnectionContext)i).PerformDisconnectAsync()));
     }
 
     protected override Task CleanupClientConnections(string fromInstanceId = null)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -34,6 +34,11 @@ internal class ServiceConnectionManager<THub> : IDisposable, IServiceConnectionM
         await _serviceConnection.OfflineAsync(mode, token);
     }
 
+    public async Task CloseClientConnections(CancellationToken c)
+    {
+        await _serviceConnection.CloseClientConnections(c);
+    }
+
     public Task WriteAsync(ServiceMessage serviceMessage)
     {
         if (_serviceConnection == null)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -34,9 +34,9 @@ internal class ServiceConnectionManager<THub> : IDisposable, IServiceConnectionM
         await _serviceConnection.OfflineAsync(mode, token);
     }
 
-    public async Task CloseClientConnections(CancellationToken c)
+    public async Task CloseClientConnections(CancellationToken cancellationToken)
     {
-        await _serviceConnection.CloseClientConnections(c);
+        await _serviceConnection.CloseClientConnections(cancellationToken);
     }
 
     public Task WriteAsync(ServiceMessage serviceMessage)

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnection.cs
@@ -64,4 +64,6 @@ internal class MockServiceConnection : IServiceConnection
         await WriteAsync(serviceMessage);
         return true;
     }
+
+    public Task CloseClientConnections(CancellationToken token) => Task.CompletedTask;
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO.Pipelines;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;
@@ -52,6 +53,11 @@ internal class TestServiceConnection(ServiceConnectionStatus status = ServiceCon
     public void Stop()
     {
         _connection?.Transport.Input.CancelPendingRead();
+    }
+
+    public override Task CloseClientConnections(CancellationToken token)
+    {
+        throw new NotImplementedException();
     }
 
     public override Task<bool> SafeWriteAsync(ServiceMessage serviceMessage)

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -104,4 +104,9 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
     public void Dispose()
     {
     }
+
+    public Task CloseClientConnections(CancellationToken token)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
@@ -404,6 +405,11 @@ public class ClientConnectionContextFacts : VerifiableLoggedTest
 
         public void Dispose()
         {
+        }
+
+        public Task CloseClientConnections(CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -60,4 +60,6 @@ internal class TestServiceConnectionManager<THub> : IServiceConnectionManager<TH
     }
 
     public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token) => Task.CompletedTask;
+
+    public Task CloseClientConnections(CancellationToken token) => Task.CompletedTask;
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Azure.SignalR.Protocol;
@@ -289,6 +290,11 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
             {
                 return false;
             }
+        }
+
+        public Task CloseClientConnections(CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -136,5 +136,10 @@ public class ServiceHubDispatcherTests
         {
             throw new NotImplementedException();
         }
+
+        public Task CloseClientConnections(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestSimpleServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestSimpleServiceConnection.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
@@ -68,5 +69,10 @@ internal sealed class TestSimpleServiceConnection : IServiceConnection
 
         _writeAsyncTcs?.TrySetResult(null);
         return Task.FromResult(true);
+    }
+
+    public Task CloseClientConnections(CancellationToken token)
+    {
+        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
When app server closes, currently it is abruptly exiting the app server, we would like to hook into the application shutdown to close the client connections routed to this app server first. This PR is to add "CloseConnections" ability to the interfaces.
