### PR TITLE
Implement presence API for `IServiceConnectionContainer`

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -169,7 +169,7 @@ internal class ServiceConnectionManager : IServiceConnectionManager
         }
     }
 
-    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
     {
         throw new NotSupportedException();
     }

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -168,4 +168,9 @@ internal class ServiceConnectionManager : IServiceConnectionManager
             }
         }
     }
+
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    {
+        throw new NotSupportedException();
+    }
 }

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -169,8 +169,8 @@ internal class ServiceConnectionManager : IServiceConnectionManager
         }
     }
 
-    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, CancellationToken token = default)
     {
-        throw new NotSupportedException();
+        throw new NotImplementedException();
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
@@ -11,5 +11,5 @@ namespace Microsoft.Azure.SignalR;
 /// </summary>
 internal interface IPresenceManager
 {
-    IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top);
+    IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null);
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.SignalR.Protocol;
+
+namespace Microsoft.Azure.SignalR;
+
+/// <summary>
+/// Manager for presence operations.
+/// </summary>
+internal interface IPresenceManager
+{
+    IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top);
+}

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IPresenceManager.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
+
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR;
@@ -11,5 +13,5 @@ namespace Microsoft.Azure.SignalR;
 /// </summary>
 internal interface IPresenceManager
 {
-    IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null);
+    IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, CancellationToken token = default);
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR;
 
-internal interface IServiceConnectionContainer : IServiceConnectionManager, IDisposable
+internal interface IServiceConnectionContainer : IServiceConnectionManager, IPresenceManager, IDisposable
 {
     ServiceConnectionStatus Status { get; }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -183,7 +183,6 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
         {
             throw new ArgumentOutOfRangeException(nameof(top), "Top must be greater than 0.");
         }
-        var memberCount = 0;
         foreach (var endpoint in TargetEndpoints)
         {
             IAsyncEnumerable<GroupMember> enumerable;
@@ -201,8 +200,8 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
                 yield return member;
                 if (top.HasValue)
                 {
-                    memberCount++;
-                    if (memberCount >= top)
+                    top--;
+                    if (top == 0)
                     {
                         yield break;
                     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.SignalR;
 /// <summary>
 /// A service connection container which sends message to multiple service endpoints.
 /// </summary>
-internal class MultiEndpointMessageWriter : IServiceMessageWriter
+internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceManager
 {
     private readonly ILogger _logger;
 
@@ -55,8 +55,8 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter
 
     public Task<bool> WriteAckableMessageAsync(ServiceMessage serviceMessage, CancellationToken cancellationToken = default)
     {
-        if (serviceMessage is CheckConnectionExistenceWithAckMessage 
-            || serviceMessage is JoinGroupWithAckMessage 
+        if (serviceMessage is CheckConnectionExistenceWithAckMessage
+            || serviceMessage is JoinGroupWithAckMessage
             || serviceMessage is LeaveGroupWithAckMessage)
         {
             return WriteSingleResultAckableMessage(serviceMessage, cancellationToken);
@@ -169,6 +169,32 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter
             // log and don't stop other endpoints
             Log.FailedWritingMessageToEndpoint(_logger, serviceMessage.GetType().Name, (serviceMessage as IMessageWithTracingId)?.TracingId, endpoint.ToString());
             throw new FailedWritingMessageToServiceException(endpoint.ServerEndpoint.AbsoluteUri);
+        }
+    }
+
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    {
+        if (TargetEndpoints.Length == 0)
+        {
+            Log.NoEndpointRouted(_logger, nameof(GroupMemberQueryMessage));
+            yield break;
+        }
+        foreach (var endpoint in TargetEndpoints)
+        {
+            IAsyncEnumerable<GroupMember> enumerable;
+            try
+            {
+                enumerable = endpoint.ConnectionContainer.ListConnectionsInGroupAsync(groupName, top);
+            }
+            catch (ServiceConnectionNotActiveException)
+            {
+                Log.FailedWritingMessageToEndpoint(_logger, nameof(GroupMemberQueryMessage), null, endpoint.ToString());
+                continue;
+            }
+            await foreach (var member in enumerable)
+            {
+                yield return member;
+            }
         }
     }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -172,19 +172,24 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
         }
     }
 
-    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
     {
         if (TargetEndpoints.Length == 0)
         {
             Log.NoEndpointRouted(_logger, nameof(GroupMemberQueryMessage));
             yield break;
         }
+        if (top <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(top), "Top must be greater than 0.");
+        }
+        var memberCount = 0;
         foreach (var endpoint in TargetEndpoints)
         {
             IAsyncEnumerable<GroupMember> enumerable;
             try
             {
-                enumerable = endpoint.ConnectionContainer.ListConnectionsInGroupAsync(groupName, top);
+                enumerable = endpoint.ConnectionContainer.ListConnectionsInGroupAsync(groupName, top, tracingId);
             }
             catch (ServiceConnectionNotActiveException)
             {
@@ -194,6 +199,14 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
             await foreach (var member in enumerable)
             {
                 yield return member;
+                if (top.HasValue)
+                {
+                    memberCount++;
+                    if (memberCount >= top)
+                    {
+                        yield break;
+                    }
+                }
             }
         }
     }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -1,12 +1,14 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -172,7 +174,7 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
         }
     }
 
-    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, [EnumeratorCancellation] CancellationToken token = default)
     {
         if (TargetEndpoints.Length == 0)
         {
@@ -188,7 +190,7 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
             IAsyncEnumerable<GroupMember> enumerable;
             try
             {
-                enumerable = endpoint.ConnectionContainer.ListConnectionsInGroupAsync(groupName, top, tracingId);
+                enumerable = endpoint.ConnectionContainer.ListConnectionsInGroupAsync(groupName, top, tracingId, token);
             }
             catch (ServiceConnectionNotActiveException)
             {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -151,7 +151,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
     }
 
 
-    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
     {
         var targetEndpoints = _routerEndpoints.needRouter ? _router.GetEndpointsForGroup(groupName, _routerEndpoints.endpoints) : _routerEndpoints.endpoints;
         var messageWriter = new MultiEndpointMessageWriter(targetEndpoints?.ToList(), _loggerFactory);

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -150,6 +150,14 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         return CreateMessageWriter(serviceMessage).WriteAckableMessageAsync(serviceMessage, cancellationToken);
     }
 
+
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    {
+        var targetEndpoints = _routerEndpoints.needRouter ? _router.GetEndpointsForGroup(groupName, _routerEndpoints.endpoints) : _routerEndpoints.endpoints;
+        var messageWriter = new MultiEndpointMessageWriter(targetEndpoints?.ToList(), _loggerFactory);
+        return messageWriter.ListConnectionsInGroupAsync(groupName, top);
+    }
+
     public Task StartGetServersPing()
     {
         return Task.WhenAll(_routerEndpoints.endpoints.Select(c => c.ConnectionContainer.StartGetServersPing()));

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 
@@ -151,11 +152,11 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
     }
 
 
-    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, CancellationToken token = default)
     {
         var targetEndpoints = _routerEndpoints.needRouter ? _router.GetEndpointsForGroup(groupName, _routerEndpoints.endpoints) : _routerEndpoints.endpoints;
         var messageWriter = new MultiEndpointMessageWriter(targetEndpoints?.ToList(), _loggerFactory);
-        return messageWriter.ListConnectionsInGroupAsync(groupName, top);
+        return messageWriter.ListConnectionsInGroupAsync(groupName, top, tracingId, token);
     }
 
     public Task StartGetServersPing()

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -249,25 +249,31 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         return AckHandler.HandleAckStatus(ackableMessage, status);
     }
 
-    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
     {
-        var currentCount = 0;
+        if (string.IsNullOrWhiteSpace(groupName))
+        {
+            throw new ArgumentException($"'{nameof(groupName)}' cannot be null or whitespace.", nameof(groupName));
+        }
+        if (top != null && top <= 0)
+        {
+            throw new ArgumentException($"'{nameof(top)}' must be greater than 0.", nameof(top));
+        }
+        var message = new GroupMemberQueryMessage() { GroupName = groupName, Top = top, TracingId = tracingId };
         do
         {
-            if (top != null)
-            {
-                top -= currentCount;
-            }
-            var message = new GroupMemberQueryMessage() { GroupName = groupName, Top = top };
             var response = await InvokeAsync<GroupMemberQueryResponse>(message);
             foreach (var member in response.Members)
             {
                 yield return member;
-                currentCount++;
-                if (top != null && currentCount >= top || response.ContinuationToken == null)
-                {
-                    yield break;
-                }
+            }
+            if (response.ContinuationToken == null)
+            {
+                yield break;
+            }
+            if (message.Top != null)
+            {
+                message.Top -= response.Members.Count;
             }
             message.ContinuationToken = response.ContinuationToken;
         } while (true);
@@ -277,7 +283,8 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
     /// <see cref="WriteAckableMessageAsync(ServiceMessage, CancellationToken)"/> only checks <see cref="AckMessage.Status"/> as the response, 
     /// while this method checks <see cref="AckMessage.Payload"/> and deserialize it to <typeparamref name="T"/>.
     /// </summary>
-    private async Task<T> InvokeAsync<T>(ServiceMessage serviceMessage, CancellationToken cancellationToken = default) where T : notnull, new()
+    /// Made "interval virtual" for testing
+    internal virtual async Task<T> InvokeAsync<T>(ServiceMessage serviceMessage, CancellationToken cancellationToken = default) where T : notnull, new()
     {
         if (serviceMessage is not IAckableMessage ackableMessage)
         {

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -249,7 +250,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         return AckHandler.HandleAckStatus(ackableMessage, status);
     }
 
-    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, [EnumeratorCancellation] CancellationToken token = default)
     {
         if (string.IsNullOrWhiteSpace(groupName))
         {
@@ -262,7 +263,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         var message = new GroupMemberQueryMessage() { GroupName = groupName, Top = top, TracingId = tracingId };
         do
         {
-            var response = await InvokeAsync<GroupMemberQueryResponse>(message);
+            var response = await InvokeAsync<GroupMemberQueryResponse>(message, token);
             foreach (var member in response.Members)
             {
                 yield return member;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -221,7 +221,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
 
     public void HandleAck(AckMessage ackMessage)
     {
-        _ackHandler.TriggerAck(ackMessage.AckId, (AckStatus)ackMessage.Status);
+        _ackHandler.TriggerAck(ackMessage.AckId, (AckStatus)ackMessage.Status, ackMessage.Payload);
     }
 
     public virtual Task WriteAsync(ServiceMessage serviceMessage)
@@ -247,6 +247,53 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
 
         var status = await task;
         return AckHandler.HandleAckStatus(ackableMessage, status);
+    }
+
+    public async IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    {
+        var currentCount = 0;
+        do
+        {
+            if (top != null)
+            {
+                top -= currentCount;
+            }
+            var message = new GroupMemberQueryMessage() { GroupName = groupName, Top = top };
+            var response = await InvokeAsync<GroupMemberQueryResponse>(message);
+            foreach (var member in response.Members)
+            {
+                yield return member;
+                currentCount++;
+                if (top != null && currentCount >= top || response.ContinuationToken == null)
+                {
+                    yield break;
+                }
+            }
+            message.ContinuationToken = response.ContinuationToken;
+        } while (true);
+    }
+
+    /// <summary>
+    /// <see cref="WriteAckableMessageAsync(ServiceMessage, CancellationToken)"/> only checks <see cref="AckMessage.Status"/> as the response, 
+    /// while this method checks <see cref="AckMessage.Payload"/> and deserialize it to <typeparamref name="T"/>.
+    /// </summary>
+    private async Task<T> InvokeAsync<T>(ServiceMessage serviceMessage, CancellationToken cancellationToken = default) where T : notnull, new()
+    {
+        if (serviceMessage is not IAckableMessage ackableMessage)
+        {
+            throw new ArgumentException($"{nameof(serviceMessage)} is not {nameof(IAckableMessage)}");
+        }
+
+        var task = _ackHandler.CreateSingleAck<T>(out var id, null, cancellationToken);
+        ackableMessage.AckId = id;
+
+        // Sending regular messages completes as soon as the data leaves the outbound pipe,
+        // whereas ackable ones complete upon full roundtrip of the message and the ack (or timeout).
+        // Therefore sending them over different connections creates a possibility for processing them out of original order.
+        // By sending both message types over the same connection we ensure that they are sent (and processed) in their original order.
+        await WriteMessageAsync(serviceMessage);
+
+        return await task;
     }
 
     public virtual Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token)

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
@@ -50,17 +50,17 @@ internal sealed class AckHandler : IDisposable
         return info.Task;
     }
 
-    public Task<T> CreateSingleAck<T>(out int id, TimeSpan? ackTimeout = default, CancellationToken cancellationToken = default) where T : IMessagePackSerializable, new()
-    {
-        id = NextId();
-        if (_disposed)
+        public Task<T> CreateSingleAck<T>(out int id, TimeSpan? ackTimeout = default, CancellationToken cancellationToken = default) where T : notnull, new()
         {
-            return Task.FromResult(new T());
+            id = NextId();
+            if (_disposed)
+            {
+                return Task.FromResult(new T());
+            }
+            var info = (SinglePayloadAck<T>)_acks.GetOrAdd(id, _ => new SinglePayloadAck<T>(ackTimeout ?? _defaultAckTimeout));
+            cancellationToken.Register(info.Cancel);
+            return info.Task.ContinueWith(task => task.Result);
         }
-        var info = (IAckInfo<IMessagePackSerializable>)_acks.GetOrAdd(id, _ => new SinglePayloadAck<T>(ackTimeout ?? _defaultAckTimeout));
-        cancellationToken.Register(info.Cancel);
-        return info.Task.ContinueWith(task => (T)task.Result);
-    }
 
     public static bool HandleAckStatus(IAckableMessage message, AckStatus status)
     {
@@ -210,19 +210,19 @@ internal sealed class AckHandler : IDisposable
             _tcs.TrySetResult(status);
     }
 
-    private sealed class SinglePayloadAck<T> : SingleAckInfo<IMessagePackSerializable> where T : IMessagePackSerializable, new()
-    {
-        public SinglePayloadAck(TimeSpan timeout) : base(timeout) { }
-        public override bool Ack(AckStatus status, ReadOnlySequence<byte>? payload = null)
+        private sealed class SinglePayloadAck<T> : SingleAckInfo<T> where T : notnull, new()
         {
-            if (status == AckStatus.Timeout)
+            public SinglePayloadAck(TimeSpan timeout) : base(timeout) { }
+            public override bool Ack(AckStatus status, ReadOnlySequence<byte>? payload = null)
             {
-                return _tcs.TrySetException(new TimeoutException($"Waiting for a {typeof(T).Name} response timed out."));
-            }
-            if (payload == null)
-            {
-                return _tcs.TrySetException(new InvalidDataException($"The expected payload is null."));
-            }
+                if (status == AckStatus.Timeout)
+                {
+                    return _tcs.TrySetException(new TimeoutException($"Waiting for a {typeof(T).Name} response timed out."));
+                }
+                if (payload == null)
+                {
+                    return _tcs.TrySetException(new InvalidDataException($"The expected payload is null."));
+                }
 
             try
             {

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
@@ -2,8 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -101,4 +107,58 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
             Assert.True(endpoint1.Online);
         }
     }
+
+    [Fact]
+    public async Task TestInvokeAsync()
+    {
+        var endpoint1 = new TestHubServiceEndpoint();
+        var conn1 = new TestServiceConnection();
+        var scf = new TestServiceConnectionFactory(endpoint1 => conn1);
+        var container = new WeakServiceConnectionContainer(scf, 5, endpoint1, Mock.Of<ILogger>());
+        var queryMessage = new GroupMemberQueryMessage() { GroupName = "group" };
+        var invokeTask = container.InvokeAsync<GroupMemberQueryResponse>(queryMessage, default);
+
+        var expectedResponse = new GroupMemberQueryResponse()
+        {
+            ContinuationToken = "abc",
+            Members = [new() { ConnectionId = "1" }, new() { ConnectionId = "2" }]
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        new ServiceProtocol().WriteMessagePayload(expectedResponse, buffer);
+        AckHandler.Singleton.TriggerAck(queryMessage.AckId, AckStatus.Ok, new ReadOnlySequence<byte>(buffer.WrittenMemory));
+        var response = await invokeTask;
+        Assert.Equal(queryMessage, conn1.ReceivedMessages.Single());
+        Assert.Equal(expectedResponse.ContinuationToken, response.ContinuationToken);
+        Assert.True(expectedResponse.Members.SequenceEqual(response.Members));
+    }
+
+    [Fact]
+    public async Task TestListConnectionsInGroupAsync()
+    {
+        var groupName = "groupName";
+        var top = 3;
+        var tracingId = (ulong)1;
+        var connectionContainerMock = new Mock<ServiceConnectionContainerBase>(
+            Mock.Of<IServiceConnectionFactory>(),
+            5,
+            new TestHubServiceEndpoint());
+        connectionContainerMock.SetupSequence(c => c.InvokeAsync<GroupMemberQueryResponse>(
+            It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GroupMemberQueryResponse() { ContinuationToken = "abc", Members = [new() { ConnectionId = "1" }, new() { ConnectionId = "2" }] })
+            .ReturnsAsync(new GroupMemberQueryResponse() { ContinuationToken = null, Members = [new() { ConnectionId = "3" }] });
+        var enumerator = connectionContainerMock.Object
+            .ListConnectionsInGroupAsync(groupName, top, tracingId)
+            .GetAsyncEnumerator();
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("1", enumerator.Current.ConnectionId);
+        connectionContainerMock.Verify(c => c.InvokeAsync<GroupMemberQueryResponse>(
+            It.Is<GroupMemberQueryMessage>(m => m.GroupName == groupName && m.Top == 3 && m.TracingId == tracingId), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("3", enumerator.Current.ConnectionId);
+        connectionContainerMock.Verify(c => c.InvokeAsync<GroupMemberQueryResponse>(
+    It.Is<GroupMemberQueryMessage>(m => m.GroupName == groupName && m.Top == 1 && m.TracingId == tracingId && m.ContinuationToken == "abc"), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
@@ -135,13 +135,17 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
     [Fact]
     public async Task TestListConnectionsInGroupAsync()
     {
+        var conn = new TestServiceConnection();
         var groupName = "groupName";
         var top = 3;
         var tracingId = (ulong)1;
         var connectionContainerMock = new Mock<ServiceConnectionContainerBase>(
-            Mock.Of<IServiceConnectionFactory>(),
+             new TestServiceConnectionFactory(endpoint => conn),
             5,
-            new TestHubServiceEndpoint());
+            new TestHubServiceEndpoint(),
+            null,
+            Mock.Of<ILogger>(),
+            null);
         connectionContainerMock.SetupSequence(c => c.InvokeAsync<GroupMemberQueryResponse>(
             It.IsAny<ServiceMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GroupMemberQueryResponse() { ContinuationToken = "abc", Members = [new() { ConnectionId = "1" }, new() { ConnectionId = "2" }] })
@@ -153,6 +157,7 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
         Assert.Equal("1", enumerator.Current.ConnectionId);
         connectionContainerMock.Verify(c => c.InvokeAsync<GroupMemberQueryResponse>(
             It.Is<GroupMemberQueryMessage>(m => m.GroupName == groupName && m.Top == 3 && m.TracingId == tracingId), It.IsAny<CancellationToken>()), Times.Once);
+        connectionContainerMock.Invocations.Clear();
         Assert.True(await enumerator.MoveNextAsync());
         Assert.True(await enumerator.MoveNextAsync());
         Assert.Equal("3", enumerator.Current.ConnectionId);
@@ -160,5 +165,4 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
     It.Is<GroupMemberQueryMessage>(m => m.GroupName == groupName && m.Top == 1 && m.TracingId == tracingId && m.ContinuationToken == "abc"), It.IsAny<CancellationToken>()), Times.Once);
         Assert.False(await enumerator.MoveNextAsync());
     }
-
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -13,13 +13,14 @@ namespace Microsoft.Azure.SignalR.Common.Tests.ServiceConnections;
 public class MultiEndpointMessageWriterTests
 {
     [Theory]
-    [InlineData(null, 6)]
-    [InlineData(5, 5)]
-    [InlineData(1, 1)]
-    [InlineData(7, 6)]
-    public async Task ListConnectionsInGroup(int? top, int resultCount)
+    [InlineData(null, 6, null, null)]
+    [InlineData(5, 5, 5, 2)]
+    [InlineData(1, 1, 1)]
+    [InlineData(7, 6, 7, 4)]
+    public async Task ListConnectionsInGroup(int? top, int resultCount, params int?[] expectedTopsInInvocations)
     {
         var targetEndpoints = new List<HubServiceEndpoint>();
+        var containerMocks = new List<Mock<IServiceConnectionContainer>>();
         for (var i = 0; i < 2; i++)
         {
             var endpoint = new TestHubServiceEndpoint();
@@ -28,9 +29,11 @@ public class MultiEndpointMessageWriterTests
                 new GroupMember { ConnectionId = "2" },
                 new GroupMember { ConnectionId = "3" }
             );
-            var connectionContainer = Mock.Of<IServiceConnectionContainer>(
-                c => c.ListConnectionsInGroupAsync(It.IsAny<string>(), It.IsAny<int?>(), null) == resultFromConnectioContainer);
-            endpoint.ConnectionContainer = connectionContainer;
+            var containerMock = new Mock<IServiceConnectionContainer>();
+            containerMocks.Add(containerMock);
+            containerMock.Setup(c => c.ListConnectionsInGroupAsync(It.IsAny<string>(), It.IsAny<int?>(), null))
+                .Returns(resultFromConnectioContainer);
+            endpoint.ConnectionContainer = containerMock.Object;
             targetEndpoints.Add(endpoint);
         }
         var multiEndpointWriter = new MultiEndpointMessageWriter(targetEndpoints, Mock.Of<ILoggerFactory>());
@@ -40,5 +43,9 @@ public class MultiEndpointMessageWriterTests
             resultMembers.Add(member);
         }
         Assert.Equal(resultCount, resultMembers.Count);
+        for (var i = 0; i < expectedTopsInInvocations.Length; i++)
+        {
+            containerMocks[i].Verify(c => c.ListConnectionsInGroupAsync("group", expectedTopsInInvocations[i], null), Times.Once());
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Common.Tests.ServiceConnections;
+public class MultiEndpointMessageWriterTests
+{
+    [Theory]
+    [InlineData(null, 6)]
+    [InlineData(5, 5)]
+    [InlineData(1, 1)]
+    [InlineData(7, 6)]
+    public async Task ListConnectionsInGroup(int? top, int resultCount)
+    {
+        var targetEndpoints = new List<HubServiceEndpoint>();
+        for (var i = 0; i < 2; i++)
+        {
+            var endpoint = new TestHubServiceEndpoint();
+            var resultFromConnectioContainer = MockAsyncEnumerable<GroupMember>.From(
+                new GroupMember { ConnectionId = "1" },
+                new GroupMember { ConnectionId = "2" },
+                new GroupMember { ConnectionId = "3" }
+            );
+            var connectionContainer = Mock.Of<IServiceConnectionContainer>(
+                c => c.ListConnectionsInGroupAsync(It.IsAny<string>(), It.IsAny<int?>(), null) == resultFromConnectioContainer);
+            endpoint.ConnectionContainer = connectionContainer;
+            targetEndpoints.Add(endpoint);
+        }
+        var multiEndpointWriter = new MultiEndpointMessageWriter(targetEndpoints, Mock.Of<ILoggerFactory>());
+        var resultMembers = new List<GroupMember>();
+        await foreach (var member in multiEndpointWriter.ListConnectionsInGroupAsync("group", top))
+        {
+            resultMembers.Add(member);
+        }
+        Assert.Equal(resultCount, resultMembers.Count);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ public class MultiEndpointMessageWriterTests
             );
             var containerMock = new Mock<IServiceConnectionContainer>();
             containerMocks.Add(containerMock);
-            containerMock.Setup(c => c.ListConnectionsInGroupAsync(It.IsAny<string>(), It.IsAny<int?>(), null))
+            containerMock.Setup(c => c.ListConnectionsInGroupAsync(It.IsAny<string>(), It.IsAny<int?>(), null, default))
                 .Returns(resultFromConnectioContainer);
             endpoint.ConnectionContainer = containerMock.Object;
             targetEndpoints.Add(endpoint);
@@ -45,7 +45,7 @@ public class MultiEndpointMessageWriterTests
         Assert.Equal(resultCount, resultMembers.Count);
         for (var i = 0; i < expectedTopsInInvocations.Length; i++)
         {
-            containerMocks[i].Verify(c => c.ListConnectionsInGroupAsync("group", expectedTopsInInvocations[i], null), Times.Once());
+            containerMocks[i].Verify(c => c.ListConnectionsInGroupAsync("group", expectedTopsInInvocations[i], null, default), Times.Once());
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/MockAsyncEnumerable.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/MockAsyncEnumerable.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.SignalR.Common.Tests;
+public class MockAsyncEnumerable<T>(IEnumerable<T> values) : IAsyncEnumerable<T>
+{
+    public static IAsyncEnumerable<Tp> From<Tp>(params Tp[] items) =>
+        new MockAsyncEnumerable<Tp>(items);
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+        new MockAsyncEnumerator<T>(values.GetEnumerator());
+
+    private sealed class MockAsyncEnumerator<Tp>(IEnumerator<Tp> enumerator) : IAsyncEnumerator<Tp>
+    {
+        public Tp Current => enumerator.Current;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(enumerator.MoveNext());
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -15,28 +15,33 @@ namespace Microsoft.Azure.SignalR.Tests.Common;
 
 #nullable enable
 
-internal class TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected,
-                                     bool throws = false,
-                                     ILogger? logger = null,
-                                     IServiceMessageHandler? serviceMessageHandler = null,
-                                     IServiceEventHandler? serviceEventHandler = null)
-    : ServiceConnectionBase(new ServiceProtocol(),
-                            "serverId",
-                            Guid.NewGuid().ToString(),
-                            new TestHubServiceEndpoint(),
-                            serviceMessageHandler,
-                            serviceEventHandler,
-                            new TestClientConnectionManager(),
-                            ServiceConnectionType.Default,
-                            logger ?? NullLogger.Instance)
+internal class TestServiceConnection : ServiceConnectionBase
 {
     private readonly TaskCompletionSource<object?> _created = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    private readonly bool _throws = throws;
+    private readonly bool _throws;
 
     private ConnectionContext? _connection;
 
-    private ServiceConnectionStatus _expectedStatus = status;
+    private ServiceConnectionStatus _expectedStatus;
+
+    public TestServiceConnection(ServiceConnectionStatus status = ServiceConnectionStatus.Connected,
+                                         bool throws = false,
+                                         ILogger? logger = null,
+                                         IServiceMessageHandler? serviceMessageHandler = null,
+                                         IServiceEventHandler? serviceEventHandler = null) : base(new ServiceProtocol(),
+                                "serverId",
+                                Guid.NewGuid().ToString(),
+                                new TestHubServiceEndpoint(),
+                                serviceMessageHandler,
+                                serviceEventHandler,
+                                new TestClientConnectionManager(),
+                                ServiceConnectionType.Default,
+                                logger ?? NullLogger.Instance)
+    {
+        _throws = throws;
+        SetStatus(status);
+    }
 
     public IDuplexPipe? Application { get; private set; }
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -109,4 +109,9 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
     {
         throw new NotImplementedException();
     }
+
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -110,7 +110,7 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
         throw new NotImplementedException();
     }
 
-    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top)
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
     {
         throw new NotImplementedException();
     }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;
@@ -111,6 +112,11 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
     }
 
     public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, CancellationToken token = default)
     {
         throw new NotImplementedException();
     }

--- a/test/Microsoft.Azure.SignalR.Tests/AckHandlerTest.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AckHandlerTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -75,4 +78,6 @@ public class AckHandlerTest
         var task = handler.CreateSingleAck(out var ackId);
         Assert.Throws<InvalidOperationException>(() => handler.SetExpectedCount(ackId, 2));
     }
+
+    // Test
 }


### PR DESCRIPTION
To expose presence API to the caller in the `IServiceConnectionContainer` interface, we have two choices:
1. Expose a low-layer method like "WriteXXXMessage", which accepts a `GroupMemberQueryMessage` parameter and return `GroupMemberQueryResponse`. However, the `MultipleEndpointServiceConnectionContainer` also implements this interface and has to implement this method. In multi-endpoint case, we have to have some aggregation logic on the results from all the endpoints. Then the verb `Write` cannot describe what has been done in multiple endpoint cases. Therefore we don't expose a low-layer method.
2. Expose a high-layer method `ListConnectionsInGroup`, to wrap operations including writing messages, fetch next pages according to `continuationToken`.