### PR TITLE
Update service protocol

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         public string GroupName { get; set; } = string.Empty;
 
         /// <summary>
-        /// The max count of connections to return. 
+        /// The max count of connections to return.
         /// </summary>
         public int? Top { get; set; }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -590,9 +590,9 @@ namespace Microsoft.Azure.SignalR.Protocol
         public string GroupName { get; set; } = string.Empty;
 
         /// <summary>
-        /// The max count of connections to return.
+        /// The max count of connections to return. 
         /// </summary>
-        public int Max { get; set; } = 200;
+        public int? Top { get; set; }
 
         /// <summary>
         /// A token to indiate the start point of results.

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -763,7 +763,14 @@ public class ServiceProtocol : IServiceProtocol
         message.WriteExtensionMembers(ref writer);
         writer.Write(message.GroupName);
         writer.Write(message.AckId);
-        writer.Write(message.Max);
+        if (message.Top != null)
+        {
+            writer.Write(message.Top.Value);
+        }
+        else
+        {
+            writer.WriteNil();
+        }
         writer.Write(message.ContinuationToken);
     }
 
@@ -1394,7 +1401,7 @@ public class ServiceProtocol : IServiceProtocol
         result.ReadExtensionMembers(ref reader);
         result.GroupName = ReadStringNotNull(ref reader, nameof(GroupMemberQueryMessage.GroupName));
         result.AckId = ReadInt32(ref reader, nameof(GroupMemberQueryMessage.AckId));
-        result.Max = ReadInt32(ref reader, nameof(GroupMemberQueryMessage.Max));
+        result.Top = reader.TryReadNil() ? null : ReadInt32(ref reader, nameof(GroupMemberQueryMessage.Top));
         result.ContinuationToken = ReadString(ref reader, nameof(GroupMemberQueryMessage.ContinuationToken));
         return result;
     }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         {
             return x.AckId == y.AckId &&
                    StringEqual(x.GroupName, y.GroupName) &&
-                   x.Max == y.Max &&
+                   x.Top == y.Top &&
                    StringEqual(x.ContinuationToken, y.ContinuationToken) &&
                    x.TracingId == y.TracingId;
         }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -704,7 +704,11 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 binary: "lSelY29ubjLSAAAAAtIAAAAEgA=="),
             new ProtocolTestData(
                 name: "GroupMemberQueryMessage",
-                message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1, Max = 10, ContinuationToken = "token", TracingId = 1234UL },
+                message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1 },
+                binary: "liiApWdyb3VwAcDA"),
+            new ProtocolTestData(
+                name: "GroupMemberQueryMessageWithOptionalFields",
+                message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1, Top = 10, ContinuationToken = "token", TracingId = 1234UL },
                 binary: "liiBAc0E0qVncm91cAEKpXRva2Vu"),
         }.ToDictionary(t => t.Name);
 


### PR DESCRIPTION
Rename the `Max` parameter to `Top` to make it clearer. 
Don't set a client-side default value for the `Top` parameter.