### PR TITLE
Fix the current verifiablelog

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceMessageBus.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/HubHost/ServiceMessageBus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -47,7 +47,7 @@ internal class ServiceMessageBus : MessageBus
             return ProcessMessage(messages[0]);
         }
 
-        return Task.WhenAll(messages.Select(m => ProcessMessage(m)));
+        return Task.WhenAll(messages.Select(ProcessMessage));
     }
 
     private async Task ProcessMessage(AppMessage message)

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -331,9 +331,9 @@ internal partial class ServiceConnection : ServiceConnectionBase
                 }
             }
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException)
         {
-            Log.SendLoopStopped(Logger, connectionId, e);
+            // Canceled
         }
         catch (Exception e)
         {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -26,9 +26,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new JoinGroupWithAckMessage("a", "a");
 
-    private readonly string ConnectionString1 = string.Format(ConnectionStringFormatter, Url1);
+    private static readonly string ConnectionString1 = string.Format(ConnectionStringFormatter, Url1);
 
-    private readonly string ConnectionString2 = string.Format(ConnectionStringFormatter, Url2);
+    private static readonly string ConnectionString2 = string.Format(ConnectionStringFormatter, Url2);
 
     public MultiEndpointServiceConnectionContainerTests(ITestOutputHelper output) : base(output)
     {
@@ -309,7 +309,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllConnectedFailsWithBadRouter()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, logChecker: logs => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var sem = new TestServiceEndpointManager(
                 new ServiceEndpoint(ConnectionString1),
@@ -338,7 +338,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllConnectedSucceedsWithGoodRouter()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, logChecker: logs => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var sem = new TestServiceEndpointManager(
                 new ServiceEndpoint(ConnectionString1),
@@ -366,14 +366,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllOfflineSucceedsWithWarning()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, logChecker: logs =>
-        {
-            var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
-
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-            return true;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var sem = new TestServiceEndpointManager(
             new ServiceEndpoint(ConnectionString1),
@@ -394,6 +387,10 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             _ = container.StartAsync();
             await container.ConnectionInitializedTask.OrTimeout();
             await container.WriteAsync(DefaultGroupMessage);
+            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning).ToList();
+
+            Assert.Single(warns);
+            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -448,7 +448,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     [Fact]
     public async Task TestRunAzureSignalRWithDefaultRouterNegotiateWithFallback()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: e => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             // Prepare the configuration
             var hubConfig = Utility.GetTestHubConfig(loggerFactory, "chat");
@@ -830,15 +830,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     public async Task TestRunAzureSignalStartsServerConnection()
     {
         // Prepare the configuration
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, logChecker: i =>
-        {
-            // the logs should contain start and stop
-            var names = i.Select(s => s.Write.EventId.Name).ToArray();
-            return names.Contains("StartingConnection")
-            && names.Contains("StartTransport")
-            && names.Contains("TransportStopping")
-            && names.Contains("FailedToConnect");
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         using (new AppSettingsConfigScope(ConnectionString))
         {
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
@@ -854,6 +846,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                 // 5 seconds for one websocket failure round
                 await options.ConnectionInitializedTask.OrTimeout(20000);
             }
+
+            // the logs should contain start and stop
+            logCollector.Expects("StartingConnection");
+            logCollector.Expects("StartTransport");
+            logCollector.Expects("TransportStopping");
+            logCollector.Expects("FailedToConnect");
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Transports;
 using Microsoft.Azure.SignalR.Protocol;
-using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -151,14 +150,7 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionWithErrorConnectHub()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true, logChecker:
-            logs =>
-            {
-                Assert.Equal(2, logs.Count);
-                Assert.Equal("ErrorExecuteConnected", logs[0].Write.EventId.Name);
-                Assert.Equal("ConnectedStartingFailed", logs[1].Write.EventId.Name);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var hubConfig = Utility.GetActualHubConfig(loggerFactory);
             var appName = "app1";
@@ -194,14 +186,16 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
 
             // cleaned up clearly
             Assert.Empty(ccm.ClientConnections);
+
+            logCollector.Expects("ErrorExecuteConnected");
+            logCollector.Expects("ConnectedStartingFailed");
         }
     }
 
-    [RetryFact]
+    [Fact]
     public async Task ServiceConnectionWithErrorDisconnectHub()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: c => true, logChecker:
-            logs => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var hubConfig = Utility.GetActualHubConfig(loggerFactory);
             var appName = "app1";
@@ -259,14 +253,7 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionDispatchOpenConnectionToUnauthorizedHubTest()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true, logChecker:
-            logs =>
-            {
-                Assert.Single(logs);
-                Assert.Equal("ConnectedStartingFailed", logs[0].Write.EventId.Name);
-                Assert.Equal("Unable to authorize request", logs[0].Write.Exception.Message);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var hubConfig = new HubConfiguration();
             var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
@@ -289,20 +276,15 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
 
             // Verify client connection is not created due to authorized failure.
             Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
+            var log = logCollector.Expects("ConnectedStartingFailed");
+            Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
         }
     }
 
     [Fact]
     public async Task ServiceConnectionWithNormalClientConnection()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true, logChecker:
-            logs =>
-            {
-                Assert.Single(logs);
-                Assert.Equal("ConnectedStartingFailed", logs[0].Write.EventId.Name);
-                Assert.Equal("Unable to authorize request", logs[0].Write.Exception.Message);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var hubConfig = new HubConfiguration();
             var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
@@ -326,6 +308,8 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
 
             // Verify client connection is not created due to authorized failure.
             Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
+            var log = logCollector.Expects("ConnectedStartingFailed");
+            Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
         }
     }
 
@@ -334,7 +318,7 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [InlineData("ErrorDisconnect")]
     public async Task ServiceConnectionWithTransportLayerClosedShouldCleanupNormalClientConnections(string hub)
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: c => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var hubConfig = Utility.GetActualHubConfig(loggerFactory);
             var appName = "app1";
@@ -383,15 +367,7 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionWithTransportLayerClosedShouldCleanupEndlessConnectClientConnections()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: c => true, logChecker:
-            logs =>
-            {
-                var errorLogs = logs.Where(s => s.Write.LogLevel == LogLevel.Error).ToList();
-                Assert.Single(errorLogs);
-                Assert.Equal("ApplicationTaskTimedOut", errorLogs[0].Write.EventId.Name);
-
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var hubConfig = Utility.GetActualHubConfig(loggerFactory);
             var appName = "app1";
@@ -417,7 +393,6 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
             var openConnectionMessage = new OpenConnectionMessage(clientConnection, [], null,
                 $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
             await proxy.WriteMessageAsync(openConnectionMessage);
-
             var connectMessage = (await connectTask) as GroupBroadcastDataMessage;
             Assert.NotNull(connectMessage);
             Assert.Equal($"hg-{hub}.note", connectMessage.GroupName);
@@ -438,13 +413,15 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
 
             // cleaned up clearly
             Assert.Empty(ccm.ClientConnections);
+
+            logCollector.Expects("ApplicationTaskTimedOut");
         }
     }
 
     [Fact]
     public async Task ServiceConnectionWithTransportLayerClosedShouldCleanupEndlessInvokeClientConnections()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: c => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var hubConfig = Utility.GetActualHubConfig(loggerFactory);
             var appName = "app1";
@@ -489,6 +466,8 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
             var broadcastMessage = (await gbTask) as GroupBroadcastDataMessage;
             Assert.NotNull(broadcastMessage);
             Assert.Equal($"hg-{hub}.group1", broadcastMessage.GroupName);
+
+            var disconnectTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage)).OrTimeout();
 
             // close transport layer
             proxy.TestConnectionContext.Application.Output.Complete();
@@ -575,6 +554,7 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
             // Validate client2 is still connected
             Assert.Single(ccm.ClientConnections);
             Assert.Equal(connectionId2, ccm.ClientConnections.FirstOrDefault().ConnectionId);
+            await proxy.WaitForConnectionClose.OrTimeout();
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -28,6 +28,10 @@ internal sealed class TestServiceConnectionHandler : ServiceConnectionManager
         {
             tcs.SetResult(serviceMessage);
         }
+        else
+        {
+            throw new InvalidOperationException("Not expected to write before tcs is inited");
+        }
 
         return Task.CompletedTask;
     }
@@ -48,18 +52,19 @@ internal sealed class TestServiceConnectionHandler : ServiceConnectionManager
 
     public Task<ServiceMessage> WaitForTransportOutputMessageAsync(Type messageType)
     {
-        if (_waitForTransportOutputMessage.TryGetValue(messageType, out var tcs))
-        {
-            tcs.TrySetCanceled();
-        }
-
         // re-init the tcs
-        tcs = _waitForTransportOutputMessage[messageType] = new TaskCompletionSource<ServiceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
-
+        var tcs = _waitForTransportOutputMessage.AddOrUpdate(messageType, t =>
+        {
+            return new TaskCompletionSource<ServiceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }, (t, old) =>
+        {
+            old.TrySetCanceled();
+            return new TaskCompletionSource<ServiceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        });
         return tcs.Task;
     }
 
-    public void DisposeServiceConnection(IServiceConnection connection)
+    public void DisposeServiceConnection(IServiceConnection _)
     {
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
@@ -37,13 +37,7 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
     [Fact]
     public void TestWeakConnectionStatus()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: e => true,
-            logChecker: s =>
-            {
-                Assert.Single(s);
-                Assert.Equal("EndpointOffline", s[0].Write.EventId.Name);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var endpoint1 = new TestHubServiceEndpoint();
             var conn1 = new TestServiceConnection();
@@ -68,19 +62,14 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
 
             conn1.SetStatus(ServiceConnectionStatus.Connected);
             Assert.True(endpoint1.Online);
+            logCollector.Expects("EndpointOffline");
         }
     }
 
     [Fact]
     public void TestStrongConnectionStatus()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: e => true,
-            logChecker: s =>
-            {
-                Assert.Single(s);
-                Assert.Equal("EndpointOffline", s[0].Write.EventId.Name);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var endpoint1 = new TestHubServiceEndpoint();
             var conn1 = new TestServiceConnection();
@@ -105,6 +94,7 @@ public class ServiceConnectionContainerBaseTests(ITestOutputHelper output) : Ver
 
             conn1.SetStatus(ServiceConnectionStatus.Connected);
             Assert.True(endpoint1.Online);
+            logCollector.Expects("EndpointOffline");
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
@@ -755,7 +755,7 @@ public class ServiceHubContextE2EFacts : VerifiableLoggedTest
     [SkipIfConnectionStringNotPresent]
     public async Task ServiceHubContextIndependencyTest()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, expectedErrors: context => context.EventId == new EventId(2, "EndpointOffline")))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             using var serviceManager = new ServiceManagerBuilder()
                 .WithOptions(o =>
@@ -771,6 +771,8 @@ public class ServiceHubContextE2EFacts : VerifiableLoggedTest
             await hubContext_1.DisposeAsync();
             await hubContext_2.Clients.All.SendAsync(MethodName, Message);
             await hubContext_2.DisposeAsync();
+
+            logCollector.Expects("EndpointOffline");
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/IVerifiableLog.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/IVerifiableLog.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.SignalR.Tests.Common;
+
+public interface IVerifiableLog : IDisposable
+{
+    LogRecord Expects(Func<LogRecord, bool> predicate);
+    LogRecord Expects(string logEventName);
+    IReadOnlyList<LogRecord> ExpectsMany(string logEventName);
+    IReadOnlyList<LogRecord> ExpectsMany(Func<LogRecord, bool> predicate);
+}

--- a/test/Microsoft.Azure.SignalR.Tests.Common/LogSinkProvider.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/LogSinkProvider.cs
@@ -1,11 +1,9 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 
@@ -27,7 +25,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
         {
         }
 
-        public IList<LogRecord> GetLogs() => _logs.ToList();
+        public IEnumerable<LogRecord> GetLogs() => _logs;
 
         public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/VerifiableLoggedTest.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/VerifiableLoggedTest.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -34,21 +36,19 @@ public class VerifiableLoggedTest(ITestOutputHelper output) : LoggedTest(output)
         }
     }
 
-    public virtual IDisposable StartVerifiableLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null, Func<WriteContext, bool> expectedErrors = null)
+    public virtual IVerifiableLog StartVerifiableLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null)
     {
         var disposable = StartLog(out loggerFactory, testName);
 
-        return new VerifyLogScope(loggerFactory, disposable, expectedErrors);
+        return new VerifyLogScope(loggerFactory, disposable);
     }
 
-    public virtual IDisposable StartVerifiableLog(out ILoggerFactory loggerFactory,
+    public virtual IVerifiableLog StartVerifiableLog(out ILoggerFactory loggerFactory,
                                                   LogLevel minLogLevel,
-                                                  [CallerMemberName] string testName = null,
-                                                  Func<WriteContext, bool> expectedErrors = null,
-                                                  Func<IList<LogRecord>, bool> logChecker = null)
+                                                  [CallerMemberName] string testName = null)
     {
         var disposable = StartLog(out loggerFactory, minLogLevel, testName);
 
-        return new VerifyLogScope(loggerFactory, disposable, expectedErrors, logChecker);
+        return new VerifyLogScope(loggerFactory, disposable);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
@@ -4,55 +4,72 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Testing;
+
+using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;
 
-internal class VerifyLogScope : IDisposable
+internal class VerifyLogScope : IVerifiableLog
 {
     private readonly IDisposable _wrappedDisposable;
-    private readonly Func<WriteContext, bool> _expectedErrors;
-    private readonly Func<IList<LogRecord>, bool> _logChecker;
     private readonly LogSinkProvider _sink;
+
+    private readonly List<Func<LogRecord, bool>> _expectedLogs = new();
 
     public ILoggerFactory LoggerFactory { get; }
 
-    public VerifyLogScope(ILoggerFactory loggerFactory = null, IDisposable wrappedDisposable = null, Func<WriteContext, bool> expectedErrors = null, Func<IList<LogRecord>, bool> logChecker = null)
+    public VerifyLogScope(ILoggerFactory loggerFactory = null, IDisposable wrappedDisposable = null)
     {
         _wrappedDisposable = wrappedDisposable;
-        _expectedErrors = expectedErrors;
-        _logChecker = logChecker;
         _sink = new LogSinkProvider();
 
         LoggerFactory = loggerFactory ?? new LoggerFactory();
         LoggerFactory.AddProvider(_sink);
     }
 
+    public LogRecord Expects(string logEventName) => Expects(i => i.Write.EventId.Name == logEventName);
+
+    public LogRecord Expects(Func<LogRecord, bool> predicate)
+    {
+        var matches = ExpectsMany(predicate);
+        Assert.NotEmpty(matches);
+        return matches[0];
+    }
+
+    public IReadOnlyList<LogRecord> ExpectsMany(string logEventName) => ExpectsMany(i => i.Write.EventId.Name == logEventName);
+
+    public IReadOnlyList<LogRecord> ExpectsMany(Func<LogRecord, bool> predicate)
+    {
+        _expectedLogs.Add(predicate);
+        return _sink.GetLogs().Where(predicate).ToArray();
+    }
+
     public void Dispose()
     {
         _wrappedDisposable?.Dispose();
-
-        var logs = _sink.GetLogs();
-        if (_logChecker?.Invoke(logs) == false)
+        var results = _sink.GetLogs().Where(i =>
         {
-            throw new InvalidOperationException("Failed checking log");
-        }
-
-        var results = _sink.GetLogs().Where(w => w.Write.LogLevel >= LogLevel.Error).ToList();
-
-        if (_expectedErrors != null)
-        {
-            if (results.Any(w => !_expectedErrors(w.Write)))
+            // Only check unexpected error logs
+            if (i.Write.LogLevel < LogLevel.Error)
             {
-                throw new InvalidOperationException("Fail to match expected error(s).");
+                return false;
             }
-            results = results.Where(w => !_expectedErrors(w.Write)).ToList();
-        }
 
-        if (results.Count > 0)
+            foreach (var filter in _expectedLogs)
+            {
+                if (filter(i))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }).ToArray();
+        if (results.Length > 0)
         {
-            string errorMessage = $"{results.Count} error(s) logged.";
+            string errorMessage = $"{results.Length} error(s) logged.";
             errorMessage += Environment.NewLine;
             errorMessage += string.Join(Environment.NewLine, results.Select(record =>
             {

--- a/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
@@ -206,11 +206,7 @@ public class ClientConnectionContextFacts : VerifiableLoggedTest
     [Fact]
     public async Task TestPauseResume()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Information, logChecker: records =>
-        {
-            return records.Any(r => r.Write.EventId == 8) && 
-                   records.Single(r => r.Write.EventId == 9) != null;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
         {
             using var serviceConnection = new TestServiceConnection();
 
@@ -258,16 +254,15 @@ public class ClientConnectionContextFacts : VerifiableLoggedTest
             var actual = Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[1]);
             Assert.Equal(connectionId, actual.ConnectionId);
             Assert.Equal(hubProtocol.GetMessageBytes(expect).ToArray(), actual.Payload.ToArray());
+            logCollector.Expects("OutgoingTaskPaused");
+            logCollector.Expects("OutgoingTaskResume");
         }
     }
 
     [Fact]
     public async Task TestPauseAck()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Information, logChecker: records =>
-        {
-            return records.Single(r => r.Write.EventId == 10) != null;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
         {
             using var serviceConnection = new TestServiceConnection();
 
@@ -311,6 +306,7 @@ public class ClientConnectionContextFacts : VerifiableLoggedTest
             Assert.Equal(connectionId, message.ConnectionId);
             Assert.Equal(ServiceProtocol.ConnectionType.Client, message.ConnectionType);
             Assert.Equal(ServiceProtocol.ConnectionFlowControlOperation.PauseAck, message.Operation);
+            logCollector.Expects("OutgoingTaskPauseAck");
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -139,11 +139,11 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new("a", "a", -1);
 
-    private readonly string ConnectionString1 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url1);
+    private static readonly string ConnectionString1 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url1);
 
-    private readonly string ConnectionString2 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url2);
+    private static readonly string ConnectionString2 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url2);
 
-    private readonly string ConnectionString3 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url3);
+    private static readonly string ConnectionString3 = string.Format(CultureInfo.InvariantCulture, ConnectionStringFormatter, Url3);
 
     public MultiEndpointServiceConnectionContainerTests(ITestOutputHelper output) : base(output)
     {
@@ -473,14 +473,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllOfflineSucceedsWithWarning()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, logChecker: logs =>
-        {
-            var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
-
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-            return true;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var sem = new TestServiceEndpointManager(
                 new ServiceEndpoint(ConnectionString1),
@@ -502,19 +495,17 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             _ = container.StartAsync();
             await container.ConnectionInitializedTask;
             await container.WriteAckableMessageAsync(DefaultGroupMessage);
+            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
+
+            Assert.Single(warns);
+            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
         }
     }
 
     [Fact]
     public async Task TestContainerWithTwoOfflineEndpointWriteAckableMessageSucceedsWithWarning()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, logChecker: logs =>
-        {
-            var warns = logs.Where(s => s.Write.LogLevel == LogLevel.Warning).ToList();
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-            return true;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var sem = new TestServiceEndpointManager(
             new ServiceEndpoint(ConnectionString1),
@@ -535,6 +526,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             await container.ConnectionInitializedTask;
 
             await container.WriteAckableMessageAsync(DefaultGroupMessage);
+            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
+            Assert.Single(warns);
+            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -27,16 +27,7 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
     [InlineData(3, 1, 0)]
     public async Task TestServersPing(int startCount, int stopCount, int expectedWarn)
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, logChecker: logs =>
-        {
-            var warns = logs.Where(s => s.Write.EventId.Name == "TimerAlreadyStopped").ToList();
-            Assert.Equal(expectedWarn, warns.Count);
-            if (expectedWarn > 0)
-            {
-                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
-            }
-            return true;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var connections = new List<IServiceConnection>
             {
@@ -78,6 +69,12 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
                 stopCount--;
             }
             await Task.WhenAll(tasks);
+            var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
+            Assert.Equal(expectedWarn, warns.Count);
+            if (expectedWarn > 0)
+            {
+                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
+            }
         }
     }
 
@@ -88,16 +85,7 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
     [InlineData(1, 3, 2, 2, 2)] // first time error stop won't break second time write.
     public async Task TestServersPingWorkSecondTime(int firstStart, int firstStop, int secondStart, int secondStop, int expectedWarn)
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug, logChecker: logs =>
-        {
-            var warns = logs.Where(s => s.Write.EventId.Name == "TimerAlreadyStopped").ToList();
-            Assert.Equal(expectedWarn, warns.Count);
-            if (expectedWarn > 0)
-            {
-                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
-            }
-            return true;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
             var connections = new List<IServiceConnection>
             {
@@ -158,6 +146,12 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
                 secondStop--;
             }
             await Task.WhenAll(tasks);
+            var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
+            Assert.Equal(expectedWarn, warns.Count);
+            if (expectedWarn > 0)
+            {
+                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
+            }
         }
     }
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -36,10 +36,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestServiceConnectionHandleOfflineMessageTask()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Information, logChecker: logs =>
-        {
-            return logs.Where(x => x.Write.EventId.Name == "ReceivedConnectionOffline").Single() != null;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory);
@@ -72,17 +69,14 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
             await connectionTask.OrTimeout();
             Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+            logCollector.Expects("ReceivedConnectionOffline");
         }
     }
 
     [Fact]
     public async Task TestServiceConnectionHandlePauseMessageTask()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Information, logChecker: logs =>
-        {
-            return logs.Where(x => x.Write.EventId.Name == "OutgoingTaskPaused").Count() == 2
-                && logs.Where(x => x.Write.EventId.Name == "OutgoingTaskPauseAck").SingleOrDefault() != null;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory);
@@ -128,16 +122,15 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
             await connectionTask.OrTimeout();
             Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+            logCollector.Expects("OutgoingTaskPaused");
+            logCollector.Expects("OutgoingTaskPauseAck");
         }
     }
 
     [Fact]
     public async Task TestServiceConnectionHandleResumeMessageTask()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Information, logChecker: logs =>
-        {
-            return logs.Where(x => x.Write.EventId.Name == "OutgoingTaskResume").SingleOrDefault() != null;
-        }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory);
@@ -173,6 +166,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
             await connectionTask.OrTimeout();
             Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+            logCollector.Expects("OutgoingTaskResume");
         }
     }
 
@@ -286,14 +280,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestServiceConnectionWithErrorApplicationTask()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                Assert.Equal(2, logs.Count);
-                Assert.Equal("SendLoopStopped", logs[0].Write.EventId.Name);
-                Assert.Equal("ApplicationTaskFailed", logs[1].Write.EventId.Name);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory);
@@ -347,6 +334,8 @@ public class ServiceConnectionTests : VerifiableLoggedTest
             await connectionTask.OrTimeout();
             Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
             Assert.Empty(ccm.ClientConnections);
+            logCollector.Expects("SendLoopStopped");
+            logCollector.Expects("ApplicationTaskFailed");
         }
     }
 
@@ -354,14 +343,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     public async Task TestServiceConnectionWithEndlessApplicationTaskNeverEnds()
     {
         var clientConnectionId = Guid.NewGuid().ToString();
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                Assert.Single(logs);
-                Assert.Equal("DetectedLongRunningApplicationTask", logs[0].Write.EventId.Name);
-                Assert.Equal($"The connection {clientConnectionId} has a long running application logic that prevents the connection from complete after 1 milliseconds.", logs[0].Write.Message);
-                return true;
-            }))
+        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 1);
@@ -418,19 +400,15 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
             // since the service connection ends, the client connection is cleaned up from the collection...
             Assert.Empty(ccm.ClientConnections);
+            var log = logCollector.Expects("DetectedLongRunningApplicationTask");
+            Assert.Equal($"The connection {clientConnectionId} has a long running application logic that prevents the connection from complete after 1 milliseconds.", log.Write.Message);
         }
     }
 
     [Fact]
     public async Task TestClientConnectionOutgoingAbortCanEndLifeTime()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                // Cancel does not need to throw
-                Assert.Empty(logs);
-                return true;
-            }))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 500);
@@ -494,8 +472,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestClientConnectionContextAbortCanSendOutCloseMessage()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 500);
@@ -657,7 +634,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [InlineData("anotherheader", false)]
     public async Task TestClientConnectionShouldSkipHandshakeWhenMigrateIn(string headerKey, bool shoudSkip)
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, logChecker: logs => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 500);
@@ -741,12 +718,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestClientConnectionLastWillCanSendOut()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                Assert.Empty(logs);
-                return true;
-            }))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 1000);
@@ -809,12 +781,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestPartialMessagesShouldFlushCorrectly()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                Assert.Empty(logs);
-                return true;
-            }))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 500);
@@ -908,12 +875,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestPartialMessagesShouldBeRemovedWhenReconnected()
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning, expectedErrors: c => true,
-            logChecker: logs =>
-            {
-                Assert.Empty(logs);
-                return true;
-            }))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
         {
             var ccm = new TestClientConnectionManager();
             var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 500);

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -264,7 +264,7 @@ public class ServiceMessageTests : VerifiableLoggedTest
     [InlineData(121, false)] // becomes unavailable only after the key has expired.
     public async Task TestAccessKeyResponseMessageWithError(int minutesElapsed, bool expectAvailable)
     {
-        using (StartVerifiableLog(out var loggerFactory, LogLevel.Error, expectedErrors: c => true))
+        using (StartVerifiableLog(out var loggerFactory, LogLevel.Error))
         {
             var endpoint = new TestHubServiceEndpoint(endpoint: new TestServiceEndpoint(new DefaultAzureCredential()));
             var key = Assert.IsType<MicrosoftEntraAccessKey>(endpoint.AccessKey);


### PR DESCRIPTION
The previous delegate pattern hides the real issue thrown from the inner code block
Change to expose `Expects` and `ExpectsMany` assertion methods for log validation.

And some minor fixes for some test race conditions.