### PR TITLE
Add retryable Fact/Theory

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false # Disable the auto cancelling of all in-progress and queued jobs in the matrix if any job in the matrix fails.
       matrix:
-        dotnet-version: [ '9.0.x', '8.0.x' ]
+        dotnet-version: [ '8.0.x' ]
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2

--- a/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,27 +13,27 @@ namespace Microsoft.Azure.SignalR.Common.Tests
 {
     public class BackOffPolicyFacts : VerifiableLoggedTest
     {
-        private static TimeSpan _overrunLeeway = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan _overrunLeeway = TimeSpan.FromMilliseconds(250);
 
-        private static TimeSpan _underrunLeeway = TimeSpan.FromMilliseconds(50);
+        private static readonly TimeSpan _underrunLeeway = TimeSpan.FromMilliseconds(50);
 
-        private static TimeSpan DefaultBackOff = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan DefaultBackOff = TimeSpan.FromSeconds(2);
 
-        private static Func<int, TimeSpan> DefaultBackOffFunc = (i) => DefaultBackOff;
+        private static readonly Func<int, TimeSpan> DefaultBackOffFunc = (i) => DefaultBackOff;
 
-        private static TimeSpan _1stBackOff = TimeSpan.FromSeconds(1.5);
+        private static readonly TimeSpan _1stBackOff = TimeSpan.FromSeconds(1.5);
 
-        private static TimeSpan _2ndBackOff = TimeSpan.FromSeconds(2.5);
+        private static readonly TimeSpan _2ndBackOff = TimeSpan.FromSeconds(2.5);
 
-        private static TimeSpan _nxtBackOff = TimeSpan.FromSeconds(4.5);
+        private static readonly TimeSpan _nxtBackOff = TimeSpan.FromSeconds(4.5);
 
-        private TimeSpan _0s = TimeSpan.FromSeconds(0);
+        private readonly TimeSpan _0s = TimeSpan.FromSeconds(0);
 
-        private TimeSpan _1s = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan _1s = TimeSpan.FromSeconds(1);
 
-        private TimeSpan _2s = TimeSpan.FromSeconds(2);
+        private readonly TimeSpan _2s = TimeSpan.FromSeconds(2);
 
-        private TimeSpan _10s = TimeSpan.FromSeconds(10);
+        private readonly TimeSpan _10s = TimeSpan.FromSeconds(10);
 
         public BackOffPolicyFacts(ITestOutputHelper output) : base(output)
         {
@@ -44,9 +45,9 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             await RetryWhenExceptionThrows(async () => await RunProbeTests(new TestData()
             {
                 Params = new ProbeParam[] {
-                    new ProbeParam() {Result = true, Duration = _1s, Throws = false },
-                    new ProbeParam() {Result = true, Duration = _0s, Throws = false },
-                    new ProbeParam() {Result = true, Duration = _0s, Throws = false }
+                    new() {Result = true, Duration = _1s, Throws = false },
+                    new() {Result = true, Duration = _0s, Throws = false },
+                    new() {Result = true, Duration = _0s, Throws = false }
                 },
                 ExpectedCallTimes = new TimeSpan[] {
                     _0s,        // this gets called right away
@@ -56,17 +57,17 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             }));
         }
 
-        [Fact]
+        [RetryFact]
         public async Task First2ProbesUnsuccessfulTest()
         {
             await RetryWhenExceptionThrows(async () => await RunProbeTests(new TestData()
             {
                 Params = new ProbeParam[] {
-                    new ProbeParam() {                              Result = false, Duration = _1s, Throws = false },
-                    new ProbeParam() {                              Result = false, Duration = _1s, Throws = false },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false }
+                    new() {                              Result = false, Duration = _1s, Throws = false },
+                    new() {                              Result = false, Duration = _1s, Throws = false },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _0s, Throws = false }
                 },
                 ExpectedCallTimes = new TimeSpan[] {
                     _0s,                            // these first 2 compete to get called right away,
@@ -88,11 +89,11 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             await RetryWhenExceptionThrows(async () => await RunProbeTests(new TestData()
             {
                 Params = new ProbeParam[] {
-                    new ProbeParam() {                              Result = false, Duration = _0s, Throws=true },
-                    new ProbeParam() {                              Result = false, Duration = _0s, Throws=true },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false },
-                    new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false }
+                    new() {                              Result = false, Duration = _0s, Throws=true },
+                    new() {                              Result = false, Duration = _0s, Throws=true },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false },
+                    new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _1s, Throws=false }
                 },
                 ExpectedCallTimes = new TimeSpan[] {
                     _0s,                            // called right away, throws and induces first back off
@@ -111,11 +112,11 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             await RunProbeTests(new TestData()
             {
                 Params = new ProbeParam[] {
-                        new ProbeParam() {                              Result = false, Duration = _10s, Throws=false }, // t/o & fail
-                        new ProbeParam() {                              Result = false, Duration = _10s, Throws=true },  // t/o & throw
-                        new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false },
-                        new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false },
-                        new ProbeParam() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false }
+                        new() {                              Result = false, Duration = _10s, Throws=false }, // t/o & fail
+                        new() {                              Result = false, Duration = _10s, Throws=true },  // t/o & throw
+                        new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false },
+                        new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false },
+                        new() {InitialDelay = _2ndBackOff,   Result = true, Duration = _2s, Throws=false }
                 },
 
                 ExpectedCallTimes = new TimeSpan[] {
@@ -132,15 +133,15 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         private static async Task RunProbeTests(TestData testData)
         {
             // initialize a few things
-            int _funcCallNumber = 0;
+            var _funcCallNumber = 0;
             var policy = new BackOffPolicy();
             testData.Results = new ProbeResult[testData.Params.Length];
-            DateTime startTime = DateTime.UtcNow;
-            Task[] probeTestTasks = new Task[testData.Params.Length];
+            var startTime = DateTime.UtcNow;
+            var probeTestTasks = new Task[testData.Params.Length];
 
-            for (int i = 0; i < testData.Params.Length; i++)
+            for (var i = 0; i < testData.Params.Length; i++)
             {
-                int index = i;
+                var index = i;
                 var currentProbe = testData.Params[index];
                 testData.Results[index] = new ProbeResult();
 
@@ -179,14 +180,14 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             await Task.WhenAll(probeTestTasks);
 
             // verify
-            for (int i = 0; i < testData.Params.Length; i++)
+            for (var i = 0; i < testData.Params.Length; i++)
             {
                 var param = testData.Params[i];
                 var result = testData.Results[i];
 
                 Assert.Equal(1, result.ActualNumberOfCalls);
                 Assert.Equal(param.Result, result.ActualResult);
-                Assert.NotEqual((result.ActualException == null), param.Throws);
+                Assert.NotEqual(result.ActualException == null, param.Throws);
 
                 // knowing the actual order of the func call we can compare it with the expected time
                 // ActualCallOrder starts with 1

--- a/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.Common.Tests
 {
-    public class BackOffPolicyFacts : VerifiableLoggedTest
+    public class BackOffPolicyFacts(ITestOutputHelper output) : VerifiableLoggedTest(output)
     {
         private static readonly TimeSpan _overrunLeeway = TimeSpan.FromMilliseconds(250);
 
@@ -35,11 +35,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
 
         private readonly TimeSpan _10s = TimeSpan.FromSeconds(10);
 
-        public BackOffPolicyFacts(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RetryFact]
         public async Task AllProbesSuccessfulTest()
         {
             await RetryWhenExceptionThrows(async () => await RunProbeTests(new TestData()

--- a/test/Microsoft.Azure.SignalR.Common.Tests/CustomizedTimerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/CustomizedTimerTests.cs
@@ -5,171 +5,165 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
-namespace Microsoft.Azure.SignalR.Common.Tests
+namespace Microsoft.Azure.SignalR.Common.Tests;
+
+public class CustomizedTimerTests(ITestOutputHelper output) : VerifiableLoggedTest(output)
 {
-    public class CustomizedTimerTests : VerifiableLoggedTest
+    private const int BasePeriodMs = 400;
+
+    private static readonly TimeSpan BaseTs = TimeSpan.FromMilliseconds(BasePeriodMs);
+
+    private static readonly TimeSpan BaseTsPlus = TimeSpan.FromMilliseconds(BasePeriodMs * 1.2); // +20% leeway to avoid false positives
+
+    [RetryTheory]
+    // #stops == #starts
+    [InlineData(0, 1, 1, 0)]
+    [InlineData(3, 1, 1, 3)]
+    // #starts < #stops
+    [InlineData(1, 2, 3, 1)]
+    // #starts > #stops
+    [InlineData(1, 3, 2, 2)]
+    public async Task BasicStartStopTest(int timerTicks, int numStarts, int numStops, int expectedCallbacks)
     {
-        private const int BasePeriodMs = 400;
+        var loggerFactory = NullLoggerFactory.Instance;
 
-        private static readonly TimeSpan BaseTs = TimeSpan.FromMilliseconds(BasePeriodMs);
-
-        private static readonly TimeSpan BaseTsPlus = TimeSpan.FromMilliseconds(BasePeriodMs * 1.2); // +20% leeway to avoid false positives
-
-        public CustomizedTimerTests(ITestOutputHelper output) : base(output)
+        await RetryWhenExceptionThrows(async () =>
         {
-        }
+            var callbackCount = 0;
+            using var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
 
-        [Theory]
-        // #stops == #starts
-        [InlineData(0, 1, 1, 0)]
-        [InlineData(3, 1, 1, 3)]
-        // #starts < #stops
-        [InlineData(1, 2, 3, 1)]
-        // #starts > #stops
-        [InlineData(1, 3, 2, 2)]
-        public async Task BasicStartStopTest(int timerTicks, int numStarts, int numStops, int expectedCallbacks)
+            for (var i = 0; i < numStarts; i++)
+            {
+                timer.Start();
+            }
+            await Task.Delay(BaseTsPlus * timerTicks);
+            for (var i = 0; i < numStops; i++)
+            {
+                timer.Stop();
+            }
+
+            // special case check when numStops < numStarts
+            Assert.Equal(numStarts <= numStops ? expectedCallbacks : timerTicks, callbackCount);
+
+            await Task.Delay(BaseTsPlus * timerTicks);
+            Assert.Equal(expectedCallbacks, callbackCount);
+        });
+    }
+
+    [Fact]
+    public async Task StartStopStartStop()
+    {
+        if (Environment.OSVersion.Platform == PlatformID.Unix)
         {
-            var loggerFactory = NullLoggerFactory.Instance;
-
-            await RetryWhenExceptionThrows(async () =>
-            {
-                var callbackCount = 0;
-                using var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
-
-                for (var i = 0; i < numStarts; i++)
-                {
-                    timer.Start();
-                }
-                await Task.Delay(BaseTsPlus * timerTicks);
-                for (var i = 0; i < numStops; i++)
-                {
-                    timer.Stop();
-                }
-
-                // special case check when numStops < numStarts
-                Assert.Equal(numStarts <= numStops ? expectedCallbacks : timerTicks, callbackCount);
-
-                await Task.Delay(BaseTsPlus * timerTicks);
-                Assert.Equal(expectedCallbacks, callbackCount);
-            });
+            // it will fail in osx in github action, due to slow machine.
+            // skip it for now.
+            return;
         }
-
-        [Fact]
-        public async Task StartStopStartStop()
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                // it will fail in osx in github action, due to slow machine.
-                // skip it for now.
-                return;
-            }
-            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-            {
-                var callbackCount = 0;
-                using var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
+            var callbackCount = 0;
+            using var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
 
-                timer.Start();
-                await Task.Delay(BaseTsPlus);
-                timer.Stop();
-                Assert.Equal(1, callbackCount);
+            timer.Start();
+            await Task.Delay(BaseTsPlus);
+            timer.Stop();
+            Assert.Equal(1, callbackCount);
 
-                await Task.Delay(BaseTsPlus * 5);
+            await Task.Delay(BaseTsPlus * 5);
 
-                timer.Start();
-                await Task.Delay(BaseTsPlus);
-                timer.Stop();
-                Assert.Equal(2, callbackCount);
-            }
+            timer.Start();
+            await Task.Delay(BaseTsPlus);
+            timer.Stop();
+            Assert.Equal(2, callbackCount);
         }
+    }
 
-        [Fact]
-        public async Task StartStopDispose_StartDisposeStop()
+    [Fact]
+    public async Task StartStopDispose_StartDisposeStop()
+    {
+        if (Environment.OSVersion.Platform == PlatformID.Unix)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                // it will fail in osx in github action, due to slow machine.
-                // skip it for now.
-                return;
-            }
-            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-            {
-                var callbackCount = 0;
-                var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
-
-                timer.Start();
-                await Task.Delay(BaseTsPlus);
-                timer.Stop();
-                Assert.Equal(1, callbackCount);
-                await Task.Delay(BaseTsPlus * 5);
-                timer.Dispose();
-                Assert.Equal(1, callbackCount);
-
-                timer.Start();
-                await Task.Delay(BaseTsPlus);
-                timer.Dispose();
-                Assert.Equal(2, callbackCount);
-                await Task.Delay(BaseTsPlus * 5);
-                timer.Stop();
-                Assert.Equal(2, callbackCount);
-            }
+            // it will fail in osx in github action, due to slow machine.
+            // skip it for now.
+            return;
         }
-
-        [Theory]
-        [InlineData(2)]
-        [InlineData(3)]
-        public async Task LongRunningCallback(int timerTicks)
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
-            using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-            {
-                var callbackCount = 0;
+            var callbackCount = 0;
+            var timer = CreatePingTimer(loggerFactory, () => Interlocked.Increment(ref callbackCount));
 
-                using var timer = CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
-                    nameof(BasicStartStopTest)), nameof(BasicStartStopTest),
-                    async () =>
-                    {
-                        Interlocked.Increment(ref callbackCount);
-                        // long running task to make timer skip timerTicks callbacks
-                        await Task.Delay(BaseTsPlus * timerTicks);
-                    },
-                    BaseTs, BaseTs);
+            timer.Start();
+            await Task.Delay(BaseTsPlus);
+            timer.Stop();
+            Assert.Equal(1, callbackCount);
+            await Task.Delay(BaseTsPlus * 5);
+            timer.Dispose();
+            Assert.Equal(1, callbackCount);
 
-                timer.Start();
-                await Task.Delay(BaseTsPlus * 2 * timerTicks);
-                timer.Stop();
-                Assert.Equal(2, callbackCount);
-
-                // extra check it really stopped
-                await Task.Delay(BaseTsPlus * 2 * timerTicks);
-                Assert.Equal(2, callbackCount);
-            }
+            timer.Start();
+            await Task.Delay(BaseTsPlus);
+            timer.Dispose();
+            Assert.Equal(2, callbackCount);
+            await Task.Delay(BaseTsPlus * 5);
+            timer.Stop();
+            Assert.Equal(2, callbackCount);
         }
+    }
 
-        private static ServiceConnectionContainerBase.CustomizedPingTimer CreatePingTimer(ILoggerFactory loggerFactory, Action counter) =>
-            CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task LongRunningCallback(int timerTicks)
+    {
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
+        {
+            var callbackCount = 0;
+
+            using var timer = CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
                 nameof(BasicStartStopTest)), nameof(BasicStartStopTest),
-                () =>
+                async () =>
                 {
-                    counter();
-                    return Task.CompletedTask;
+                    Interlocked.Increment(ref callbackCount);
+                    // long running task to make timer skip timerTicks callbacks
+                    await Task.Delay(BaseTsPlus * timerTicks);
                 },
                 BaseTs, BaseTs);
 
-        private class CustomizedPingTimerFactory : ServiceConnectionContainerBase
-        {
-            private CustomizedPingTimerFactory(IServiceConnectionFactory serviceConnectionFactory, int minConnectionCount, HubServiceEndpoint endpoint, IReadOnlyList<IServiceConnection> initialConnections = null, ILogger logger = null, AckHandler ackHandler = null) : base(serviceConnectionFactory, minConnectionCount, endpoint, initialConnections, logger, ackHandler)
-            {
-            }
+            timer.Start();
+            await Task.Delay(BaseTsPlus * 2 * timerTicks);
+            timer.Stop();
+            Assert.Equal(2, callbackCount);
 
-            internal static CustomizedPingTimer CreateCustomizedPingTimer(ILogger logger, string name, Func<Task> func, TimeSpan due, TimeSpan interval) =>
-                new CustomizedPingTimer(logger, name, func, due, interval);
+            // extra check it really stopped
+            await Task.Delay(BaseTsPlus * 2 * timerTicks);
+            Assert.Equal(2, callbackCount);
         }
+    }
+
+    private static ServiceConnectionContainerBase.CustomizedPingTimer CreatePingTimer(ILoggerFactory loggerFactory, Action counter) =>
+        CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
+            nameof(BasicStartStopTest)), nameof(BasicStartStopTest),
+            () =>
+            {
+                counter();
+                return Task.CompletedTask;
+            },
+            BaseTs, BaseTs);
+
+    private class CustomizedPingTimerFactory : ServiceConnectionContainerBase
+    {
+        private CustomizedPingTimerFactory(IServiceConnectionFactory serviceConnectionFactory, int minConnectionCount, HubServiceEndpoint endpoint, IReadOnlyList<IServiceConnection> initialConnections = null, ILogger logger = null, AckHandler ackHandler = null) : base(serviceConnectionFactory, minConnectionCount, endpoint, initialConnections, logger, ackHandler)
+        {
+        }
+
+        internal static CustomizedPingTimer CreateCustomizedPingTimer(ILogger logger, string name, Func<Task> func, TimeSpan due, TimeSpan interval) =>
+            new CustomizedPingTimer(logger, name, func, due, interval);
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
@@ -23,475 +23,447 @@ using Xunit;
 using Xunit.Abstractions;
 using AspNetTestServer = Microsoft.AspNetCore.TestHost.TestServer;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests
+namespace Microsoft.Azure.SignalR.IntegrationTests;
+
+public class MessageOrderTests(ITestOutputHelper output) : VerifiableLoggedTest(output)
 {
-    public class MessageOrderTests : VerifiableLoggedTest
+    private static readonly JsonHubProtocol SignalRPro = new();
+
+    private readonly ITestOutputHelper _output = output;
+
+    public static async Task<List<WeakReference>> BroadcastAndHotReloadAllEndpoints(AspNetTestServer server)
     {
-        private readonly ITestOutputHelper _output;
+        // Part1: broadcast messages over initial set of endpoints
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<HotReloadTestHub>>() as MockServiceHubDispatcher<HotReloadTestHub>).MockService;
+        await mockSvc.AllConnectionsEstablished();
+        var allSvcConns0 = mockSvc.ServiceSideConnections;
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
 
-        public MessageOrderTests(ITestOutputHelper output) : base(output)
+        var priList = allSvcConns0.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
+        var primarySvc0 = priList[0];
+        var client0 = await primarySvc0.ConnectClientAsync();
+
+        const int msgNum = 10;
+        await client0.SendMessage("BroadcastNumCalls", [msgNum]).OrTimeout();
+
+        // Todo: properly drain messages from this hub call before hot reload
+        // (otherwise they appear on the new endpoints)
+        await Task.Delay(3333); // a small delay will normally be enough
+
+        // check and save the refs to the old connections before hot reload
+        var wrList = new List<WeakReference>();
+
+        foreach (var svcConn in allSvcConns0)
         {
-            _output = output;
+            Assert.NotNull(svcConn.SDKSideServiceConnection);
+            wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection));
+
+            Assert.NotNull(svcConn.SDKSideServiceConnection.MyMockServiceConnetion);
+            wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection.MyMockServiceConnetion));
+
+            Assert.NotNull(svcConn.SDKSideServiceConnection.MyMockServiceConnetion.InnerServiceConnection);
+            wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection.MyMockServiceConnetion.InnerServiceConnection));
+
+            Assert.NotNull(svcConn.Endpoint);
+            wrList.Add(new WeakReference(svcConn.Endpoint));
         }
 
-        [Fact]
-        // verifies that outgoing messages from a hub call:
-        // - use the same primary service connection the hub call was made from
-        // - pick and stick to the same secondary connection(s)
-        public async Task OutgoingMessagesUseSameServiceConnection()
+        // Part2: hot reload and until the old connections are all gone
+        mockSvc.RemoveUnregisteredConnections = true;
+        HotReloadIntegrationTestStartup<HotReloadMessageOrderTestParams, HotReloadTestHub>.ReloadConfig(index: 1);
+
+        List<MockServiceSideConnection> allSvcConnsNew = null;
+        var allNew = false;
+        do
         {
-            var builder = WebHost.CreateDefaultBuilder()
-                .ConfigureServices((IServiceCollection services) => { })
-                .ConfigureLogging(logging => logging.AddXunit(_output))
-                .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, UseSameServiceConnectionHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<UseSameServiceConnectionHub>>()
-                as MockServiceHubDispatcher<UseSameServiceConnectionHub>).MockService;
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var allSvcConns = mockSvc.ServiceSideConnections;
-
-            // A few extra checks (just for this initial test to verify more invariants)
-            // Each ServiceEndpoint will have ConnectionCount connections
-            Assert.Equal(
-                MockServiceMessageOrderTestParams.ConnectionCount * MockServiceMessageOrderTestParams.ServiceEndpoints.Length,
-                allSvcConns.Count);
-            var endpointCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
-            Assert.Equal(MockServiceMessageOrderTestParams.ServiceEndpoints.Length, endpointCount);
-
-            // specify invocation binder before making calls
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-
-            // pick a random primary svc connection to make a client connection
-            var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
-            await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
-            var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
-
-            const int MsgNum = 10;
-            await client0.SendMessage("BroadcastNumCalls", new object[] { MsgNum }).OrTimeout();
-            var counts = await DrainBroadcastMessages(endpointCount, MsgNum, mockSvc).OrTimeout();
-
-            // Did we got the expected number of calls and all of them stick to exactly one primary?
-            var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
-            Assert.Single(primary);
-
-            // the primary is the one we used to send client message
-            Assert.Equal(primarySvc0, primary.FirstOrDefault().Key);
-
-            // the primary received MsgNum messages
-            Assert.Equal(MsgNum, primary.FirstOrDefault().Value);
-
-            // for every secondary that received the messages verify that
-            // - their number equals to the number of seconary endpoints
-            // - each received N messages
-            var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
-            var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
-            Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
-            foreach (var conn in secondary)
-            {
-                Assert.Equal(MsgNum, conn.Value);
-            }
-        }
-
-        // Helper method to pull raw messages received by the mock service and count them per service connection
-        private static async Task<ConcurrentDictionary<MockServiceSideConnection, int>> DrainBroadcastMessages(
-            int endpointCount, int msgNum, IMockService mockSvc,
-            ConcurrentDictionary<MockServiceSideConnection, int> counts = null)
-        {
-            counts ??= new ConcurrentDictionary<MockServiceSideConnection, int>();
-
-            // Each endpoint will get the broadcast message so we should receive endpointCount * MsgNum messages
-            for (var ep = 0; ep < endpointCount * msgNum; ep++)
-            {
-                // we go "peek then take" route because we don't know which secondary connection will receive the messages
-                var connWithMessage = await Task.WhenAny(mockSvc.ServiceSideConnections.Select(async c =>
-                {
-                    var moreData = await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
-                    Assert.True(moreData);
-                    return (c, moreData);
-                }));
-
-                var conn = connWithMessage.Result.c;
-                var newMsg = await conn.DequeueMessageAsync<BroadcastDataMessage>();
-
-                var msgCount = counts.GetOrAdd(conn, 0);
-                counts[conn] = ++msgCount;
-
-                // parse each BroadcastDataMessage and verify this is the correct message
-                var hubMessage = ParseBroadcastDataMessageJson(newMsg, mockSvc.CurrentInvocationBinder);
-                Assert.True(hubMessage is InvocationMessage);
-                var invMsg = hubMessage as InvocationMessage;
-                Assert.Equal("Callback", invMsg.Target);
-
-                // finally, get ready to verify the order of messages
-                var actualCallbackNum = (int)invMsg.Arguments[0];
-
-                // this check works for both primary and secondary connections
-                Assert.Equal(msgCount, actualCallbackNum);
-            }
-            // todo: verify we received no extra BroadcastDataMessage - need TryPeek method (async with timeout?)
-            return counts;
-        }
-
-        // Todo: helper for scenarios where we recycle connections so mockSvc contains a mixture of old (closed) and new (active) connections
-        //static async Task WaitForAllNewConnectionsEstablished(IMockService mockSvc, int expectedActiveConnCount)
-
-        [RetryFact]
-        // verifies that when original outboud service connection associated with the hub call is closed:
-        // - a new service connection for each endpoint is selected 
-        // - all subsequent messages use newly selected service connections
-        // Note 1: this test is for a scenario which already has much weaker message order guarantees
-        // because switching from one connection to another may lead to out of order messages.
-        // However there are valid scenarios when the outboud messages are only sent after the original connection is closed.
-        // In this case all the messages will be sent over a new connection and the order will be preserved.
-        // Note 2: there are multiple ways to close service connection. In this test we ask the mock service to close the pipe.
-        // There are several other cases when SDK initiates disconnect which we didn't test here.
-        // In either case we need to wait for the connection to be "fully closed" before sending messages.
-        public async Task OutgoingMessagesSwitchOverToNewServiceConnection()
-        {
-            // step 0: create initial connections
-            var builder = WebHost.CreateDefaultBuilder()
-                .ConfigureServices((IServiceCollection services) => { })
-                .ConfigureLogging(logging => logging.AddXunit(_output))
-                .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, SwitchOverToNewServiceConnectionHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>>()
-                as MockServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>).MockService;
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var allSvcConns = mockSvc.ServiceSideConnections;
-            var primarySvc0 = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
-            var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
-
-            // step 1: broadcast a message to figure out secondary connection selections
-            // we already know the primary connection (primarySvc0) but not the secondary one(s)
-            // which will only be selected at the first outgoing message to the service
-            await client0.SendMessage("BroadcastNumCalls", new object[] { 1 }).OrTimeout();
-            var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
-            var connSelections = new ConcurrentBag<MockServiceSideConnection>();
-
-            for (var ep = 0; ep < epCount; ep++)
-            {
-                var connReceivedMessage = await Task.WhenAny(allSvcConns.Select(async c =>
-                {
-                    await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
-                    return c;
-                }));
-                connSelections.Add(connReceivedMessage.Result);
-                await connReceivedMessage.Result.DequeueMessageAsync<BroadcastDataMessage>().OrTimeout();
-            }
-
-            // sanity checks
-            Assert.Equal(primarySvc0, connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault());
-            var secondaryEpCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary).Count();
-            var secondaryReceivedCount = connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary).Count();
-            Assert.Equal(secondaryEpCount, secondaryReceivedCount);
-
-            // step 2: call hub and drop all the connections associated with the current client
-            const int MsgNum = 10;
-            await client0.SendMessage("BroadcastNumCallsAfterDisconnected", new object[] { MsgNum }).OrTimeout();
-            foreach (var secConnUsed in connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary))
-            {
-                await secConnUsed.StopAsync().OrTimeout();
-            }
-            await primarySvc0.StopAsync().OrTimeout();
-
-            // step 3: drain and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
-
-            // step 4: verify the connections that received messages
-            var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
-            Assert.Single(primary);
-            // the primary is NOT the one we used to send client message
-            Assert.NotEqual(primary.FirstOrDefault().Key, primarySvc0);
-            // and it received MsgNum messages
-            Assert.Equal(MsgNum, primary.FirstOrDefault().Value);
-
-            // for every secondary verify that
-            // - their number equals to the number of seconary endpoints
-            // - each received MsgNum messages
-            // - each of the secondary ones is not the same as the original selection
-            var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
-            var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
-            Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
-            foreach (var newSecCon in secondary)
-            {
-                // none of the new secondary connections are the same as the ones initially used
-                foreach (var oldSecCon in connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary))
-                {
-                    Assert.NotEqual(newSecCon.Key, oldSecCon);
-                }
-                // each of the new secondary connections received MsgNum messages
-                Assert.Equal(MsgNum, newSecCon.Value);
-            }
-        }
-
-        [Fact]
-        // App server may continue sending messages after both the hub call is finished and the client connection is closed.
-        // This test verifies the following strong guarantees:
-        // - outgoing messages continue to use the same service connection
-        // - the order of messages is preserved
-        // This test also verifies that all hub calls over the same client connection 
-        // stick to the same primary and secondary service connections
-        public async Task OutgoingMessagesOnSameServiceConnectionAfterClientConnectionClosed()
-        {
-            // step 0: initialize
-            var builder = WebHost.CreateDefaultBuilder()
-                .ConfigureServices((IServiceCollection services) => { })
-                .ConfigureLogging(logging => logging.AddXunit(_output))
-                .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, SameSvcConnAfterClientConnectionClosedHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SameSvcConnAfterClientConnectionClosedHub>>() as MockServiceHubDispatcher<SameSvcConnAfterClientConnectionClosedHub>).MockService;
-            var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var allSvcConns = mockSvc.ServiceSideConnections;
-            await using var primarySvc0 = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
-            var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
-
-            // step 1: make sure we know initial connection selections before disconnecting the client
-            // make 2 calls to also verify that subsequent calls stick to previous selections
-            await client0.SendMessage("BroadcastNumCalls", new object[] { /*numCalls*/ 1, /*countOffset*/ 0 });
-            await client0.SendMessage("BroadcastNumCalls", new object[] { /*numCalls*/ 1, /*countOffset*/ 1 });
-            var counts = await DrainBroadcastMessages(epCount, 2, mockSvc).OrTimeout();
-
-            // step 2: call hub and drop the client connection
-            const int MsgNum = 10;
-            const int countOffset = 2; // account for 2 extra messages sent before we disconnected the client
-            await client0.SendMessage("BroadcastNumCallsAfterDisconnected", new object[] { MsgNum, countOffset });
-            await client0.CloseConnection();
-
-            // step 3: receive and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
-            await DrainBroadcastMessages(epCount, MsgNum, mockSvc, counts).OrTimeout();
-
-            // step 4: verify the connections that received messages
-            var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
-            Assert.Single(primary);
-            // the primary is the one we used to send client message
-            Assert.Equal(primarySvc0, primary.FirstOrDefault().Key);
-            // and it received N + 2 messages
-            Assert.Equal(MsgNum + countOffset, primary.FirstOrDefault().Value);
-
-            // for every secondary verify that
-            // - their number equals to the number of seconary endpoints
-            // - each received N + 2 messages
-            // - each of the secondary ones is the same as the original selection
-            var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
-            var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
-            Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
-            foreach (var secCon in secondary)
-            {
-                // each of the new secondary connections received MsgNum + 2 (including initial 2 calls) messages
-                Assert.Equal(MsgNum + countOffset, secCon.Value);
-            }
-        }
-
-        [Fact]
-        // Hub method is not flowing execution context but using ClientConnectionScope instead
-        public async Task OutgoingMessagesWithoutExecutionContextFlow()
-        {
-            var builder = WebHost.CreateDefaultBuilder()
-                 .ConfigureServices((IServiceCollection services) => { })
-                 .ConfigureLogging(logging => logging.AddXunit(_output))
-                 .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, NoExecutionContextFlowHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<NoExecutionContextFlowHub>>() as MockServiceHubDispatcher<NoExecutionContextFlowHub>).MockService;
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var allSvcConns = mockSvc.ServiceSideConnections;
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-            var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
-            await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
-            var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
-
-            const int MsgNum = 10;
-            await client0.SendMessage("BroadcastNumCallsNotFlowing", new object[] { MsgNum }).OrTimeout();
-            var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
-
-            var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
-
-            Assert.Equal(MockServiceMessageOrderTestParams.ServiceEndpoints.Count(), counts.Count());
-            foreach (var conn in counts)
-            {
-                Assert.Equal(MsgNum, conn.Value);
-            }
-        }
-
-        [Fact]
-        // OnConnectedAsync and regular hub method calls should have the same connection selection for the same client connection
-        // This test verifies this by sending messages from both and verifying the message order.
-        public async Task OutgoingMessagesMultipleContexts()
-        {
-            var builder = WebHost.CreateDefaultBuilder()
-                 .ConfigureServices((IServiceCollection services) => { })
-                 .ConfigureLogging(logging => logging.AddXunit(_output))
-                 .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, MultipleContextsHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<MultipleContextsHub>>() as MockServiceHubDispatcher<MultipleContextsHub>).MockService;
-            await mockSvc.AllConnectionsEstablished().OrTimeout();
-            var allSvcConns = mockSvc.ServiceSideConnections;
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-            var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
-            await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
-            var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
-
-            var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
-            const int MsgNum = 10;
-            await client0.SendMessage("BroadcastNumCallsMultipleContexts", new object[] { MsgNum }).OrTimeout();
-            var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
-
-            Assert.Equal(counts.Count(), MockServiceMessageOrderTestParams.ServiceEndpoints.Count());
-            foreach (var conn in counts)
-            {
-                Assert.Equal(MsgNum, conn.Value);
-            }
-        }
-
-        // Config hot reload allows adding & removing endpoints and corresponding service connections
-        // This test verifies that when new endpoits are added, they will be selected for new connections.
-        // When old endpoints are removed, the corresponding previously used connections are not leaked.
-        //
-        // The test makes a service connection C over endpoint E, then makes a hub call which runs a new task.
-        // This new task sends messages to the service and its execution context carries connection selection info.
-        // When the endpoint E is removed as the result of config hot reload, the corresponding connection C is closed.
-        // However the task spawned in the hub call still carries the previous connection selection information.
-        //
-        // To verify that there are no leaks after the hot reload we wrap the references to the old connection C and endpoint E
-        // in weak reference handles and induce a full GC. Then we check if the the weak references targets are nulled out.
-        [RetryFact]
-        public async Task PreviouslyUsedServiceConnectionsNotLeakedAfterHotReload2()
-        {
-            var builder = WebHost.CreateDefaultBuilder()
-                 .ConfigureServices((IServiceCollection services) => { })
-                 .ConfigureLogging(logging => logging.AddXunit(_output))
-                 .UseStartup<HotReloadIntegrationTestStartup<HotReloadMessageOrderTestParams, HotReloadTestHub>>();
-
-            using var server = new AspNetTestServer(builder);
-            var wrList = await BroadcastAndHotReloadAllEndpoints(server);
-
-            // here we assume that 2 GCs and 1 finalizer are enough
-            await Task.Delay(3300);
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            await Task.Delay(3300);
-            GC.Collect();
-
-            foreach (var wr in wrList)
-            {
-                var o = wr.Target;
-                Assert.Null(o);
-            }
-        }
-
-        public async Task<List<WeakReference>> BroadcastAndHotReloadAllEndpoints(AspNetTestServer server)
-        {
-            // Part1: broadcast messages over initial set of endpoints
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<HotReloadTestHub>>() as MockServiceHubDispatcher<HotReloadTestHub>).MockService;
+            await Task.Delay(TimeSpan.FromSeconds(3));
             await mockSvc.AllConnectionsEstablished();
-            var allSvcConns0 = mockSvc.ServiceSideConnections;
-            mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
-
-            var priList = allSvcConns0.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
-            var primarySvc0 = priList[0];
-            var client0 = await primarySvc0.ConnectClientAsync();
-
-            const int MsgNum = 10;
-            await client0.SendMessage("BroadcastNumCalls", new object[] { MsgNum }).OrTimeout();
-
-            // Todo: properly drain messages from this hub call before hot reload
-            // (otherwise they appear on the new endpoints)
-            await Task.Delay(3333); // a small delay will normally be enough
-
-            // check and save the refs to the old connections before hot reload
-            var wrList = new List<WeakReference>();
-
-            foreach (var svcConn in allSvcConns0)
+            allSvcConnsNew = mockSvc.ServiceSideConnections;
+            var newEndpoints = HotReloadMessageOrderTestParams.AllEndpoints[1];
+            if (allSvcConnsNew.Count != newEndpoints.Length)
             {
-                Assert.NotNull(svcConn.SDKSideServiceConnection);
-                wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection));
-
-                Assert.NotNull(svcConn.SDKSideServiceConnection.MyMockServiceConnetion);
-                wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection.MyMockServiceConnetion));
-
-                Assert.NotNull(svcConn.SDKSideServiceConnection.MyMockServiceConnetion.InnerServiceConnection);
-                wrList.Add(new WeakReference(svcConn.SDKSideServiceConnection.MyMockServiceConnetion.InnerServiceConnection));
-
-                Assert.NotNull(svcConn.Endpoint);
-                wrList.Add(new WeakReference(svcConn.Endpoint));
+                continue;
             }
 
-            // Part2: hot reload and until the old connections are all gone
-            mockSvc.RemoveUnregisteredConnections = true;
-            HotReloadIntegrationTestStartup<HotReloadMessageOrderTestParams, HotReloadTestHub>.ReloadConfig(index: 1);
-
-            List<MockServiceSideConnection> allSvcConnsNew = null;
-            var allNew = false;
-            do
+            foreach (var ep in HotReloadMessageOrderTestParams.AllEndpoints[1])
             {
-                await Task.Delay(TimeSpan.FromSeconds(3));
-                await mockSvc.AllConnectionsEstablished();
-                allSvcConnsNew = mockSvc.ServiceSideConnections;
-                var newEndpoints = HotReloadMessageOrderTestParams.AllEndpoints[1];
-                if (allSvcConnsNew.Count != newEndpoints.Length)
+                allNew = true;
+                var foundEp = false;
+                foreach (var conn in allSvcConnsNew)
                 {
-                    continue;
-                }
-
-                foreach (var ep in HotReloadMessageOrderTestParams.AllEndpoints[1])
-                {
-                    allNew = true;
-                    var foundEp = false;
-                    foreach (var conn in allSvcConnsNew)
+                    if (conn.Endpoint.ConnectionString == ep.Value)
                     {
-                        if (conn.Endpoint.ConnectionString == ep.Value)
-                        {
-                            foundEp = true;
-                            break;
-                        }
-                    }
-                    if (!foundEp)
-                    {
-                        allNew = false;
+                        foundEp = true;
                         break;
                     }
                 }
-            } while (!allNew);
-
-            // Part3: send message over the new set of endpoints and verify that only the new endpoints are used
-            var primarySvc1 = allSvcConnsNew.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
-            var endpointCount = allSvcConnsNew.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
-            var client1 = await primarySvc1.ConnectClientAsync().OrTimeout();
-            await client1.SendMessage("BroadcastNumCalls", new object[] { MsgNum }).OrTimeout();
-
-            var counts = await DrainBroadcastMessages(endpointCount, MsgNum, mockSvc);
-
-            Assert.Equal(HotReloadMessageOrderTestParams.AllEndpoints[1].Count(), counts.Count());
-            foreach (var conn in counts)
-            {
-                Assert.Equal(MsgNum, conn.Value);
-            }
-            return wrList;
-        }
-
-        private static readonly JsonHubProtocol _signalRPro = new();
-        private static HubMessage ParseBroadcastDataMessageJson(BroadcastDataMessage bdm, IInvocationBinder binder)
-        {
-            foreach (var payload in bdm.Payloads)
-            {
-                if (payload.Key == "json")
+                if (!foundEp)
                 {
-                    var sequence = new ReadOnlySequence<byte>(payload.Value);
-                    if (_signalRPro.TryParseMessage(ref sequence, binder, out var signalRRRmessage))
-                    {
-                        return signalRRRmessage;
-                    }
+                    allNew = false;
+                    break;
                 }
             }
-            return null;
+        } while (!allNew);
+
+        // Part3: send message over the new set of endpoints and verify that only the new endpoints are used
+        var primarySvc1 = allSvcConnsNew.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
+        var endpointCount = allSvcConnsNew.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+        var client1 = await primarySvc1.ConnectClientAsync().OrTimeout();
+        await client1.SendMessage("BroadcastNumCalls", [msgNum]).OrTimeout();
+
+        var counts = await DrainBroadcastMessages(endpointCount, msgNum, mockSvc);
+
+        Assert.Equal(HotReloadMessageOrderTestParams.AllEndpoints[1].Length, counts.Count);
+        foreach (var conn in counts)
+        {
+            Assert.Equal(msgNum, conn.Value);
         }
+        return wrList;
+    }
+
+    [Fact]
+    public async Task OutgoingMessagesUseSameServiceConnection()
+    {
+        var builder = WebHost.CreateDefaultBuilder()
+            .ConfigureServices((IServiceCollection services) => { })
+            .ConfigureLogging(logging => logging.AddXunit(_output))
+            .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, UseSameServiceConnectionHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<UseSameServiceConnectionHub>>()
+            as MockServiceHubDispatcher<UseSameServiceConnectionHub>).MockService;
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var allSvcConns = mockSvc.ServiceSideConnections;
+
+        // A few extra checks (just for this initial test to verify more invariants)
+        // Each ServiceEndpoint will have ConnectionCount connections
+        Assert.Equal(
+            MockServiceMessageOrderTestParams.ConnectionCount * MockServiceMessageOrderTestParams.ServiceEndpoints.Length,
+            allSvcConns.Count);
+        var endpointCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+        Assert.Equal(MockServiceMessageOrderTestParams.ServiceEndpoints.Length, endpointCount);
+
+        // specify invocation binder before making calls
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
+
+        // pick a random primary svc connection to make a client connection
+        var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
+        await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
+        var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
+
+        const int msgNum = 10;
+        await client0.SendMessage("BroadcastNumCalls", [msgNum]).OrTimeout();
+        var counts = await DrainBroadcastMessages(endpointCount, msgNum, mockSvc).OrTimeout();
+
+        // Did we got the expected number of calls and all of them stick to exactly one primary?
+        var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
+        Assert.Single(primary);
+
+        // the primary is the one we used to send client message
+        Assert.Equal(primarySvc0, primary.FirstOrDefault().Key);
+
+        // the primary received MsgNum messages
+        Assert.Equal(msgNum, primary.FirstOrDefault().Value);
+
+        // for every secondary that received the messages verify that
+        // - their number equals to the number of seconary endpoints
+        // - each received N messages
+        var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
+        var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
+        Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
+        foreach (var conn in secondary)
+        {
+            Assert.Equal(msgNum, conn.Value);
+        }
+    }
+
+    // Todo: helper for scenarios where we recycle connections so mockSvc contains a mixture of old (closed) and new (active) connections
+    //static async Task WaitForAllNewConnectionsEstablished(IMockService mockSvc, int expectedActiveConnCount)
+    [RetryFact]
+    public async Task OutgoingMessagesSwitchOverToNewServiceConnection()
+    {
+        // step 0: create initial connections
+        var builder = WebHost.CreateDefaultBuilder()
+            .ConfigureServices((IServiceCollection services) => { })
+            .ConfigureLogging(logging => logging.AddXunit(_output))
+            .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, SwitchOverToNewServiceConnectionHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>>()
+            as MockServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>).MockService;
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var allSvcConns = mockSvc.ServiceSideConnections;
+        var primarySvc0 = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
+        var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
+
+        // step 1: broadcast a message to figure out secondary connection selections
+        // we already know the primary connection (primarySvc0) but not the secondary one(s)
+        // which will only be selected at the first outgoing message to the service
+        await client0.SendMessage("BroadcastNumCalls", [1]).OrTimeout();
+        var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
+        var connSelections = new ConcurrentBag<MockServiceSideConnection>();
+
+        for (var ep = 0; ep < epCount; ep++)
+        {
+            var connReceivedMessage = await Task.WhenAny(allSvcConns.Select(async c =>
+            {
+                await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
+                return c;
+            }));
+            connSelections.Add(connReceivedMessage.Result);
+            await connReceivedMessage.Result.DequeueMessageAsync<BroadcastDataMessage>().OrTimeout();
+        }
+
+        // sanity checks
+        Assert.Equal(primarySvc0, connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault());
+        var secondaryEpCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary).Count();
+        var secondaryReceivedCount = connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary).Count();
+        Assert.Equal(secondaryEpCount, secondaryReceivedCount);
+
+        // step 2: call hub and drop all the connections associated with the current client
+        const int msgNum = 10;
+        await client0.SendMessage("BroadcastNumCallsAfterDisconnected", [msgNum]).OrTimeout();
+        foreach (var secConnUsed in connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary))
+        {
+            await secConnUsed.StopAsync().OrTimeout();
+        }
+        await primarySvc0.StopAsync().OrTimeout();
+
+        // step 3: drain and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var counts = await DrainBroadcastMessages(epCount, msgNum, mockSvc).OrTimeout();
+
+        // step 4: verify the connections that received messages
+        var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
+        Assert.Single(primary);
+        // the primary is NOT the one we used to send client message
+        Assert.NotEqual(primary.FirstOrDefault().Key, primarySvc0);
+        // and it received MsgNum messages
+        Assert.Equal(msgNum, primary.FirstOrDefault().Value);
+
+        // for every secondary verify that
+        // - their number equals to the number of seconary endpoints
+        // - each received MsgNum messages
+        // - each of the secondary ones is not the same as the original selection
+        var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
+        var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
+        Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
+        foreach (var newSecCon in secondary)
+        {
+            // none of the new secondary connections are the same as the ones initially used
+            foreach (var oldSecCon in connSelections.Where(c => c.Endpoint.EndpointType == EndpointType.Secondary))
+            {
+                Assert.NotEqual(newSecCon.Key, oldSecCon);
+            }
+            // each of the new secondary connections received MsgNum messages
+            Assert.Equal(msgNum, newSecCon.Value);
+        }
+    }
+
+    [Fact]
+    public async Task OutgoingMessagesOnSameServiceConnectionAfterClientConnectionClosed()
+    {
+        // step 0: initialize
+        var builder = WebHost.CreateDefaultBuilder()
+            .ConfigureServices((IServiceCollection services) => { })
+            .ConfigureLogging(logging => logging.AddXunit(_output))
+            .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, SameSvcConnAfterClientConnectionClosedHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SameSvcConnAfterClientConnectionClosedHub>>() as MockServiceHubDispatcher<SameSvcConnAfterClientConnectionClosedHub>).MockService;
+        var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var allSvcConns = mockSvc.ServiceSideConnections;
+        await using var primarySvc0 = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
+        var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
+
+        // step 1: make sure we know initial connection selections before disconnecting the client
+        // make 2 calls to also verify that subsequent calls stick to previous selections
+        await client0.SendMessage("BroadcastNumCalls", [/*numCalls*/ 1, /*countOffset*/ 0]);
+        await client0.SendMessage("BroadcastNumCalls", [/*numCalls*/ 1, /*countOffset*/ 1]);
+        var counts = await DrainBroadcastMessages(epCount, 2, mockSvc).OrTimeout();
+
+        // step 2: call hub and drop the client connection
+        const int msgNum = 10;
+        const int countOffset = 2; // account for 2 extra messages sent before we disconnected the client
+        await client0.SendMessage("BroadcastNumCallsAfterDisconnected", [msgNum, countOffset]);
+        await client0.CloseConnection();
+
+        // step 3: receive and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
+        await DrainBroadcastMessages(epCount, msgNum, mockSvc, counts).OrTimeout();
+
+        // step 4: verify the connections that received messages
+        var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
+        Assert.Single(primary);
+        // the primary is the one we used to send client message
+        Assert.Equal(primarySvc0, primary.FirstOrDefault().Key);
+        // and it received N + 2 messages
+        Assert.Equal(msgNum + countOffset, primary.FirstOrDefault().Value);
+
+        // for every secondary verify that
+        // - their number equals to the number of seconary endpoints
+        // - each received N + 2 messages
+        // - each of the secondary ones is the same as the original selection
+        var secondary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Secondary);
+        var secondaryEndpoints = MockServiceMessageOrderTestParams.ServiceEndpoints.Where(ep => ep.EndpointType == EndpointType.Secondary);
+        Assert.Equal(secondaryEndpoints.Count(), secondary.Count());
+        foreach (var secCon in secondary)
+        {
+            // each of the new secondary connections received MsgNum + 2 (including initial 2 calls) messages
+            Assert.Equal(msgNum + countOffset, secCon.Value);
+        }
+    }
+
+    [Fact]
+    public async Task OutgoingMessagesWithoutExecutionContextFlow()
+    {
+        var builder = WebHost.CreateDefaultBuilder()
+             .ConfigureServices((IServiceCollection services) => { })
+             .ConfigureLogging(logging => logging.AddXunit(_output))
+             .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, NoExecutionContextFlowHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<NoExecutionContextFlowHub>>() as MockServiceHubDispatcher<NoExecutionContextFlowHub>).MockService;
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var allSvcConns = mockSvc.ServiceSideConnections;
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
+        var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
+        await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
+        var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
+
+        const int msgNum = 10;
+        await client0.SendMessage("BroadcastNumCallsNotFlowing", [msgNum]).OrTimeout();
+        var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+
+        var counts = await DrainBroadcastMessages(epCount, msgNum, mockSvc).OrTimeout();
+
+        Assert.Equal(MockServiceMessageOrderTestParams.ServiceEndpoints.Length, counts.Count);
+        foreach (var conn in counts)
+        {
+            Assert.Equal(msgNum, conn.Value);
+        }
+    }
+
+    [Fact]
+    public async Task OutgoingMessagesMultipleContexts()
+    {
+        var builder = WebHost.CreateDefaultBuilder()
+             .ConfigureServices((IServiceCollection services) => { })
+             .ConfigureLogging(logging => logging.AddXunit(_output))
+             .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, MultipleContextsHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<MultipleContextsHub>>() as MockServiceHubDispatcher<MultipleContextsHub>).MockService;
+        await mockSvc.AllConnectionsEstablished().OrTimeout();
+        var allSvcConns = mockSvc.ServiceSideConnections;
+        mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
+        var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
+        await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
+        var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
+
+        var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+        const int msgNum = 10;
+        await client0.SendMessage("BroadcastNumCallsMultipleContexts", [msgNum]).OrTimeout();
+        var counts = await DrainBroadcastMessages(epCount, msgNum, mockSvc).OrTimeout();
+
+        Assert.Equal(counts.Count, MockServiceMessageOrderTestParams.ServiceEndpoints.Length);
+        foreach (var conn in counts)
+        {
+            Assert.Equal(msgNum, conn.Value);
+        }
+    }
+
+    // Config hot reload allows adding & removing endpoints and corresponding service connections
+    // This test verifies that when new endpoits are added, they will be selected for new connections.
+    // When old endpoints are removed, the corresponding previously used connections are not leaked.
+    //
+    // The test makes a service connection C over endpoint E, then makes a hub call which runs a new task.
+    // This new task sends messages to the service and its execution context carries connection selection info.
+    // When the endpoint E is removed as the result of config hot reload, the corresponding connection C is closed.
+    // However the task spawned in the hub call still carries the previous connection selection information.
+    //
+    // To verify that there are no leaks after the hot reload we wrap the references to the old connection C and endpoint E
+    // in weak reference handles and induce a full GC. Then we check if the the weak references targets are nulled out.
+    [RetryFact]
+    public async Task PreviouslyUsedServiceConnectionsNotLeakedAfterHotReload2()
+    {
+        var builder = WebHost.CreateDefaultBuilder()
+             .ConfigureServices((IServiceCollection services) => { })
+             .ConfigureLogging(logging => logging.AddXunit(_output))
+             .UseStartup<HotReloadIntegrationTestStartup<HotReloadMessageOrderTestParams, HotReloadTestHub>>();
+
+        using var server = new AspNetTestServer(builder);
+        var wrList = await BroadcastAndHotReloadAllEndpoints(server);
+
+        // here we assume that 2 GCs and 1 finalizer are enough
+        await Task.Delay(3300);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Task.Delay(3300);
+        GC.Collect();
+
+        foreach (var wr in wrList)
+        {
+            var o = wr.Target;
+            Assert.Null(o);
+        }
+    }
+
+    // Helper method to pull raw messages received by the mock service and count them per service connection
+    private static async Task<ConcurrentDictionary<MockServiceSideConnection, int>> DrainBroadcastMessages(
+        int endpointCount, int msgNum, IMockService mockSvc,
+        ConcurrentDictionary<MockServiceSideConnection, int> counts = null)
+    {
+        counts ??= new ConcurrentDictionary<MockServiceSideConnection, int>();
+
+        // Each endpoint will get the broadcast message so we should receive endpointCount * MsgNum messages
+        for (var ep = 0; ep < endpointCount * msgNum; ep++)
+        {
+            // we go "peek then take" route because we don't know which secondary connection will receive the messages
+            var connWithMessage = await Task.WhenAny(mockSvc.ServiceSideConnections.Select(async c =>
+            {
+                var moreData = await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
+                Assert.True(moreData);
+                return (c, moreData);
+            }));
+
+            var conn = connWithMessage.Result.c;
+            var newMsg = await conn.DequeueMessageAsync<BroadcastDataMessage>();
+
+            var msgCount = counts.GetOrAdd(conn, 0);
+            counts[conn] = ++msgCount;
+
+            // parse each BroadcastDataMessage and verify this is the correct message
+            var hubMessage = ParseBroadcastDataMessageJson(newMsg, mockSvc.CurrentInvocationBinder);
+            Assert.True(hubMessage is InvocationMessage);
+            var invMsg = hubMessage as InvocationMessage;
+            Assert.Equal("Callback", invMsg.Target);
+
+            // finally, get ready to verify the order of messages
+            var actualCallbackNum = (int)invMsg.Arguments[0];
+
+            // this check works for both primary and secondary connections
+            Assert.Equal(msgCount, actualCallbackNum);
+        }
+        // todo: verify we received no extra BroadcastDataMessage - need TryPeek method (async with timeout?)
+        return counts;
+    }
+
+    private static HubMessage ParseBroadcastDataMessageJson(BroadcastDataMessage bdm, IInvocationBinder binder)
+    {
+        foreach (var payload in bdm.Payloads)
+        {
+            if (payload.Key == "json")
+            {
+                var sequence = new ReadOnlySequence<byte>(payload.Value);
+                if (SignalRPro.TryParseMessage(ref sequence, binder, out var signalRRRmessage))
+                {
+                    return signalRRRmessage;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
 using Microsoft.Azure.SignalR.IntegrationTests.Infrastructure.MessageOrderTests;
 using Microsoft.Azure.SignalR.IntegrationTests.MockService;
 using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -135,7 +136,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
         // Todo: helper for scenarios where we recycle connections so mockSvc contains a mixture of old (closed) and new (active) connections
         //static async Task WaitForAllNewConnectionsEstablished(IMockService mockSvc, int expectedActiveConnCount)
 
-        [Fact]
+        [RetryFact]
         // verifies that when original outboud service connection associated with the hub call is closed:
         // - a new service connection for each endpoint is selected 
         // - all subsequent messages use newly selected service connections

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs
@@ -41,22 +41,22 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
         public async Task OutgoingMessagesUseSameServiceConnection()
         {
             var builder = WebHost.CreateDefaultBuilder()
-                .ConfigureServices((IServiceCollection services) =>{})
+                .ConfigureServices((IServiceCollection services) => { })
                 .ConfigureLogging(logging => logging.AddXunit(_output))
                 .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, UseSameServiceConnectionHub>>();
 
             using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<UseSameServiceConnectionHub>>() 
+            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<UseSameServiceConnectionHub>>()
                 as MockServiceHubDispatcher<UseSameServiceConnectionHub>).MockService;
             await mockSvc.AllConnectionsEstablished().OrTimeout();
-            List<MockServiceSideConnection> allSvcConns = mockSvc.ServiceSideConnections;
+            var allSvcConns = mockSvc.ServiceSideConnections;
 
             // A few extra checks (just for this initial test to verify more invariants)
             // Each ServiceEndpoint will have ConnectionCount connections
             Assert.Equal(
                 MockServiceMessageOrderTestParams.ConnectionCount * MockServiceMessageOrderTestParams.ServiceEndpoints.Length,
                 allSvcConns.Count);
-            int endpointCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+            var endpointCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
             Assert.Equal(MockServiceMessageOrderTestParams.ServiceEndpoints.Length, endpointCount);
 
             // specify invocation binder before making calls
@@ -95,18 +95,18 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
 
         // Helper method to pull raw messages received by the mock service and count them per service connection
         private static async Task<ConcurrentDictionary<MockServiceSideConnection, int>> DrainBroadcastMessages(
-            int endpointCount, int msgNum, IMockService mockSvc, 
+            int endpointCount, int msgNum, IMockService mockSvc,
             ConcurrentDictionary<MockServiceSideConnection, int> counts = null)
         {
             counts ??= new ConcurrentDictionary<MockServiceSideConnection, int>();
 
             // Each endpoint will get the broadcast message so we should receive endpointCount * MsgNum messages
-            for (int ep = 0; ep < endpointCount * msgNum; ep++)
+            for (var ep = 0; ep < endpointCount * msgNum; ep++)
             {
                 // we go "peek then take" route because we don't know which secondary connection will receive the messages
                 var connWithMessage = await Task.WhenAny(mockSvc.ServiceSideConnections.Select(async c =>
                 {
-                    bool moreData = await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
+                    var moreData = await c.WaitToDequeueMessageAsync<BroadcastDataMessage>();
                     Assert.True(moreData);
                     return (c, moreData);
                 }));
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
                 var conn = connWithMessage.Result.c;
                 var newMsg = await conn.DequeueMessageAsync<BroadcastDataMessage>();
 
-                int msgCount = counts.GetOrAdd(conn, 0);
+                var msgCount = counts.GetOrAdd(conn, 0);
                 counts[conn] = ++msgCount;
 
                 // parse each BroadcastDataMessage and verify this is the correct message
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
                 Assert.Equal("Callback", invMsg.Target);
 
                 // finally, get ready to verify the order of messages
-                int actualCallbackNum = (int)invMsg.Arguments[0];
+                var actualCallbackNum = (int)invMsg.Arguments[0];
 
                 // this check works for both primary and secondary connections
                 Assert.Equal(msgCount, actualCallbackNum);
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
                 .UseStartup<IntegrationTestStartup<MockServiceMessageOrderTestParams, SwitchOverToNewServiceConnectionHub>>();
 
             using var server = new AspNetTestServer(builder);
-            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>>() 
+            var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>>()
                 as MockServiceHubDispatcher<SwitchOverToNewServiceConnectionHub>).MockService;
             mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
             await mockSvc.AllConnectionsEstablished().OrTimeout();
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
             var connSelections = new ConcurrentBag<MockServiceSideConnection>();
 
-            for (int ep = 0; ep < epCount; ep++)
+            for (var ep = 0; ep < epCount; ep++)
             {
                 var connReceivedMessage = await Task.WhenAny(allSvcConns.Select(async c =>
                 {
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             await primarySvc0.StopAsync().OrTimeout();
 
             // step 3: drain and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
-            await mockSvc.AllConnectionsEstablished().OrTimeout(); 
+            await mockSvc.AllConnectionsEstablished().OrTimeout();
             var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
 
             // step 4: verify the connections that received messages
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             var epCount = MockServiceMessageOrderTestParams.ServiceEndpoints.Length;
             mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
             await mockSvc.AllConnectionsEstablished().OrTimeout();
-            List<MockServiceSideConnection> allSvcConns = mockSvc.ServiceSideConnections;
+            var allSvcConns = mockSvc.ServiceSideConnections;
             await using var primarySvc0 = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
             var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
 
@@ -266,7 +266,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
 
             // step 3: receive and count messages sent as the result of the call to BroadcastNumCallsAfterDisconnected
             await DrainBroadcastMessages(epCount, MsgNum, mockSvc, counts).OrTimeout();
-            
+
             // step 4: verify the connections that received messages
             var primary = counts.Where(c => c.Key.Endpoint.EndpointType == EndpointType.Primary);
             Assert.Single(primary);
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
 
             const int MsgNum = 10;
             await client0.SendMessage("BroadcastNumCallsNotFlowing", new object[] { MsgNum }).OrTimeout();
-            int epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+            var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
 
             var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
 
@@ -333,13 +333,13 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             using var server = new AspNetTestServer(builder);
             var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<MultipleContextsHub>>() as MockServiceHubDispatcher<MultipleContextsHub>).MockService;
             await mockSvc.AllConnectionsEstablished().OrTimeout();
-            List<MockServiceSideConnection> allSvcConns = mockSvc.ServiceSideConnections;
+            var allSvcConns = mockSvc.ServiceSideConnections;
             mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
             var priList = allSvcConns.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
             await using var primarySvc0 = priList[StaticRandom.Next(priList.Count)];
             var client0 = await primarySvc0.ConnectClientAsync().OrTimeout();
 
-            int epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+            var epCount = allSvcConns.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
             const int MsgNum = 10;
             await client0.SendMessage("BroadcastNumCallsMultipleContexts", new object[] { MsgNum }).OrTimeout();
             var counts = await DrainBroadcastMessages(epCount, MsgNum, mockSvc).OrTimeout();
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
         //
         // To verify that there are no leaks after the hot reload we wrap the references to the old connection C and endpoint E
         // in weak reference handles and induce a full GC. Then we check if the the weak references targets are nulled out.
-        [Fact]
+        [RetryFact]
         public async Task PreviouslyUsedServiceConnectionsNotLeakedAfterHotReload2()
         {
             var builder = WebHost.CreateDefaultBuilder()
@@ -382,17 +382,17 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
 
             foreach (var wr in wrList)
             {
-                object o = wr.Target;
+                var o = wr.Target;
                 Assert.Null(o);
             }
         }
 
         public async Task<List<WeakReference>> BroadcastAndHotReloadAllEndpoints(AspNetTestServer server)
-        { 
+        {
             // Part1: broadcast messages over initial set of endpoints
             var mockSvc = (server.Host.Services.GetRequiredService<ServiceHubDispatcher<HotReloadTestHub>>() as MockServiceHubDispatcher<HotReloadTestHub>).MockService;
             await mockSvc.AllConnectionsEstablished();
-            List<MockServiceSideConnection> allSvcConns0 = mockSvc.ServiceSideConnections;
+            var allSvcConns0 = mockSvc.ServiceSideConnections;
             mockSvc.CurrentInvocationBinder = new TestHubBroadcastNCallsInvocationBinder();
 
             var priList = allSvcConns0.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).ToList();
@@ -429,7 +429,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             HotReloadIntegrationTestStartup<HotReloadMessageOrderTestParams, HotReloadTestHub>.ReloadConfig(index: 1);
 
             List<MockServiceSideConnection> allSvcConnsNew = null;
-            bool allNew = false;
+            var allNew = false;
             do
             {
                 await Task.Delay(TimeSpan.FromSeconds(3));
@@ -444,7 +444,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
                 foreach (var ep in HotReloadMessageOrderTestParams.AllEndpoints[1])
                 {
                     allNew = true;
-                    bool foundEp = false;
+                    var foundEp = false;
                     foreach (var conn in allSvcConnsNew)
                     {
                         if (conn.Endpoint.ConnectionString == ep.Value)
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
 
             // Part3: send message over the new set of endpoints and verify that only the new endpoints are used
             var primarySvc1 = allSvcConnsNew.Where(i => i.Endpoint.EndpointType == EndpointType.Primary).FirstOrDefault();
-            int endpointCount = allSvcConnsNew.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
+            var endpointCount = allSvcConnsNew.Distinct(new MockServiceSideConnectionEndpointComparer()).Count();
             var client1 = await primarySvc1.ConnectClientAsync().OrTimeout();
             await client1.SendMessage("BroadcastNumCalls", new object[] { MsgNum }).OrTimeout();
 
@@ -474,10 +474,10 @@ namespace Microsoft.Azure.SignalR.IntegrationTests
             {
                 Assert.Equal(MsgNum, conn.Value);
             }
-            return wrList;        
+            return wrList;
         }
 
-        private static readonly JsonHubProtocol _signalRPro = new JsonHubProtocol();
+        private static readonly JsonHubProtocol _signalRPro = new();
         private static HubMessage ParseBroadcastDataMessageJson(BroadcastDataMessage bdm, IInvocationBinder binder)
         {
             foreach (var payload in bdm.Payloads)

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
@@ -16,129 +17,126 @@ using Moq.Protected;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Azure.SignalR.Management.Tests
+namespace Microsoft.Azure.SignalR.Management.Tests;
+
+public class RestHealthCheckServiceFacts(ITestOutputHelper output = null) : LoggedTest(output)
 {
-    public class RestHealthCheckServiceFacts : LoggedTest
+    private const string HubName = "hub";
+
+    public static IEnumerable<object[]> HttpClientMockData
     {
-        private const string HubName = "hub";
-        public static IEnumerable<object[]> HttpClientMockData
+        get
         {
-            get
+            yield return new object[] { new TestRootHandler(HttpStatusCode.BadGateway) };
+            yield return new object[] { new TestRootHandler(HttpStatusCode.NotFound) };
+            yield return new object[] { new TestRootHandler((request, token) => throw new HttpRequestException()) };
+        }
+    }
+
+    [RetryFact]
+    public async Task TestRestHealthCheckServiceWithEndpointFromHealthyToUnhealthy()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var handlerMock = new Mock<DelegatingHandler>();
+        // mock health api calls first return healthy then unhealthy.
+        handlerMock.Protected().SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+           .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK))
+           .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+           .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
+           .ReturnsAsync(() =>
+           {
+               tcs.SetResult(true);
+               return new HttpResponseMessage(HttpStatusCode.BadGateway);
+           })
+           .ReturnsAsync(() =>
+           {
+               Assert.Fail("Unexpected invoke.");
+               return default;
+           });
+
+        var checkInterval = TimeSpan.FromSeconds(3);
+        var retryInterval = TimeSpan.FromSeconds(0.5);
+        using var _ = StartLog(out var loggerFactory);
+        var services = new ServiceCollection()
+            .AddSignalRServiceManager()
+            .AddHttpClient(Constants.HttpClientNames.InternalDefault).ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object).Services
+            .Configure<HealthCheckOption>(o =>
             {
-                yield return new object[] { new TestRootHandler(HttpStatusCode.BadGateway) };
-                yield return new object[] { new TestRootHandler(HttpStatusCode.NotFound) };
-                yield return new object[] { new TestRootHandler((request, token) => throw new HttpRequestException()) };
-            }
-        }
-        public RestHealthCheckServiceFacts(ITestOutputHelper output = null) : base(output)
-        {
-        }
+                o.CheckInterval = checkInterval;
+                o.RetryInterval = retryInterval;
+                o.EnabledForSingleEndpoint = true;
+            });
+        using var serviceHubContext = await new ServiceManagerBuilder(services)
+            .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
+            .WithLoggerFactory(loggerFactory)
+            .BuildServiceManager()
+            .CreateHubContextAsync(HubName, default);
 
-        [Theory]
-        [MemberData(nameof(HttpClientMockData))]
-        internal async Task TestRestHealthCheckServiceWithUnhealthyEndpoint(TestRootHandler testHandler)
-        {
-            using var _ = StartLog(out var loggerFactory);
-            using var serviceHubContext = await new ServiceManagerBuilder()
-                .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
-                .WithLoggerFactory(loggerFactory)
-                .ConfigureServices(services =>
+        var endpoint = (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IServiceEndpointManager>().GetEndpoints(HubName)[0];
+
+        //The first health check is OK
+        Assert.True(endpoint.Online);
+
+        //Wait until the next health check finish
+        await tcs.Task;
+        // let our handler handle the response.
+        await Task.Delay(1);
+
+        Assert.False(endpoint.Online);
+    }
+
+    [Fact]
+    public async Task TestTimeoutAsync()
+    {
+        using var _ = StartLog(out var loggerFactory);
+        var taskSource = new TaskCompletionSource();
+        var services = new ServiceCollection()
+            .AddSignalRServiceManager()
+            .AddHttpClient(Constants.HttpClientNames.InternalDefault).ConfigurePrimaryHttpMessageHandler(() => new TestRootHandler(async (message, token) =>
+            {
+                try
                 {
-                    services.AddHttpClient(Constants.HttpClientNames.InternalDefault)
-                            .ConfigurePrimaryHttpMessageHandler(() => testHandler);
-                    services.Configure<HealthCheckOption>(o => o.EnabledForSingleEndpoint = true);
-                })
-                .BuildServiceManager()
-                .CreateHubContextAsync(HubName, default);
-            var endpoint = (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IServiceEndpointManager>().GetEndpoints(HubName).First();
-            Assert.False(endpoint.Online);
-        }
-
-        [Fact]
-        public async Task TestRestHealthCheckServiceWithEndpointFromHealthyToUnhealthy()
-        {
-            var tcs = new TaskCompletionSource<bool>();
-            var handlerMock = new Mock<DelegatingHandler>();
-            // mock health api calls first return healthy then unhealthy.
-            handlerMock.Protected().SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-               .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK))
-               .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
-               .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
-               .ReturnsAsync(() =>
-               {
-                   tcs.SetResult(true);
-                   return new HttpResponseMessage(HttpStatusCode.BadGateway);
-               })
-               .ReturnsAsync(() =>
-               {
-                   Assert.Fail("Unexpected invoke.");
-                   return default;
-               });
-
-            var checkInterval = TimeSpan.FromSeconds(3);
-            var retryInterval = TimeSpan.FromSeconds(0.5);
-            using var _ = StartLog(out var loggerFactory);
-            var services = new ServiceCollection()
-                .AddSignalRServiceManager()
-                .AddHttpClient(Constants.HttpClientNames.InternalDefault).ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object).Services
-                .Configure<HealthCheckOption>(o =>
+                    await Task.Delay(-1, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
-                    o.CheckInterval = checkInterval;
-                    o.RetryInterval = retryInterval;
-                    o.EnabledForSingleEndpoint = true;
-                });
-            using var serviceHubContext = await new ServiceManagerBuilder(services)
-                .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
-                .WithLoggerFactory(loggerFactory)
-                .BuildServiceManager()
-                .CreateHubContextAsync(HubName, default);
+                    taskSource.SetResult();
+                }
+            })).Services
+            .Configure<HealthCheckOption>(o =>
+            {
+                // Never retry
+                o.RetryInterval = Timeout.InfiniteTimeSpan;
+                // Make the timeout happens as soon as quickly.
+                o.HttpTimeout = TimeSpan.FromMilliseconds(1);
+                o.EnabledForSingleEndpoint = true;
+            });
+        using var serviceHubContext = await new ServiceManagerBuilder(services)
+            .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
+            .WithLoggerFactory(loggerFactory)
+            .BuildServiceManager()
+            .CreateHubContextAsync(HubName, default);
 
-            var endpoint = (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IServiceEndpointManager>().GetEndpoints(HubName).First();
+        await taskSource.Task.OrTimeout();
+    }
 
-            //The first health check is OK
-            Assert.True(endpoint.Online);
-
-            //Wait until the next health check finish
-            await tcs.Task;
-            // let our handler handle the response.
-            await Task.Delay(1);
-
-            Assert.False(endpoint.Online);
-        }
-
-        [Fact]
-        public async Task TestTimeoutAsync()
-        {
-            using var _ = StartLog(out var loggerFactory);
-            var taskSource = new TaskCompletionSource();
-            var services = new ServiceCollection()
-                .AddSignalRServiceManager()
-                .AddHttpClient(Constants.HttpClientNames.InternalDefault).ConfigurePrimaryHttpMessageHandler(() => new TestRootHandler(async (message, token) =>
-                {
-                    try
-                    {
-                        await Task.Delay(-1, token);
-                    }
-                    catch (OperationCanceledException) when (token.IsCancellationRequested)
-                    {
-                        taskSource.SetResult();
-                    }
-                })).Services
-                .Configure<HealthCheckOption>(o =>
-                {
-                    // Never retry
-                    o.RetryInterval = Timeout.InfiniteTimeSpan;
-                    // Make the timeout happens as soon as quickly.
-                    o.HttpTimeout = TimeSpan.FromMilliseconds(1);
-                    o.EnabledForSingleEndpoint = true;
-                });
-            using var serviceHubContext = await new ServiceManagerBuilder(services)
-                .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
-                .WithLoggerFactory(loggerFactory)
-                .BuildServiceManager()
-                .CreateHubContextAsync(HubName, default);
-
-            await taskSource.Task.OrTimeout();
-        }
+    [Theory]
+    [MemberData(nameof(HttpClientMockData))]
+    internal async Task TestRestHealthCheckServiceWithUnhealthyEndpoint(TestRootHandler testHandler)
+    {
+        using var _ = StartLog(out var loggerFactory);
+        using var serviceHubContext = await new ServiceManagerBuilder()
+            .WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single())
+            .WithLoggerFactory(loggerFactory)
+            .ConfigureServices(services =>
+            {
+                services.AddHttpClient(Constants.HttpClientNames.InternalDefault)
+                        .ConfigurePrimaryHttpMessageHandler(() => testHandler);
+                services.Configure<HealthCheckOption>(o => o.EnabledForSingleEndpoint = true);
+            })
+            .BuildServiceManager()
+            .CreateHubContextAsync(HubName, default);
+        var endpoint = (serviceHubContext as ServiceHubContextImpl).ServiceProvider.GetRequiredService<IServiceEndpointManager>().GetEndpoints(HubName)[0];
+        Assert.False(endpoint.Online);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/BlockingMessageBus.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/BlockingMessageBus.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+/// <summary>
+/// An XUnit message bus that can block messages from being passed until we want them to be.
+/// </summary>
+public sealed class BlockingMessageBus(IMessageBus underlyingMessageBus, MessageTransformer messageTransformer) : IMessageBus
+{
+    private ConcurrentQueue<IMessageSinkMessage> _messageQueue = new();
+
+    public bool QueueMessage(IMessageSinkMessage rawMessage)
+    {
+        // Transform the message to apply any additional functionality, then intercept & store it for replay later
+        var transformedMessage = messageTransformer.Transform(rawMessage);
+        _messageQueue.Enqueue(transformedMessage);
+
+        // Returns if execution should continue. Since we are intercepting the message, we
+        //  have no way of checking this so always continue...
+        return true;
+    }
+
+    public void Clear()
+    {
+        _messageQueue = new ConcurrentQueue<IMessageSinkMessage>();
+    }
+
+    /// <summary>
+    /// Write the cached messages to the underlying message bus
+    /// </summary>
+    public void Flush()
+    {
+        while (_messageQueue.TryDequeue(out var message))
+        {
+            underlyingMessageBus.QueueMessage(message);
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not dispose of the underlying message bus - it is an externally owned resource
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/EnumerableExtensions.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/EnumerableExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
+
+public static class EnumerableExtensions
+{
+    public static bool ContainsAny<T>(this IEnumerable<T> values, T[] searchFor, IEqualityComparer<T>? comparer = null)
+    {
+        if (searchFor == null)
+        {
+            throw new ArgumentNullException(nameof(searchFor));
+        }
+
+        comparer ??= EqualityComparer<T>.Default;
+
+        return searchFor.Length != 0 &&
+               values.Any(val => searchFor.Any(search => comparer.Equals(val, search)));
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/IRetryableTestCase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/IRetryableTestCase.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+public interface IRetryableTestCase : IXunitTestCase
+{
+    int MaxRetries { get; }
+
+    int DelayBetweenRetriesMs { get; }
+
+    string[] SkipOnExceptionFullNames { get; }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/MessageTransformer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/MessageTransformer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+public class MessageTransformer(string[] skipOnExceptionFullNames)
+{
+    public bool Skipped { get; private set; }
+
+    /// <summary>
+    /// Transforms a message received from an xUnit test into another message, replacing it
+    /// where necessary to add additional functionality, e.g. dynamic skipping
+    /// </summary>
+    /// <param name="message"></param>
+    /// <returns></returns>
+    public IMessageSinkMessage Transform(IMessageSinkMessage message)
+    {
+        // If this is a message saying that the test has been skipped, replace the message with skipping the test
+        if (message is TestFailed failed && failed.ExceptionTypes.ContainsAny(skipOnExceptionFullNames))
+        {
+            var reason = failed.Messages?.FirstOrDefault() ?? string.Empty;
+            Skipped = true;
+            return new TestSkipped(failed.Test, reason);
+        }
+
+        // Otherwise this isn't a message saying the test is skipped, follow usual intercept for replay later behaviour
+        return message;
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactAttribute.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactAttribute.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+/// <summary>
+/// Attribute that is applied to a method to indicate that it is a fact that should be run
+/// by the test runner up to <see cref="MaxRetries"/> times, until it succeeds.
+/// </summary>
+[XunitTestCaseDiscoverer("Microsoft.Azure.SignalR.Tests.RetryFactDiscoverer", "Microsoft.Azure.SignalR.TestCommon")]
+[AttributeUsage(AttributeTargets.Method)]
+public class RetryFactAttribute : FactAttribute
+{
+    public const int DEFAULT_MAX_RETRIES = 2;
+
+    public const int DEFAULT_DELAY_BETWEEN_RETRIES_MS = 0;
+
+    public int MaxRetries { get; } = DEFAULT_MAX_RETRIES;
+
+    public int DelayBetweenRetriesMs { get; } = DEFAULT_DELAY_BETWEEN_RETRIES_MS;
+
+    public Type[] SkipOnExceptions { get; } = [];
+
+    /// <summary>
+    /// Ctor (just skip on exceptions)
+    /// </summary>
+    /// <param name="skipOnExceptions">Mark the test as skipped when this type of exception is encountered</param>
+    public RetryFactAttribute(params Type[] skipOnExceptions)
+    {
+        SkipOnExceptions = skipOnExceptions ?? Type.EmptyTypes;
+
+        if (SkipOnExceptions.Any(t => !t.IsSubclassOf(typeof(Exception))))
+        {
+            throw new ArgumentException("Specified type must be an exception", nameof(skipOnExceptions));
+        }
+    }
+
+    /// <summary>
+    /// Ctor (full)
+    /// </summary>
+    /// <param name="maxRetries">The number of times to attempt to run a test for until it succeeds</param>
+    /// <param name="delayBetweenRetriesMs">The amount of time (in ms) to wait between each test run attempt</param>
+    /// <param name="skipOnExceptions">Mark the test as skipped when this type of exception is encountered</param>
+    public RetryFactAttribute(int maxRetries = DEFAULT_MAX_RETRIES,
+                              int delayBetweenRetriesMs = DEFAULT_DELAY_BETWEEN_RETRIES_MS,
+                              params Type[] skipOnExceptions) : this(skipOnExceptions)
+    {
+        if (maxRetries < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxRetries));
+        }
+
+        if (delayBetweenRetriesMs < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delayBetweenRetriesMs));
+        }
+
+        MaxRetries = maxRetries;
+        DelayBetweenRetriesMs = delayBetweenRetriesMs;
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactDiscoverer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactDiscoverer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Testing.xunit;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#pragma warning disable CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well.
+
+public class RetryFactDiscoverer(IMessageSink messageSink) : FactDiscoverer(messageSink)
+{
+    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                         ITestMethod testMethod,
+                                                         IAttributeInfo factAttribute)
+    {
+        IXunitTestCase testCase;
+
+        if (testMethod.Method.GetParameters().Any())
+        {
+            testCase = new ExecutionErrorTestCase(messageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod,
+                "[RetryFact] methods are not allowed to have parameters. Did you mean to use [RetryTheory]?");
+        }
+        else if (testMethod.Method.IsGenericMethodDefinition)
+        {
+            testCase = new ExecutionErrorTestCase(messageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod,
+                "[RetryFact] methods are not allowed to be generic.");
+        }
+        else
+        {
+            testCase = CreateTestCase(discoveryOptions, testMethod, factAttribute);
+        }
+
+        return [testCase];
+    }
+
+    protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                     ITestMethod testMethod,
+                                                     IAttributeInfo factAttribute)
+    {
+        var text = testMethod.EvaluateSkipConditions();
+        if (text is not null)
+        {
+            return new SkippedTestCase(text, base.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+        var maxRetries =
+            factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.MaxRetries));
+        var delayBetweenRetriesMs =
+            factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.DelayBetweenRetriesMs));
+        var skipOnExceptions =
+            factAttribute.GetNamedArgument<Type[]>(nameof(RetryFactAttribute.SkipOnExceptions));
+
+        return new RetryTestCase(messageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, maxRetries, delayBetweenRetriesMs,
+            skipOnExceptions);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCase.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
+
+[Serializable]
+public class RetryTestCase : XunitTestCase, IRetryableTestCase
+{
+    public int MaxRetries { get; private set; }
+
+    public int DelayBetweenRetriesMs { get; private set; }
+
+    public string[] SkipOnExceptionFullNames { get; private set; } = [];
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete(
+        "Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", true)]
+    public RetryTestCase()
+    { }
+
+    public RetryTestCase(IMessageSink diagnosticMessageSink,
+                         TestMethodDisplay defaultMethodDisplay,
+                         ITestMethod testMethod,
+                         int maxRetries,
+                         int delayBetweenRetriesMs,
+                         Type[] skipOnExceptions,
+                         object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, testMethod,
+            testMethodArguments)
+    {
+        MaxRetries = maxRetries;
+        DelayBetweenRetriesMs = delayBetweenRetriesMs;
+        SkipOnExceptionFullNames = GetSkipOnExceptionFullNames(skipOnExceptions);
+    }
+
+    public static string[] GetSkipOnExceptionFullNames(Type[] customSkipOnExceptions)
+    {
+        var toRet = new string[customSkipOnExceptions.Length + 1];
+        for (var i = 0; i < customSkipOnExceptions.Length; i++)
+        {
+            toRet[i] = customSkipOnExceptions[i].FullName!;
+        }
+        toRet[toRet.Length - 1] = typeof(SkipTestException).FullName!;
+        return toRet;
+    }
+
+    public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                              IMessageBus messageBus,
+                                              object[] constructorArguments,
+                                              ExceptionAggregator aggregator,
+                                              CancellationTokenSource cancellationTokenSource) =>
+        RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
+            blockingMessageBus => new XunitTestCaseRunner(this,
+                                                          DisplayName,
+                                                          SkipReason,
+                                                          constructorArguments,
+                                                          TestMethodArguments,
+                                                          blockingMessageBus,
+                                                          aggregator,
+                                                          cancellationTokenSource)
+                .RunAsync());
+
+    public override void Serialize(IXunitSerializationInfo data)
+    {
+        base.Serialize(data);
+
+        data.AddValue("MaxRetries", MaxRetries);
+        data.AddValue("DelayBetweenRetriesMs", DelayBetweenRetriesMs);
+        data.AddValue("SkipOnExceptionFullNames", SkipOnExceptionFullNames);
+    }
+
+    public override void Deserialize(IXunitSerializationInfo data)
+    {
+        base.Deserialize(data);
+
+        MaxRetries = data.GetValue<int>("MaxRetries");
+        DelayBetweenRetriesMs = data.GetValue<int>("DelayBetweenRetriesMs");
+        SkipOnExceptionFullNames = data.GetValue<string[]>("SkipOnExceptionFullNames");
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCaseRunner.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCaseRunner.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+// Note: public so that other xunit extensions can call this, allowing xRetry to be
+//  integrated into them. e.g. Xunit.DependencyInjection.xRetry
+public static class RetryTestCaseRunner
+{
+    /// <summary>
+    /// Runs a retryable test case, handling any wait and retry logic between test runs, reporting statuses out to xunit etc...
+    /// </summary>
+    /// <param name="testCase">The test case to be retried</param>
+    /// <param name="diagnosticMessageSink">The diagnostic message sink to write messages to about retries, waits etc...</param>
+    /// <param name="messageBus">The message bus xunit is listening for statuses to report on</param>
+    /// <param name="cancellationTokenSource">The cancellation token source from xunit</param>
+    /// <param name="fnRunSingle">(async) Lambda to run this test case once (without retries) - takes the blocking message bus and returns the test run result</param>
+    /// <returns>Resulting run summary</returns>
+    public static async Task<RunSummary> RunAsync(IRetryableTestCase testCase,
+                                                  IMessageSink diagnosticMessageSink,
+                                                  IMessageBus messageBus,
+                                                  CancellationTokenSource cancellationTokenSource,
+                                                  Func<IMessageBus, Task<RunSummary>> fnRunSingle)
+    {
+        for (var i = 1; ; i++)
+        {
+            // Prevent messages from the test run from being passed through, as we don't want
+            //  a message to mark the test as failed when we're going to retry it
+            var messageTransformer = new MessageTransformer(testCase.SkipOnExceptionFullNames);
+            using var blockingMessageBus = new BlockingMessageBus(messageBus, messageTransformer);
+            diagnosticMessageSink.OnMessage(new DiagnosticMessage("Running test \"{0}\" attempt ({1}/{2})",
+                testCase.DisplayName, i, testCase.MaxRetries));
+
+            var summary = await fnRunSingle(blockingMessageBus);
+
+            if (messageTransformer.Skipped)
+            {
+                summary.Failed = 0;
+                summary.Skipped = 1;
+            }
+
+            // If we succeeded, skipped, or we've reached the max retries return the result
+            if (summary.Failed == 0 || i == testCase.MaxRetries)
+            {
+                // If we have failed (after all retries, log that)
+                if (summary.Failed != 0)
+                {
+                    diagnosticMessageSink.OnMessage(new DiagnosticMessage(
+                        "Test \"{0}\" has failed and been retried the maximum number of times ({1})",
+                        testCase.DisplayName, testCase.MaxRetries));
+                }
+
+                blockingMessageBus.Flush();
+                return summary;
+            }
+            // Otherwise log that we've had a failed run and will retry
+            diagnosticMessageSink.OnMessage(new DiagnosticMessage(
+                "Test \"{0}\" failed but is set to retry ({1}/{2}) . . .", testCase.DisplayName, i,
+                testCase.MaxRetries));
+
+            // If there is a delay between test attempts, apply it now
+            if (testCase.DelayBetweenRetriesMs > 0)
+            {
+                diagnosticMessageSink.OnMessage(new DiagnosticMessage(
+                    "Test \"{0}\" attempt ({1}/{2}) delayed by {3}ms. Waiting . . .", testCase.DisplayName, i,
+                    testCase.MaxRetries, testCase.DelayBetweenRetriesMs));
+
+                // Don't await to prevent thread hopping.
+                //  If all of a users test cases in a collection/class are synchronous and expecting to not thread-hop
+                //  (because they're making use of thread static/thread local/managed thread ID to share data between tests rather than
+                //  a more modern async-friendly mechanism) then if a thread-hop were to happen here we'd get flickering tests.
+                //  SpecFlow relies on this as they use the managed thread ID to separate instances of some of their internal classes, which caused
+                //  a this problem for xRetry.SpecFlow: https://github.com/JoshKeegan/xRetry/issues/18
+                Task.Delay(testCase.DelayBetweenRetriesMs, cancellationTokenSource.Token).Wait();
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryAttribute.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+/// <summary>
+/// Attribute that is applied to a method to indicate that it is a theory that should be run
+/// by the test runner up to <see cref="RetryFactAttribute.MaxRetries"/> times, until it succeeds.
+/// </summary>
+[XunitTestCaseDiscoverer("Microsoft.Azure.SignalR.Tests.RetryTheoryDiscoverer", "Microsoft.Azure.SignalR.TestCommon")]
+[AttributeUsage(AttributeTargets.Method)]
+public class RetryTheoryAttribute : RetryFactAttribute
+{
+    /// <inheritdoc/>
+    public RetryTheoryAttribute(params Type[] skipOnExceptions)
+        : base(skipOnExceptions) { }
+
+    /// <inheritdoc/>
+    public RetryTheoryAttribute(int maxRetries = DEFAULT_MAX_RETRIES,
+                                int delayBetweenRetriesMs = DEFAULT_DELAY_BETWEEN_RETRIES_MS,
+                                params Type[] skipOnExceptions)
+        : base(maxRetries, delayBetweenRetriesMs, skipOnExceptions) { }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoverer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoverer.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Testing.xunit;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+public class RetryTheoryDiscoverer(IMessageSink diagnosticMessageSink) : TheoryDiscoverer(diagnosticMessageSink)
+{
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute,
+        object[] dataRow)
+    {
+        var text = testMethod.EvaluateSkipConditions();
+        if (text is not null)
+        {
+            return base.CreateTestCasesForSkippedDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow, text);
+        }
+        var maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+        var delayBetweenRetriesMs =
+            theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+        var skipOnExceptions =
+            theoryAttribute.GetNamedArgument<Type[]>(nameof(RetryTheoryAttribute.SkipOnExceptions));
+        return
+        [
+            new RetryTestCase(
+                DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(),
+                testMethod,
+                maxRetries,
+                delayBetweenRetriesMs,
+                skipOnExceptions,
+                dataRow)
+        ];
+    }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                                            ITestMethod testMethod,
+                                                                            IAttributeInfo theoryAttribute)
+    {
+        var text = testMethod.EvaluateSkipConditions();
+        if (text is not null)
+        {
+            return (IEnumerable<IXunitTestCase>)(object)new SkippedTestCase[1]
+            {
+                new(text, base.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod)
+            };
+        }
+
+        var maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+        var delayBetweenRetriesMs =
+            theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+        var skipOnExceptions =
+            theoryAttribute.GetNamedArgument<Type[]>(nameof(RetryTheoryAttribute.SkipOnExceptions));
+
+        return
+        [
+            new RetryTheoryDiscoveryAtRuntimeCase(DiagnosticMessageSink,
+                                                  discoveryOptions.MethodDisplayOrDefault(),
+                                                  testMethod,
+                                                  maxRetries,
+                                                  delayBetweenRetriesMs,
+                                                  skipOnExceptions)
+        ];
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+/// <summary>
+/// Represents a test case to be retried which runs multiple tests for theory data, either because the
+/// data was not enumerable or because the data was not serializable.
+/// Equivalent to xunit's XunitTheoryTestCase
+/// </summary>
+[Serializable]
+public class RetryTheoryDiscoveryAtRuntimeCase : XunitTestCase, IRetryableTestCase
+{
+    public int MaxRetries { get; private set; }
+
+    public int DelayBetweenRetriesMs { get; private set; }
+
+    public string[] SkipOnExceptionFullNames { get; private set; } = [];
+
+    /// <summary/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public RetryTheoryDiscoveryAtRuntimeCase()
+    { }
+
+    public RetryTheoryDiscoveryAtRuntimeCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        ITestMethod testMethod,
+        int maxRetries,
+        int delayBetweenRetriesMs,
+        Type[] skipOnExceptions)
+        : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+    {
+        MaxRetries = maxRetries;
+        DelayBetweenRetriesMs = delayBetweenRetriesMs;
+        SkipOnExceptionFullNames = RetryTestCase.GetSkipOnExceptionFullNames(skipOnExceptions);
+    }
+
+    /// <inheritdoc />
+    public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus,
+        object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource) =>
+        RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
+            blockingMessageBus => new XunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,
+                    diagnosticMessageSink, blockingMessageBus, aggregator, cancellationTokenSource)
+                .RunAsync());
+
+    public override void Serialize(IXunitSerializationInfo data)
+    {
+        base.Serialize(data);
+
+        data.AddValue("MaxRetries", MaxRetries);
+        data.AddValue("DelayBetweenRetriesMs", DelayBetweenRetriesMs);
+        data.AddValue("SkipOnExceptionFullNames", SkipOnExceptionFullNames);
+    }
+
+    public override void Deserialize(IXunitSerializationInfo data)
+    {
+        base.Deserialize(data);
+
+        MaxRetries = data.GetValue<int>("MaxRetries");
+        DelayBetweenRetriesMs = data.GetValue<int>("DelayBetweenRetriesMs");
+        SkipOnExceptionFullNames = data.GetValue<string[]>("SkipOnExceptionFullNames");
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/Skip.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/Skip.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
+
+public static class Skip
+{
+    /// <summary>
+    /// Throws an exception that results in a "Skipped" result for the test.
+    /// </summary>
+    /// <param name="reason">Reason for the test needing to be skipped</param>
+    public static void Always(string? reason = null)
+    {
+        throw new SkipTestException(reason);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/SkipTestException.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/SkipTestException.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
+
+[Serializable]
+public class SkipTestException : Exception
+{
+    public readonly string? Reason;
+
+    public SkipTestException(string? reason)
+        : base("Test skipped. Reason: " + reason)
+    {
+        Reason = reason;
+    }
+
+    [Obsolete]
+    protected SkipTestException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+        Reason = info.GetString(nameof(Reason));
+    }
+
+    [Obsolete]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+    {
+        info.AddValue(nameof(Reason), Reason);
+
+        base.GetObjectData(info, context);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TaskExtensions.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TaskExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Xunit;
 
 namespace System.Threading.Tasks
 {

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -33,13 +33,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             }
         },
         // add
@@ -47,12 +47,12 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             }
         },
         // remove
@@ -60,12 +60,12 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1")
             }
         },
         // rename
@@ -73,13 +73,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "22"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "11")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "22"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "11")
             }
         },
         // type
@@ -87,13 +87,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Secondary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Secondary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             }
         },
         // client endpoint
@@ -101,13 +101,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2"),
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG;ClientEndpoint=https://ce.com", EndpointType.Primary, "1")
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Primary, "2"),
+                new("Endpoint=http://url1;AccessKey=ABCDEFG;ClientEndpoint=https://ce.com", EndpointType.Primary, "1")
             }
         },
         // server endpoint
@@ -115,13 +115,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2")
+                new("Endpoint=http://url1;AccessKey=ABCDEFG", EndpointType.Primary, "1"),
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2")
             },
             new ServiceEndpoint[]
             {
-                new ServiceEndpoint("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2"),
-                new ServiceEndpoint("Endpoint=http://url1;AccessKey=ABCDEFG;ServerEndpoint=https://se.com/", EndpointType.Primary, "1")
+                new("Endpoint=http://url2;AccessKey=ABCDEFG", EndpointType.Secondary, "2"),
+                new("Endpoint=http://url1;AccessKey=ABCDEFG;ServerEndpoint=https://se.com/", EndpointType.Primary, "1")
             }
         }
     };
@@ -136,7 +136,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     private const int TimeoutSec = 10000;
 
-    private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new JoinGroupWithAckMessage("a", "a", -1);
+    private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new("a", "a", -1);
 
     private readonly string ConnectionString1 = string.Format(ConnectionStringFormatter, Url1);
 
@@ -321,7 +321,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     {
         Assert.Throws<AzureSignalRNoPrimaryEndpointException>(() => new TestServiceEndpointManager(new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Secondary)
+            new(ConnectionString1, EndpointType.Secondary)
         }));
     }
 
@@ -520,9 +520,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new ServiceEndpoint(ConnectionString2));
 
             var router = new TestEndpointRouter();
-            var container = new TestMultiEndpointServiceConnectionContainer("hub", e =>
-            {
-                return new TestServiceConnectionContainer(new List<IServiceConnection> {
+            var container = new TestMultiEndpointServiceConnectionContainer("hub", e => new TestServiceConnectionContainer(new List<IServiceConnection> {
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -530,8 +528,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
-                }, e);
-            }, sem, router, loggerFactory);
+                }, e), sem, router, loggerFactory);
 
             _ = container.StartAsync();
             await container.ConnectionInitializedTask;
@@ -941,9 +938,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         // Trigger reload to test rename
         var renamedEndpoint = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "11"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2"),
-            new ServiceEndpoint(ConnectionString3, EndpointType.Secondary, "33")
+            new(ConnectionString1, EndpointType.Primary, "11"),
+            new(ConnectionString2, EndpointType.Primary, "2"),
+            new(ConnectionString3, EndpointType.Secondary, "33")
         };
         await sem.TestReloadServiceEndpoints(renamedEndpoint, 10);
 
@@ -1012,9 +1009,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         var connstr3 = $"{ConnectionString3};ClientEndpoint={testClientEp};";
         var updateEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2"),
-            new ServiceEndpoint(connstr3, EndpointType.Secondary, "3")
+            new(ConnectionString1, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Primary, "2"),
+            new(connstr3, EndpointType.Secondary, "3")
         };
         await sem.TestReloadServiceEndpoints(updateEndpoints, 10);
 
@@ -1067,9 +1064,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2"),
-            new ServiceEndpoint(ConnectionString3, EndpointType.Primary, "3")
+            new(ConnectionString1, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Primary, "2"),
+            new(ConnectionString3, EndpointType.Primary, "3")
         };
         var timeoutToken = new CancellationTokenSource(1000).Token;
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 1);
@@ -1120,8 +1117,8 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2")
+            new(ConnectionString1, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Primary, "2")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 10);
 
@@ -1188,7 +1185,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1")
+            new(ConnectionString1, EndpointType.Primary, "1")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 1);
 
@@ -1238,7 +1235,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1")
+            new(ConnectionString1, EndpointType.Primary, "1")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 10);
 
@@ -1304,8 +1301,8 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "22")
+            new(ConnectionString1, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Primary, "22")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 15);
 
@@ -1365,7 +1362,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         Assert.Equal(EndpointType.Primary, hubEndpoints[1].EndpointType);
     }
 
-    [Fact]
+    [RetryFact]
     public async Task TestEndpointManagerWithMultiHubsWithServerEndpointUpdate()
     {
         var sem = new TestServiceEndpointManager(
@@ -1408,8 +1405,8 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         var con1Se = $"{ConnectionString1};ServerEndpoint={testSe};";
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(con1Se, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "22")
+            new(con1Se, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Secondary, "22")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 15);
 
@@ -1499,8 +1496,8 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         // Stage1: Add EP2
         var newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Primary, "1"),
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2")
+            new(ConnectionString1, EndpointType.Primary, "1"),
+            new(ConnectionString2, EndpointType.Primary, "2")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 10);
 
@@ -1541,7 +1538,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         newEndpoints = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "2")
+            new(ConnectionString2, EndpointType.Primary, "2")
         };
         _ = sem.TestReloadServiceEndpoints(newEndpoints, 10);
 
@@ -1569,7 +1566,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         // Trigger reload to test rename
         var renamedEndpoint = new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString2, EndpointType.Primary, "22"),
+            new(ConnectionString2, EndpointType.Primary, "22"),
         };
         // mock all active to emulate has clients
         containers = container.GetTestOnlineContainers();
@@ -1689,12 +1686,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             var router = new TestEndpointRouter();
 
             var multiContainer = new TestMultiEndpointServiceConnectionContainer("hub",
-                e =>
-                {
-                    return e.Endpoint == endpoints[0].Endpoint ?
+                e => e.Endpoint == endpoints[0].Endpoint ?
                      new TestServiceConnectionContainer(new List<IServiceConnection> { connection1 }, e) :
-                    new TestServiceConnectionContainer(new List<IServiceConnection> { connection2, connection22 }, e);
-                }, sem, router, NullLoggerFactory.Instance);
+                    new TestServiceConnectionContainer(new List<IServiceConnection> { connection2, connection22 }, e), sem, router, NullLoggerFactory.Instance);
 
             var containers = multiContainer.GetTestOnlineContainers();
             try
@@ -1882,8 +1876,10 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             {
                 new TestSimpleServiceConnection(),
                 new TestSimpleServiceConnection()
-            });
-            c.MockOffline = true;
+            })
+            {
+                MockOffline = true
+            };
             containers.Add(c);
             return c;
         }, manager, router, NullLoggerFactory.Instance);
@@ -1929,7 +1925,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     private sealed class PingConnectionHandler : ConnectionHandler
     {
-        public ConcurrentDictionary<string, IList<bool>> Result = new ConcurrentDictionary<string, IList<bool>>();
+        public ConcurrentDictionary<string, IList<bool>> Result = new();
 
         public CancellationTokenSource Cts { get; } = new CancellationTokenSource();
 

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -1042,7 +1042,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         await task.OrTimeout();
     }
 
-    [Fact]
+    [RetryFact]
     public async Task TestEndpointManagerWithAddEndpointsWithTimeoutCanPromote()
     {
         var sem = new TestServiceEndpointManager(

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -20,7 +20,7 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
     public ServiceConnectionContainerBaseTests(ITestOutputHelper helper) : base(helper)
     { }
 
-    [Theory]
+    [RetryTheory]
     [InlineData(3, 3, 0)]
     [InlineData(0, 1, 1)] // stop more than start will log warn
     [InlineData(1, 2, 1)] // stop more than start will log warn

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -81,7 +81,7 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
         }
     }
 
-    [Theory]
+    [RetryTheory]
     [InlineData(1, 1, 3, 3, 0)]
     [InlineData(1, 1, 0, 1, 1)]
     [InlineData(1, 1, 1, 0, 0)]

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionFacts.cs
@@ -10,14 +10,12 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Primitives;
-
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -26,7 +24,7 @@ public class ServiceConnectionFacts
 {
     private const int DefaultTimeoutInMilliSeconds = 1000;
 
-    private static readonly ServiceProtocol Protocol = new ServiceProtocol();
+    private static readonly ServiceProtocol Protocol = new();
 
     [Theory]
     [InlineData(true)]
@@ -142,10 +140,8 @@ public class ServiceConnectionFacts
     public async Task ClosingConnectionSendsCloseMessage()
     {
         var proxy = new ServiceConnectionProxy(context =>
-        {
             // Just let the connection end immediately
-            return Task.CompletedTask;
-        });
+            Task.CompletedTask);
 
         var serverTask = proxy.WaitForServerConnectionAsync(1);
         _ = proxy.StartAsync();
@@ -336,7 +332,7 @@ public class ServiceConnectionFacts
     /// <summary>
     /// When having intermittent connectivity failure, service connection should keep reconnecting to service.
     /// </summary>
-    [Fact]
+    [RetryFact]
     public async Task ReconnectWhenHavingIntermittentConnectivityFailure()
     {
         var proxy = new ServiceConnectionProxy(connectionFactoryCallback: c => new TestConnectionFactoryWithConnectivityFailure(c));
@@ -578,7 +574,7 @@ public class ServiceConnectionFacts
             var initTask = conn.StartAsync();
             await conn.ConnectionInitializedTask;
             conn.Stop();
-            var completedTask = Task.WhenAny(initTask, Task.Delay(3000)).Result;
+            var completedTask = await Task.WhenAny(initTask, Task.Delay(3000));
             Assert.Equal(initTask, completedTask);
         }
         finally

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -22,7 +22,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-
 using SignalRProtocol = Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -59,7 +58,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         _ = connection.WriteFromServiceAsync(openConnectionMessage);
         await connection.ClientConnectedTask.OrTimeout();
 
-        Assert.Equal(1, clientConnectionFactory.Connections.Count);
+        Assert.Single(clientConnectionFactory.Connections);
         var clientConnection = clientConnectionFactory.Connections[0];
         Assert.True((bool)isMigratedProperty.GetValue(clientConnection));
 
@@ -96,7 +95,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         _ = connection.WriteFromServiceAsync(openConnectionMessage);
         await connection.ClientConnectedTask;
 
-        Assert.Equal(1, clientConnectionFactory.Connections.Count);
+        Assert.Single(clientConnectionFactory.Connections);
         var clientConnection = clientConnectionFactory.Connections[0];
         Assert.False((bool)isMigratedProperty.GetValue(clientConnection));
 
@@ -137,7 +136,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         _ = connection.WriteFromServiceAsync(openConnectionMessage);
         await connection.ClientConnectedTask.OrTimeout();
 
-        Assert.Equal(1, clientConnectionFactory.Connections.Count);
+        Assert.Single(clientConnectionFactory.Connections);
         var clientConnection = clientConnectionFactory.Connections[0];
         var feature = clientConnection.Features.Get<IConnectionMigrationFeature>();
         Assert.NotNull(feature);
@@ -162,7 +161,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         Assert.Null(clientConnection.Features.Get<IConnectionMigrationFeature>());
     }
 
-    [Fact]
+    [RetryFact]
     public async Task TestCloseConnectionMessage()
     {
         var clientConnectionFactory = new TestClientConnectionFactory();
@@ -178,7 +177,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         _ = connection.WriteFromServiceAsync(openConnectionMessage);
         await connection.ClientConnectedTask;
 
-        Assert.Equal(1, clientConnectionFactory.Connections.Count);
+        Assert.Single(clientConnectionFactory.Connections);
         var clientConnection = clientConnectionFactory.Connections[0];
 
         // write a signalr handshake response
@@ -457,11 +456,11 @@ public class ServiceMessageTests : VerifiableLoggedTest
     {
         private readonly TestConnectionContainer _container;
 
-        private readonly TaskCompletionSource _clientConnectedTcs = new TaskCompletionSource();
+        private readonly TaskCompletionSource _clientConnectedTcs = new();
 
-        private readonly TaskCompletionSource _clientDisconnectedTcs = new TaskCompletionSource();
+        private readonly TaskCompletionSource _clientDisconnectedTcs = new();
 
-        private ReadOnlySequence<byte> _payload = new ReadOnlySequence<byte>();
+        private ReadOnlySequence<byte> _payload = new();
 
         public TestClientConnectionManager ClientConnectionManager { get; }
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -197,7 +197,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
         await connection.StopAsync();
     }
 
-    [Theory]
+    [RetryTheory]
     [InlineData(typeof(AccessKey))]
     [InlineData(typeof(MicrosoftEntraAccessKey))]
     public async Task TestAccessKeyRequestMessage(Type keyType)


### PR DESCRIPTION
This pull request includes several changes to the test files and workflow configurations. The primary focus is on improving code quality, updating dependencies, and ensuring consistency across the tests.

### Test Code Improvements:
* [`test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs`](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8R7-R46): Replaced `Fact` with `RetryFact` for better test reliability, made various fields `readonly`, and used simplified object initialization. [[1]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8R7-R46) [[2]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L59-R66) [[3]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L91-R92) [[4]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L114-R115) [[5]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L135-R140) [[6]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L182-R186)
* [`test/Microsoft.Azure.SignalR.Common.Tests/CustomizedTimerTests.cs`](diffhunk://#diff-c8533fcfb0972eb2ae41d2ead84af9e8385d416048708ed0490cf31675e7a84bL8-R25): Changed `Theory` to `RetryTheory`, removed unnecessary namespace declaration, and updated the class to use constructor injection for `ITestOutputHelper`. [[1]](diffhunk://#diff-c8533fcfb0972eb2ae41d2ead84af9e8385d416048708ed0490cf31675e7a84bL8-R25) [[2]](diffhunk://#diff-c8533fcfb0972eb2ae41d2ead84af9e8385d416048708ed0490cf31675e7a84bL175)
* [`test/Microsoft.Azure.SignalR.IntegrationTests/MessageOrderTests.cs`](diffhunk://#diff-599510f26c40b8029f9535e4c5d07054c4fec2c3377e3f77f28cbb37d7668420R18-L39): Refactored the `MessageOrderTests` class to use constructor injection for `ITestOutputHelper`, added a new method to handle broadcasting and hot reloading, and updated existing test methods for better readability and consistency. [[1]](diffhunk://#diff-599510f26c40b8029f9535e4c5d07054c4fec2c3377e3f77f28cbb37d7668420R18-L39) [[2]](diffhunk://#diff-599510f26c40b8029f9535e4c5d07054c4fec2c3377e3f77f28cbb37d7668420L51-R143) [[3]](diffhunk://#diff-599510f26c40b8029f9535e4c5d07054c4fec2c3377e3f77f28cbb37d7668420L69-R156) [[4]](diffhunk://#diff-599510f26c40b8029f9535e4c5d07054c4fec2c3377e3f77f28cbb37d7668420L81-R166)

### Workflow Configuration:
* [`.github/workflows/ubuntu.yml`](diffhunk://#diff-6640e8c668a6deeb426558faaa2b0f535d95814c09a05c044a1df27a008dd544L17-R17): Removed the `9.0.x` version from the `dotnet-version` matrix to streamline the testing process.