### PR TITLE
Fix client invocation bug with multiple endpoints

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
@@ -141,7 +141,7 @@ internal class DispatcherHelper
             configuration.Resolver.Register(typeof(IServiceConnectionFactory), () => scf);
         }
 
-        var sccf = new ServiceConnectionContainerFactory(scf, endpoint, router, options, loggerFactory);
+        var sccf = new ServiceConnectionContainerFactory(scf, endpoint, router, options, null, loggerFactory);
 
         if (hubs?.Count > 0)
         {

--- a/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;
@@ -31,5 +31,8 @@ namespace Microsoft.Azure.SignalR
         bool TryCompleteResult(string connectionId, ErrorCompletionMessage message);
 
         void RemoveInvocation(string invocationId);
+
+        void SetAckNumber(string invocationId, int ackNumber);
+
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;

--- a/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ClientInvocation/ICallerClientResultsManager.cs
@@ -33,6 +33,5 @@ namespace Microsoft.Azure.SignalR
         void RemoveInvocation(string invocationId);
 
         void SetAckNumber(string invocationId, int ackNumber);
-
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -58,6 +59,13 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
         {
             // Accroding to target endpoints in method `WriteMultiEndpointMessageAsync`
             _clientInvocationManager.Caller.SetAckNumber(invocationMessage.InvocationId, TargetEndpoints.Length);
+            if (TargetEndpoints.Length == 0)
+            {
+                _clientInvocationManager.Caller.TryCompleteResult(
+                    invocationMessage.ConnectionId,
+                    CompletionMessage.WithError(invocationMessage.InvocationId, "No available endpoint to send invocation message.")
+                );
+            }
         }
 
         return WriteMultiEndpointMessageAsync(serviceMessage, connection => connection.WriteAsync(serviceMessage));

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointMessageWriter.cs
@@ -21,11 +21,13 @@ namespace Microsoft.Azure.SignalR;
 internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceManager
 {
     private readonly ILogger _logger;
+    private readonly IClientInvocationManager _clientInvocationManager;
 
     internal HubServiceEndpoint[] TargetEndpoints { get; }
 
-    public MultiEndpointMessageWriter(IReadOnlyCollection<ServiceEndpoint> targetEndpoints, ILoggerFactory loggerFactory)
+    public MultiEndpointMessageWriter(IReadOnlyCollection<ServiceEndpoint> targetEndpoints, IClientInvocationManager invocationManager, ILoggerFactory loggerFactory)
     {
+        _clientInvocationManager = invocationManager;
         _logger = loggerFactory.CreateLogger<MultiEndpointMessageWriter>();
         var normalized = new List<HubServiceEndpoint>();
         if (targetEndpoints != null)
@@ -52,6 +54,12 @@ internal class MultiEndpointMessageWriter : IServiceMessageWriter, IPresenceMana
 
     public Task WriteAsync(ServiceMessage serviceMessage)
     {
+        if (serviceMessage is ClientInvocationMessage invocationMessage)
+        {
+            // Accroding to target endpoints in method `WriteMultiEndpointMessageAsync`
+            _clientInvocationManager.Caller.SetAckNumber(invocationMessage.InvocationId, TargetEndpoints.Length);
+        }
+
         return WriteMultiEndpointMessageAsync(serviceMessage, connection => connection.WriteAsync(serviceMessage));
     }
 

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -30,6 +30,8 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
 
     private readonly object _lock = new object();
 
+    private readonly IClientInvocationManager _clientInvocationManager;
+
     private (bool needRouter, IReadOnlyList<HubServiceEndpoint> endpoints) _routerEndpoints;
 
     private int _started;
@@ -56,6 +58,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         int? maxCount,
         IServiceEndpointManager endpointManager,
         IMessageRouter router,
+        IClientInvocationManager clientInvocationManager,
         ILoggerFactory loggerFactory,
         TimeSpan? scaleTimeout = null
         ) : this(
@@ -63,6 +66,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
             endpoint => CreateContainer(serviceConnectionFactory, endpoint, count, maxCount, loggerFactory),
             endpointManager,
             router,
+            clientInvocationManager,
             loggerFactory,
             scaleTimeout)
     {
@@ -73,6 +77,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         Func<HubServiceEndpoint, IServiceConnectionContainer> generator,
         IServiceEndpointManager endpointManager,
         IMessageRouter router,
+        IClientInvocationManager clientInvocationManager,
         ILoggerFactory loggerFactory,
         TimeSpan? scaleTimeout = null)
     {
@@ -90,6 +95,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         _loggerFactory = loggerFactory;
         _logger = loggerFactory?.CreateLogger<MultiEndpointServiceConnectionContainer>() ?? throw new ArgumentNullException(nameof(loggerFactory));
         _serviceEndpointManager = endpointManager;
+        _clientInvocationManager = clientInvocationManager;
         _scaleTimeout = scaleTimeout ?? Constants.Periods.DefaultScaleTimeout;
 
         // Reserve generator for potential scale use.
@@ -158,7 +164,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
     public IAsyncEnumerable<GroupMember> ListConnectionsInGroupAsync(string groupName, int? top = null, ulong? tracingId = null, CancellationToken token = default)
     {
         var targetEndpoints = _routerEndpoints.needRouter ? _router.GetEndpointsForGroup(groupName, _routerEndpoints.endpoints) : _routerEndpoints.endpoints;
-        var messageWriter = new MultiEndpointMessageWriter(targetEndpoints?.ToList(), _loggerFactory);
+        var messageWriter = new MultiEndpointMessageWriter(targetEndpoints?.ToList(), _clientInvocationManager, _loggerFactory);
         return messageWriter.ListConnectionsInGroupAsync(groupName, top, tracingId, token);
     }
 
@@ -271,7 +277,7 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
     private MultiEndpointMessageWriter CreateMessageWriter(ServiceMessage serviceMessage)
     {
         var targetEndpoints = GetRoutedEndpoints(serviceMessage)?.ToList();
-        return new MultiEndpointMessageWriter(targetEndpoints, _loggerFactory);
+        return new MultiEndpointMessageWriter(targetEndpoints, _clientInvocationManager, _loggerFactory);
     }
 
     private void OnAdd(HubServiceEndpoint endpoint)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -18,16 +18,20 @@ internal class ServiceConnectionContainerFactory : IServiceConnectionContainerFa
 
     private readonly IServiceConnectionFactory _serviceConnectionFactory;
 
+    private readonly IClientInvocationManager _clientInvocationManager;
+
     public ServiceConnectionContainerFactory(IServiceConnectionFactory serviceConnectionFactory,
                                              IServiceEndpointManager serviceEndpointManager,
                                              IMessageRouter router,
                                              IServiceEndpointOptions options,
+                                             IClientInvocationManager clientInvocationManager,
                                              ILoggerFactory loggerFactory)
     {
         _serviceConnectionFactory = serviceConnectionFactory;
         _serviceEndpointManager = serviceEndpointManager ?? throw new ArgumentNullException(nameof(serviceEndpointManager));
         _router = router ?? throw new ArgumentNullException(nameof(router));
         _options = options;
+        _clientInvocationManager = clientInvocationManager;
         _loggerFactory = loggerFactory;
     }
 
@@ -39,6 +43,7 @@ internal class ServiceConnectionContainerFactory : IServiceConnectionContainerFa
                                                            _options.MaxHubServerConnectionCount,
                                                            _serviceEndpointManager,
                                                            _router,
+                                                           _clientInvocationManager,
                                                            _loggerFactory,
                                                            serviceScaleTimeout);
     }

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.SignalR.Common;
@@ -14,14 +14,16 @@ namespace Microsoft.Azure.SignalR.Management
         private readonly IServiceEndpointManager _endpointManager;
         private readonly int _connectionCount;
         private readonly IEndpointRouter _router;
+        private readonly IClientInvocationManager _clientInvocationManager;
 
-        public MultiEndpointConnectionContainerFactory(IServiceConnectionFactory connectionFactory, ILoggerFactory loggerFactory, IServiceEndpointManager serviceEndpointManager, IOptions<ServiceManagerOptions> options, IEndpointRouter router = null)
+        public MultiEndpointConnectionContainerFactory(IServiceConnectionFactory connectionFactory, ILoggerFactory loggerFactory, IServiceEndpointManager serviceEndpointManager, IOptions<ServiceManagerOptions> options, IEndpointRouter router = null, IClientInvocationManager clientInvocationManager = null)
         {
             _connectionFactory = connectionFactory;
             _loggerFactory = loggerFactory;
             _endpointManager = serviceEndpointManager;
             _connectionCount = options.Value.ConnectionCount;
             _router = router;
+            _clientInvocationManager = clientInvocationManager;
         }
 
         public MultiEndpointServiceConnectionContainer Create(string hubName)
@@ -31,6 +33,7 @@ namespace Microsoft.Azure.SignalR.Management
                 endpoint => new WeakServiceConnectionContainer(_connectionFactory, _connectionCount, endpoint, _loggerFactory.CreateLogger<WeakServiceConnectionContainer>()),
                 _endpointManager,
                 _router,
+                _clientInvocationManager,
                 _loggerFactory);
             return container;
         }

--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/MultiEndpointConnectionContainerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.SignalR.Common;

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.SignalR.Management
         private sealed class MessageWriterServiceContainerWrapper : MultiEndpointMessageWriter, IServiceConnectionContainer
         {
             public MessageWriterServiceContainerWrapper(IReadOnlyCollection<ServiceEndpoint> targetEndpoints, ILoggerFactory loggerFactory)
-            : base(targetEndpoints, loggerFactory) { }
+            : base(targetEndpoints, null, loggerFactory) { }
 
             public Task StartAsync() => Task.CompletedTask;
 

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #if NET7_0_OR_GREATER
 using System;
@@ -204,6 +204,14 @@ namespace Microsoft.Azure.SignalR
         public void RemoveInvocation(string invocationId)
         {
             _pendingInvocations.TryRemove(invocationId, out _);
+        }
+
+        public void SetAckNumber(string invocationId, int ackNumber)
+        {
+            if (_pendingInvocations.TryGetValue(invocationId, out var item))
+            {
+                _ackHandler.SetExpectedCount(item.AckId, ackNumber);
+            }
         }
 
         // Unused, here to honor the IInvocationBinder interface but should never be called

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #if NET7_0_OR_GREATER
 using System;
@@ -47,8 +47,6 @@ namespace Microsoft.Azure.SignalR
             var ackNumber = _endpointRouter.GetEndpointsForConnection(connectionId, serviceEndpoints).Count();
 
             var multiAck = _ackHandler.CreateMultiAck(out var ackId);
-
-            _ackHandler.SetExpectedCount(ackId, ackNumber);
 
             // When the caller server is also the client router, Azure SignalR service won't send a ServiceMappingMessage to server.
             // To handle this condition, CallerClientResultsManager itself should record this mapping information rather than waiting for a ServiceMappingMessage sent by service. Only in this condition, this method is called with instanceId != null.

--- a/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
+++ b/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #if NET7_0_OR_GREATER
 using System;
@@ -42,9 +42,6 @@ namespace Microsoft.Azure.SignalR
             var tcs = new TaskCompletionSourceWithCancellation<T>(
                 cancellationToken,
                 () => TryCompleteResult(connectionId, CompletionMessage.WithError(invocationId, "Canceled")));
-
-            var serviceEndpoints = _serviceEndpointManager.GetEndpoints(hub);
-            var ackNumber = _endpointRouter.GetEndpointsForConnection(connectionId, serviceEndpoints).Count();
 
             var multiAck = _ackHandler.CreateMultiAck(out var ackId);
 

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceHubDispatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -195,6 +195,7 @@ internal class ServiceHubDispatcher<THub> where THub : Hub
                 _serviceEndpointManager,
                 _router,
                 _options,
+                _clientInvocationManager,
                 _loggerFactory
             );
         }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -132,6 +132,11 @@ namespace Microsoft.Azure.SignalR
             // The ack number of invocation will be set inside `WriteAsync`. So adding invocation should be first.
             var task = _clientInvocationManager.Caller.AddInvocation<T>(_hub, connectionId, invocationId, cancellationToken);
             await WriteAsync(message);
+            if (ServiceConnectionContainer is not MultiEndpointServiceConnectionContainer)
+            {
+                // `WriteAsync` in test class `TestServiceConnectionHandler` does not set ack number. Set the number manually.
+                _clientInvocationManager.Caller.SetAckNumber(invocationId, 1);
+            }
 
             // Exception handling follows https://source.dot.net/#Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs,349
             try

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -129,8 +129,9 @@ namespace Microsoft.Azure.SignalR
 
             var invocationId = _clientInvocationManager.Caller.GenerateInvocationId(connectionId);
             var message = AppendMessageTracingId(new ClientInvocationMessage(invocationId, connectionId, _callerId, SerializeAllProtocols(methodName, args, invocationId)));
-            await WriteAsync(message);
+            // The ack number of invocation will be set inside `WriteAsync`. So adding invocation should be first.
             var task = _clientInvocationManager.Caller.AddInvocation<T>(_hub, connectionId, invocationId, cancellationToken);
+            await WriteAsync(message);
 
             // Exception handling follows https://source.dot.net/#Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs,349
             try

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -486,7 +486,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                                                            Func<HubServiceEndpoint, IServiceConnectionContainer> generator,
                                                            IServiceEndpointManager endpoint,
                                                            IEndpointRouter router,
-                                                           ILoggerFactory loggerFactory) : base(hub, generator, endpoint, router, loggerFactory)
+                                                           ILoggerFactory loggerFactory) : base(hub, generator, endpoint, router, null, loggerFactory)
         {
         }
     }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -36,7 +36,7 @@ public class MultiEndpointMessageWriterTests
             endpoint.ConnectionContainer = containerMock.Object;
             targetEndpoints.Add(endpoint);
         }
-        var multiEndpointWriter = new MultiEndpointMessageWriter(targetEndpoints, Mock.Of<ILoggerFactory>());
+        var multiEndpointWriter = new MultiEndpointMessageWriter(targetEndpoints, null, Mock.Of<ILoggerFactory>());
         var resultMembers = new List<GroupMember>();
         await foreach (var member in multiEndpointWriter.ListConnectionsInGroupAsync("group", top))
         {

--- a/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET7_0_OR_GREATER
@@ -34,7 +34,8 @@ public class ClientInvocationManagerTests
     private static readonly List<string> TestInstanceIds = new() { "instance0", "instance1" };
     private static readonly List<string> TestServerIds = new() { "server1", "server2" };
     private const string SuccessCompleteResult = "success-result";
-    private const string ErrorCompleteResult = "error-result";
+    private const string CommonErrorCompleteResult = "error-result";
+    private const string NoEndpointErrorCompleteResult = "No available endpoint to send invocation message.";
 
     private static ClientInvocationManager GetTestClientInvocationManager(int endpointCount = 1, int badEndpointsCount = 0)
     {
@@ -82,6 +83,7 @@ public class ClientInvocationManagerTests
         var cancellationToken = new CancellationToken();
         // Server A knows the InstanceId of Client 2, so `instaceId` in `AddInvocation` is `targetClientInstanceId` 
         var task = clientInvocationManager.Caller.AddInvocation<string>("TestHub", connectionId, invocationId, cancellationToken);
+        clientInvocationManager.Caller.SetAckNumber(invocationId, 1);
 
         var ret = clientInvocationManager.Caller.TryGetInvocationReturnType(invocationId, out var t);
 
@@ -90,7 +92,7 @@ public class ClientInvocationManagerTests
 
         var completionMessage = isCompletionWithResult
             ? CompletionMessage.WithResult(invocationId, SuccessCompleteResult)
-            : CompletionMessage.WithError(invocationId, ErrorCompleteResult);
+            : CompletionMessage.WithError(invocationId, CommonErrorCompleteResult);
 
         ret = clientInvocationManager.Caller.TryCompleteResult(connectionId, completionMessage);
         Assert.True(ret);
@@ -104,7 +106,7 @@ public class ClientInvocationManagerTests
         catch (Exception e)
         {
             Assert.False(isCompletionWithResult);
-            Assert.Equal(ErrorCompleteResult, e.Message);
+            Assert.Equal(CommonErrorCompleteResult, e.Message);
         }
     }
 
@@ -131,12 +133,14 @@ public class ClientInvocationManagerTests
         var cancellationToken = new CancellationToken();
         // Server 1 doesn't know the InstanceId of Client 2, so `instaceId` is null for `AddInvocation`
         var task = ciManagers[0].Caller.AddInvocation<string>("TestHub", TestConnectionIds[0], invocationId, cancellationToken);
+        ciManagers[0].Caller.SetAckNumber(invocationId, 1);
         ciManagers[0].Caller.AddServiceMapping(new ServiceMappingMessage(invocationId, TestConnectionIds[1], TestInstanceIds[1]));
+
         ciManagers[1].Router.AddInvocation(TestConnectionIds[1], invocationId, serverIds[0], new CancellationToken());
 
         var completionMessage = isCompletionWithResult
                             ? CompletionMessage.WithResult(invocationId, SuccessCompleteResult)
-                            : CompletionMessage.WithError(invocationId, ErrorCompleteResult);
+                            : CompletionMessage.WithError(invocationId, CommonErrorCompleteResult);
 
         var ret = ciManagers[1].Router.TryCompleteResult(TestConnectionIds[1], completionMessage);
         Assert.True(ret);
@@ -156,17 +160,18 @@ public class ClientInvocationManagerTests
         catch (Exception e)
         {
             Assert.False(isCompletionWithResult);
-            Assert.Equal(ErrorCompleteResult, e.Message);
+            Assert.Equal(CommonErrorCompleteResult, e.Message);
         }
     }
 
     [Fact]
     public void TestCallerManagerCancellation()
     {
-        var clientInvocationManager = GetTestClientInvocationManager();
+        var clientInvocationManager = GetTestClientInvocationManager(1);
         var invocationId = clientInvocationManager.Caller.GenerateInvocationId(TestConnectionIds[0]);
         var cts = new CancellationTokenSource();
         var task = clientInvocationManager.Caller.AddInvocation<string>("TestHub", TestConnectionIds[0], invocationId, cts.Token);
+        clientInvocationManager.Caller.SetAckNumber(invocationId, 1);
 
         // Check if the invocation is existing
         Assert.True(clientInvocationManager.Caller.TryGetInvocationReturnType(invocationId, out _));
@@ -182,7 +187,6 @@ public class ClientInvocationManagerTests
     [Theory]
     [InlineData(true, 2, 0)]
     [InlineData(true, 2, 1)]
-    [InlineData(true, 2, 2)]
     [InlineData(false, 2, 0)]
     [InlineData(false, 2, 1)]
     [InlineData(false, 2, 2)]
@@ -191,15 +195,16 @@ public class ClientInvocationManagerTests
     // isCompletionWithResult: the invocation is completed with result or error 
     public async Task TestCompleteWithMultiEndpointAtLast(bool isCompletionWithResult, int endpointsCount, int badEndpointsCount)
     {
-        Assert.True(endpointsCount > 1);
-        Assert.True(endpointsCount >= badEndpointsCount);
-        var clientInvocationManager = GetTestClientInvocationManager(endpointsCount);
+        var availableEndpointsCount = endpointsCount - badEndpointsCount;
+        Assert.True(endpointsCount > 0 && availableEndpointsCount >= 0);
+        var clientInvocationManager = GetTestClientInvocationManager(endpointsCount, badEndpointsCount);
         var connectionId = TestConnectionIds[0];
         var invocationId = clientInvocationManager.Caller.GenerateInvocationId(connectionId);
 
         var cancellationToken = new CancellationToken();
         // Server A knows the InstanceId of Client 2, so `instaceId` in `AddInvocation` is `targetClientInstanceId` 
         var task = clientInvocationManager.Caller.AddInvocation<string>("TestHub", connectionId, invocationId, cancellationToken);
+        clientInvocationManager.Caller.SetAckNumber(invocationId, endpointsCount - badEndpointsCount);
 
         var ret = clientInvocationManager.Caller.TryGetInvocationReturnType(invocationId, out var t);
 
@@ -207,18 +212,17 @@ public class ClientInvocationManagerTests
         Assert.Equal(typeof(string), t);
 
         var completionMessage = CompletionMessage.WithResult(invocationId, SuccessCompleteResult);
-        var errorCompletionMessage = CompletionMessage.WithError(invocationId, ErrorCompleteResult);
+        var errorCompletionMessage = CompletionMessage.WithError(invocationId, availableEndpointsCount > 0 ?  CommonErrorCompleteResult : NoEndpointErrorCompleteResult);
 
         // The first `endpointsCount - 1` CompletionMessage complete the invocation with error
         // The last one completes the invocation according to `isCompletionWithResult`
         // The invocation should be uncompleted until the last one CompletionMessage
-        for (var i = 0; i < endpointsCount - 1; i++)
+        for (var i = 0; i < availableEndpointsCount - 1; i++)
         {
             var currentCompletionMessage = errorCompletionMessage;
             ret = clientInvocationManager.Caller.TryCompleteResult(connectionId, currentCompletionMessage);
             Assert.False(ret);
         }
-
         ret = clientInvocationManager.Caller.TryCompleteResult(connectionId, isCompletionWithResult ? completionMessage : errorCompletionMessage);
         Assert.True(ret);
 
@@ -226,12 +230,12 @@ public class ClientInvocationManagerTests
         {
             var result = await task;
             Assert.True(isCompletionWithResult);
-            Assert.Equal(SuccessCompleteResult, result);
+            Assert.Equal(completionMessage.Result, result);
         }
         catch (Exception e)
         {
             Assert.False(isCompletionWithResult);
-            Assert.Equal(ErrorCompleteResult, e.Message);
+            Assert.Equal(errorCompletionMessage.Error, e.Message);
         }
     }
 
@@ -248,6 +252,7 @@ public class ClientInvocationManagerTests
         var cancellationToken = new CancellationToken();
         // Server A knows the InstanceId of Client 2, so `instaceId` in `AddInvocation` is `targetClientInstanceId` 
         var task = clientInvocationManager.Caller.AddInvocation<string>("TestHub", connectionId, invocationId, cancellationToken);
+        clientInvocationManager.Caller.SetAckNumber(invocationId, endpointsCount);
 
         var ret = clientInvocationManager.Caller.TryGetInvocationReturnType(invocationId, out var t);
 
@@ -255,7 +260,7 @@ public class ClientInvocationManagerTests
         Assert.Equal(typeof(string), t);
 
         var successCompletionMessage = CompletionMessage.WithResult(invocationId, SuccessCompleteResult);
-        var errorCompletionMessage = CompletionMessage.WithError(invocationId, ErrorCompleteResult);
+        var errorCompletionMessage = CompletionMessage.WithError(invocationId, CommonErrorCompleteResult);
 
         // The first `endpointsCount - 2` CompletionMessage complete the invocation with error
         // The next one completes the invocation with result

--- a/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
@@ -36,12 +36,17 @@ public class ClientInvocationManagerTests
     private const string SuccessCompleteResult = "success-result";
     private const string ErrorCompleteResult = "error-result";
 
-    private static ClientInvocationManager GetTestClientInvocationManager(int endpointCount = 1)
+    private static ClientInvocationManager GetTestClientInvocationManager(int endpointCount = 1, int badEndpointsCount = 0)
     {
         var services = new ServiceCollection();
         var endpoints = Enumerable.Range(0, endpointCount)
             .Select(i => new ServiceEndpoint($"Endpoint=https://test{i}connectionstring;AccessKey=1"))
             .ToArray();
+
+        for (var i = 0; i < badEndpointsCount && i < endpointCount; i++)
+        {
+            endpoints[i].Online = false;
+        }
 
         var config = new ConfigurationBuilder().Build();
 
@@ -175,14 +180,19 @@ public class ClientInvocationManagerTests
     }
 
     [Theory]
-    [InlineData(true, 2)]
-    [InlineData(false, 2)]
-    [InlineData(true, 3)]
-    [InlineData(false, 3)]
+    [InlineData(true, 2, 0)]
+    [InlineData(true, 2, 1)]
+    [InlineData(true, 2, 2)]
+    [InlineData(false, 2, 0)]
+    [InlineData(false, 2, 1)]
+    [InlineData(false, 2, 2)]
+    [InlineData(true, 3, 0)]
+    [InlineData(false, 3, 0)]
     // isCompletionWithResult: the invocation is completed with result or error 
-    public async Task TestCompleteWithMultiEndpointAtLast(bool isCompletionWithResult, int endpointsCount)
+    public async Task TestCompleteWithMultiEndpointAtLast(bool isCompletionWithResult, int endpointsCount, int badEndpointsCount)
     {
         Assert.True(endpointsCount > 1);
+        Assert.True(endpointsCount >= badEndpointsCount);
         var clientInvocationManager = GetTestClientInvocationManager(endpointsCount);
         var connectionId = TestConnectionIds[0];
         var invocationId = clientInvocationManager.Caller.GenerateInvocationId(connectionId);

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -174,9 +174,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             var connectionFactory1 = new TestServiceConnectionFactory();
             var connectionFactory2 = new TestServiceConnectionFactory();
 
-            var hub1 = new MultiEndpointServiceConnectionContainer(connectionFactory1, "hub1", 2, null, sem, router,
+            var hub1 = new MultiEndpointServiceConnectionContainer(connectionFactory1, "hub1", 2, null, sem, router, null,
                 loggerFactory);
-            var hub2 = new MultiEndpointServiceConnectionContainer(connectionFactory2, "hub2", 2, null, sem, router,
+            var hub2 = new MultiEndpointServiceConnectionContainer(connectionFactory2, "hub2", 2, null, sem, router, null,
                 loggerFactory);
 
             var connections = connectionFactory1.CreatedConnections.SelectMany(kv => kv.Value).ToArray();
@@ -1985,7 +1985,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                                                       IEndpointRouter router,
                                                       ILoggerFactory loggerFactory,
                                                       TimeSpan? _ = null
-            ) : base(hub, generator, endpoint, router, loggerFactory)
+            ) : base(hub, generator, endpoint, router, null, loggerFactory)
         {
         }
 


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
 - It's wrong for a client invocation to simply use the number of endpoints as its ack number. See https://github.com/Azure/azure-signalr/blob/v1.30.2/src/Microsoft.Azure.SignalR/ClientInvocation/CallerClientResultsManager.cs
 - Now we use the actual number of endpoints which will be sent with client invocation message.
