### PR TITLE
Update .net versions on pipelines

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -12,6 +12,7 @@ jobs:
   build_osx:
     runs-on: macOS-latest
     strategy:
+      fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
         dotnet-version: [ '9.0.x', '8.0.x' ]
     steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
-        dotnet-version: [ '9.0.x', '8.0.x' ]
+        dotnet-version: [ '9.0.x', '8.0.x', '6.0.x' ]
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,11 +1,11 @@
 name: Gated-OSX
-on: 
+on:
  push:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
  pull_request:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
 jobs:
@@ -13,7 +13,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x', '7.0.x', '6.0.x' ]
+        dotnet-version: [ '9.0.x', '8.0.x' ]
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
@@ -43,13 +43,11 @@ jobs:
       run: dotnet --version
     - name: Build with dotnet
       run: |
-        if [ "${{ matrix.dotnet-version }}" != "6.0.x" ]; then
-          dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Protocols.Tests/Microsoft.Azure.SignalR.Protocols.Tests.csproj
-          dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Emulator.Tests/Microsoft.Azure.SignalR.Emulator.Tests.csproj
-          dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Management.Tests/Microsoft.Azure.SignalR.Management.Tests.csproj
-          dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Serverless.Protocols.Tests/Microsoft.Azure.SignalR.Serverless.Protocols.Tests.csproj
-          dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.IntegrationTests/Microsoft.Azure.SignalR.IntegrationTests.csproj
-        fi
+        dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Protocols.Tests/Microsoft.Azure.SignalR.Protocols.Tests.csproj
+        dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Emulator.Tests/Microsoft.Azure.SignalR.Emulator.Tests.csproj
+        dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Management.Tests/Microsoft.Azure.SignalR.Management.Tests.csproj
+        dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.Serverless.Protocols.Tests/Microsoft.Azure.SignalR.Serverless.Protocols.Tests.csproj
+        dotnet sln AzureSignalR.sln remove test/Microsoft.Azure.SignalR.IntegrationTests/Microsoft.Azure.SignalR.IntegrationTests.csproj
         dotnet build AzureSignalR.sln /p:DisableNet461Tests=true
       if: steps.filter.outputs.src == 'true'
     - name: Test

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,11 +1,11 @@
 name: Gated-Ubuntu
-on: 
+on:
  push:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
  pull_request:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
 jobs:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x', '7.0.x', '6.0.x' ]
+        dotnet-version: [ '9.0.x', '8.0.x' ]
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,6 +12,7 @@ jobs:
   build_ubuntu:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
         dotnet-version: [ '9.0.x', '8.0.x' ]
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,7 @@ jobs:
   build_windows:
     runs-on: [windows-latest]
     strategy:
+      fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
         dotnet-version: [ '9.0.x', '8.0.x']
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,11 +1,11 @@
 name: Gated-Windows
-on: 
+on:
  push:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
  pull_request:
-   branches: 
+   branches:
     - 'releases/**'
     - dev
 jobs:
@@ -13,7 +13,7 @@ jobs:
     runs-on: [windows-latest]
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x', '7.0.x', '6.0.x' ]
+        dotnet-version: [ '9.0.x', '8.0.x']
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
-        dotnet-version: [ '9.0.x', '8.0.x']
+        dotnet-version: [ '9.0.x', '8.0.x', '6.0.x']
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2


### PR DESCRIPTION
.net 6 and .net 7 are no longer supported on ubuntu-latest image.
* Remove out-of-support versions .net 6, .net 7 on ubuntu
* Other .net 6 jobs on osx, windows will be removed once .net 6 is removed from the TFM lists of projects.
* Add new versions .net 9
