### PR TITLE
nit: run code cleanup on AspNet tests

### DIFF
--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/AspNetSignalRServiceE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/AspNetSignalRServiceE2EFacts.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestClientSet.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestClientSet.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR.Client;
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests

--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestClientSetFactory.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestClientSetFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests

--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestHub.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.Azure.SignalR.Tests.Common;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests
 {
     public class TestHub : Hub
     {
-        private TestHubConnectionManager _testHubConnectionManager;
+        private readonly TestHubConnectionManager _testHubConnectionManager;
 
         public TestHub(TestHubConnectionManager testHubConnectionManager)
         {

--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestServer.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestServer.cs
@@ -6,11 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Owin.Hosting;
+
 using Owin;
+
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests

--- a/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestServerFactory.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.E2ETests/TestServerFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ClientConnectionManagerTests.cs
@@ -7,10 +7,12 @@ using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Transports;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
@@ -66,7 +68,7 @@ public class ClientConnectionManagerTests
     {
         var message = new OpenConnectionMessage(Guid.NewGuid().ToString("N"),
             new Claim[] {
-                new Claim(ClaimTypes.Name, "user1")
+                new(ClaimTypes.Name, "user1")
             },
             new Dictionary<string, StringValues>
             {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Owin;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,7 +26,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     private const string Url2 = "https://url2";
 
-    private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new JoinGroupWithAckMessage("a", "a");
+    private static readonly JoinGroupWithAckMessage DefaultGroupMessage = new("a", "a");
 
     private static readonly string ConnectionString1 = string.Format(ConnectionStringFormatter, Url1);
 
@@ -49,10 +51,10 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var router = new TestEndpointRouter(false);
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         // Start the container for it to disconnect
         _ = container.StartAsync();
@@ -82,22 +84,22 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var router = new TestEndpointRouter(false);
         var container1 = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         var container2 = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         var container3 = new TestMultiEndpointServiceConnectionContainer("hub-another",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         // Start the container for it to disconnect
         _ = container1.StartAsync();
@@ -154,10 +156,10 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var router = new TestEndpointRouter(false);
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
         await container.ConnectionInitializedTask.OrTimeout();
@@ -182,10 +184,10 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
         var router = new TestEndpointRouter(false);
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
         await container.ConnectionInitializedTask.OrTimeout();
@@ -207,7 +209,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     {
         Assert.Throws<AzureSignalRNoPrimaryEndpointException>(() => new TestServiceEndpointManager(new ServiceEndpoint[]
         {
-            new ServiceEndpoint(ConnectionString1, EndpointType.Secondary)
+            new(ConnectionString1, EndpointType.Secondary)
         }));
     }
 
@@ -217,7 +219,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         var sem = new TestServiceEndpointManager(new ServiceEndpoint(ConnectionString1));
         var router = new DefaultEndpointRouter();
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
@@ -225,7 +227,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
         await container.ConnectionInitializedTask.OrTimeout();
@@ -239,7 +241,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         var sem = new TestServiceEndpointManager(new ServiceEndpoint(ConnectionString1));
         var router = new TestEndpointRouter(false);
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
@@ -247,7 +249,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
         await container.ConnectionInitializedTask.OrTimeout();
@@ -261,7 +263,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         var sem = new TestServiceEndpointManager(new ServiceEndpoint(ConnectionString1));
         var router = new TestEndpointRouter(true);
         var container = new TestMultiEndpointServiceConnectionContainer("hub",
-            e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            e => new TestBaseServiceConnectionContainer([
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
@@ -269,7 +271,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestServiceConnection(),
             new TestServiceConnection(),
             new TestServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        ], e), sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
         await container.ConnectionInitializedTask.OrTimeout();
@@ -288,7 +290,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             var sem = new TestServiceEndpointManager(endpoint);
             var router = new DefaultEndpointRouter();
             var container = new TestMultiEndpointServiceConnectionContainer("hub",
-                e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                e => new TestBaseServiceConnectionContainer([
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -296,7 +298,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-            }, e), sem, router, loggerFactory);
+            ], e), sem, router, loggerFactory);
 
             _ = container.StartAsync();
             await container.ConnectionInitializedTask.OrTimeout();
@@ -317,7 +319,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             var logger = loggerFactory.CreateLogger<TestServiceConnection>();
             var router = new TestEndpointRouter(true);
             var container = new TestMultiEndpointServiceConnectionContainer("hub",
-                e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                e => new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(logger: logger),
                     new TestServiceConnection(logger: logger),
                     new TestServiceConnection(logger: logger),
@@ -325,7 +327,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(logger: logger),
                     new TestServiceConnection(logger: logger),
                     new TestServiceConnection(logger: logger),
-                }, e, logger), sem, router, loggerFactory);
+                ], e, logger), sem, router, loggerFactory);
             _ = Task.Run(container.StartAsync);
             await container.ConnectionInitializedTask.OrTimeout();
 
@@ -346,7 +348,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
             var router = new TestEndpointRouter(false);
             var container = new TestMultiEndpointServiceConnectionContainer("hub",
-                e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                e => new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
@@ -354,7 +356,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
-                }, e), sem, router, loggerFactory);
+                ], e), sem, router, loggerFactory);
 
             _ = container.StartAsync();
             await container.ConnectionInitializedTask.OrTimeout();
@@ -366,32 +368,30 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllOfflineSucceedsWithWarning()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var sem = new TestServiceEndpointManager(
-            new ServiceEndpoint(ConnectionString1),
-            new ServiceEndpoint(ConnectionString2));
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var sem = new TestServiceEndpointManager(
+        new ServiceEndpoint(ConnectionString1),
+        new ServiceEndpoint(ConnectionString2));
 
-            var router = new TestEndpointRouter(false);
-            var container = new TestMultiEndpointServiceConnectionContainer("hub",
-                e => new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+        var router = new TestEndpointRouter(false);
+        var container = new TestMultiEndpointServiceConnectionContainer("hub",
+            e => new TestBaseServiceConnectionContainer([
+        new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-            new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-            }, e), sem, router, loggerFactory);
+        ], e), sem, router, loggerFactory);
 
-            _ = container.StartAsync();
-            await container.ConnectionInitializedTask.OrTimeout();
-            await container.WriteAsync(DefaultGroupMessage);
-            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning).ToList();
+        _ = container.StartAsync();
+        await container.ConnectionInitializedTask.OrTimeout();
+        await container.WriteAsync(DefaultGroupMessage);
+        var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning).ToList();
 
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-        }
+        Assert.Single(warns);
+        Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             {
                 if (string.IsNullOrEmpty(e.Name))
                 {
-                    return new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                    return new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -416,9 +416,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-                    }, e);
+                    ], e);
                 }
-                return new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                return new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
@@ -426,7 +426,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
-                    }, e);
+                    ], e);
             }, sem, router, loggerFactory);
 
             _ = container.StartAsync();
@@ -447,7 +447,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         {
             if (string.IsNullOrEmpty(e.Name))
             {
-                return new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+                return new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -455,9 +455,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestServiceConnection(ServiceConnectionStatus.Disconnected),
-                }, e);
+                ], e);
             }
-            return new TestBaseServiceConnectionContainer(new List<IServiceConnection> {
+            return new TestBaseServiceConnectionContainer([
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
@@ -465,7 +465,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestServiceConnection(),
                     new TestServiceConnection(),
                     new TestServiceConnection(),
-                }, e);
+                ], e);
         }, sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 public class RunAzureSignalRTests : VerifiableLoggedTest
 {
-    private static readonly Version VersionSupportingApplicationNamePrefix = new Version(1, 0, 9);
+    private static readonly Version VersionSupportingApplicationNamePrefix = new(1, 0, 9);
 
     private const string ServiceUrl = "http://localhost:8086";
     private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
@@ -303,7 +303,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
         {
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
             using (WebApp.Start(ServiceUrl,
-                app => app.RunAzureSignalR(AppName, hubConfig, 
+                app => app.RunAzureSignalR(AppName, hubConfig,
                     s =>
                     {
                         s.ConnectionString = ConnectionString;
@@ -340,9 +340,9 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             {
                 options.Endpoints = new ServiceEndpoint[]
                 {
-                    new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
-                    new ServiceEndpoint(ConnectionString3),
-                    new ServiceEndpoint(ConnectionString4)
+                    new(ConnectionString2, EndpointType.Secondary),
+                    new(ConnectionString3),
+                    new(ConnectionString4)
                 };
             })))
             {
@@ -371,9 +371,9 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             {
                 options.Endpoints = new ServiceEndpoint[]
                 {
-                    new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
-                    new ServiceEndpoint(ConnectionString3),
-                    new ServiceEndpoint(ConnectionString4)
+                    new(ConnectionString2, EndpointType.Secondary),
+                    new(ConnectionString3),
+                    new(ConnectionString4)
                 };
             })))
             {
@@ -405,9 +405,9 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             {
                 options.Endpoints = new ServiceEndpoint[]
                 {
-                    new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
-                    new ServiceEndpoint(ConnectionString3, name: "chosen"),
-                    new ServiceEndpoint(ConnectionString4)
+                    new(ConnectionString2, EndpointType.Secondary),
+                    new(ConnectionString3, name: "chosen"),
+                    new(ConnectionString4)
                 };
             })))
             {
@@ -468,9 +468,9 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             {
                 options.Endpoints = new ServiceEndpoint[]
                 {
-                    new ServiceEndpoint(ConnectionString2, EndpointType.Secondary, "es"),
-                    new ServiceEndpoint(ConnectionString3, name: "tt3"),
-                    new ServiceEndpoint(ConnectionString4, name: "tt4", type: EndpointType.Secondary),
+                    new(ConnectionString2, EndpointType.Secondary, "es"),
+                    new(ConnectionString3, name: "tt3"),
+                    new(ConnectionString4, name: "tt4", type: EndpointType.Secondary),
                 };
             })))
             {
@@ -631,7 +631,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                 options.ConnectionString = ConnectionString;
                 options.ClaimsProvider = context => new Claim[]
                 {
-                new Claim("user", "hello"),
+                new("user", "hello"),
                 };
                 options.AccessTokenLifetime = TimeSpan.FromDays(1);
             })))
@@ -670,7 +670,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     {
         using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
-            Func<IOwinContext, bool> diagnosticClientFilter = context => context.Request.Query["diag"] != null;
+            bool diagnosticClientFilter(IOwinContext context) => context.Request.Query["diag"] != null;
             var hubConfiguration = Utility.GetTestHubConfig(loggerFactory);
             hubConfiguration.EnableDetailedErrors = true;
             using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
@@ -705,7 +705,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                 options.ConnectionString = ConnectionString;
                 options.ClaimsProvider = context => new Claim[]
                 {
-                new Claim("user", "hello"),
+                new("user", "hello"),
                 };
                 options.AccessTokenLifetime = TimeSpan.FromDays(1);
             })))
@@ -746,8 +746,10 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     {
         using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
-            var hubConfig = new HubConfiguration();
-            hubConfig.Resolver = new DefaultDependencyResolver();
+            var hubConfig = new HubConfiguration
+            {
+                Resolver = new DefaultDependencyResolver()
+            };
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, ConnectionString, hubConfig)))
             {
                 var client = new HttpClient { BaseAddress = new Uri(ServiceUrl) };
@@ -779,8 +781,10 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     [InlineData(500)]
     public void TestRunAzureSignalRWithInvalidMaxPollIntervalThrows(int maxPollInterval)
     {
-        var hubConfig = new HubConfiguration();
-        hubConfig.Resolver = new DefaultDependencyResolver();
+        var hubConfig = new HubConfiguration
+        {
+            Resolver = new DefaultDependencyResolver()
+        };
         var exception = Assert.Throws<AzureSignalRInvalidServiceOptionsException>(
                 () =>
                 {
@@ -857,7 +861,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
 
     private sealed class TestLoggerProvider : ILoggerProvider
     {
-        public List<string> Loggers { get; } = new List<string>();
+        public List<string> Loggers { get; } = [];
         public void Dispose()
         {
         }
@@ -960,7 +964,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
         }
     }
 
-    private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new JwtSecurityTokenHandler();
+    private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
 
     private sealed class ResponseMessage
     {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceConnectionTests.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Transports;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -150,46 +152,44 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionWithErrorConnectHub()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var hubConfig = Utility.GetActualHubConfig(loggerFactory);
-            var appName = "app1";
-            var hub = "ErrorConnect"; // error connect hub
-            var scm = new TestServiceConnectionHandler();
-            hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
-            var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
-            hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
-            DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig, new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
-            using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var hubConfig = Utility.GetActualHubConfig(loggerFactory);
+        var appName = "app1";
+        var hub = "ErrorConnect"; // error connect hub
+        var scm = new TestServiceConnectionHandler();
+        hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
+        var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+        hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
+        DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig, new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
+        using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
 
-            // start the server connection
-            await proxy.StartServiceAsync().OrTimeout();
+        // start the server connection
+        await proxy.StartServiceAsync().OrTimeout();
 
-            var clientConnection = Guid.NewGuid().ToString("N");
+        var clientConnection = Guid.NewGuid().ToString("N");
 
-            var connectTask = proxy.WaitForOutgoingMessageAsync(clientConnection).OrTimeout();
+        var connectTask = proxy.WaitForOutgoingMessageAsync(clientConnection).OrTimeout();
 
-            // Application layer sends OpenConnectionMessage
-            var openConnectionMessage = new OpenConnectionMessage(clientConnection, [], null, $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
-            await proxy.WriteMessageAsync(openConnectionMessage);
+        // Application layer sends OpenConnectionMessage
+        var openConnectionMessage = new OpenConnectionMessage(clientConnection, [], null, $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
+        await proxy.WriteMessageAsync(openConnectionMessage);
 
-            // other messages are just ignored because OnConnected failed
-            await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"JoinGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
+        // other messages are just ignored because OnConnected failed
+        await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"JoinGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
 
-            await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"LeaveGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
+        await proxy.WriteMessageAsync(new ConnectionDataMessage(clientConnection, Encoding.UTF8.GetBytes($"{{\"H\":\"{hub}\",\"M\":\"LeaveGroup\",\"A\":[\"user1\",\"group1\"],\"I\":1}}")));
 
-            await proxy.WriteMessageAsync(new CloseConnectionMessage(clientConnection));
+        await proxy.WriteMessageAsync(new CloseConnectionMessage(clientConnection));
 
-            var message = await connectTask;
+        var message = await connectTask;
 
-            Assert.True(message is CloseConnectionMessage);
+        Assert.True(message is CloseConnectionMessage);
 
-            // cleaned up clearly
-            Assert.Empty(ccm.ClientConnections);
+        // cleaned up clearly
+        Assert.Empty(ccm.ClientConnections);
 
-            logCollector.Expects("ErrorExecuteConnected");
-            logCollector.Expects("ConnectedStartingFailed");
-        }
+        logCollector.Expects("ErrorExecuteConnected");
+        logCollector.Expects("ConnectedStartingFailed");
     }
 
     [Fact]
@@ -253,64 +253,60 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionDispatchOpenConnectionToUnauthorizedHubTest()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var hubConfig = new HubConfiguration();
-            var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
-            hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
-            using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var hubConfig = new HubConfiguration();
+        var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+        hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
+        using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
 
-            // start the server connection
-            await proxy.StartServiceAsync().OrTimeout();
+        // start the server connection
+        await proxy.StartServiceAsync().OrTimeout();
 
-            var connectionId = Guid.NewGuid().ToString("N");
-            var connectTask = proxy.WaitForOutgoingMessageAsync(connectionId).OrTimeout();
+        var connectionId = Guid.NewGuid().ToString("N");
+        var connectTask = proxy.WaitForOutgoingMessageAsync(connectionId).OrTimeout();
 
-            // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
-            var openConnectionMessage = new OpenConnectionMessage(connectionId, [], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
-            await proxy.WriteMessageAsync(openConnectionMessage);
+        // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
+        var openConnectionMessage = new OpenConnectionMessage(connectionId, [], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
+        await proxy.WriteMessageAsync(openConnectionMessage);
 
-            var message = await connectTask;
+        var message = await connectTask;
 
-            Assert.True(message is CloseConnectionMessage);
+        Assert.True(message is CloseConnectionMessage);
 
-            // Verify client connection is not created due to authorized failure.
-            Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
-            var log = logCollector.Expects("ConnectedStartingFailed");
-            Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
-        }
+        // Verify client connection is not created due to authorized failure.
+        Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
+        var log = logCollector.Expects("ConnectedStartingFailed");
+        Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
     }
 
     [Fact]
     public async Task ServiceConnectionWithNormalClientConnection()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var hubConfig = new HubConfiguration();
-            var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
-            hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
-            using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var hubConfig = new HubConfiguration();
+        var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+        hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
+        using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory: loggerFactory);
 
-            // start the server connection
-            await proxy.StartServiceAsync().OrTimeout();
+        // start the server connection
+        await proxy.StartServiceAsync().OrTimeout();
 
-            var connectionId = Guid.NewGuid().ToString("N");
+        var connectionId = Guid.NewGuid().ToString("N");
 
-            var connectTask = proxy.WaitForOutgoingMessageAsync(connectionId).OrTimeout();
+        var connectTask = proxy.WaitForOutgoingMessageAsync(connectionId).OrTimeout();
 
-            // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
-            var openConnectionMessage = new OpenConnectionMessage(connectionId, [], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
-            await proxy.WriteMessageAsync(openConnectionMessage);
+        // Application layer sends OpenConnectionMessage to an authorized hub from anonymous user
+        var openConnectionMessage = new OpenConnectionMessage(connectionId, [], null, "?transport=webSockets&connectionData=%5B%7B%22name%22%3A%22authchat%22%7D%5D");
+        await proxy.WriteMessageAsync(openConnectionMessage);
 
-            var message = await connectTask;
+        var message = await connectTask;
 
-            Assert.True(message is CloseConnectionMessage);
+        Assert.True(message is CloseConnectionMessage);
 
-            // Verify client connection is not created due to authorized failure.
-            Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
-            var log = logCollector.Expects("ConnectedStartingFailed");
-            Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
-        }
+        // Verify client connection is not created due to authorized failure.
+        Assert.False(ccm.TryGetClientConnection(connectionId, out var connection));
+        var log = logCollector.Expects("ConnectedStartingFailed");
+        Assert.Equal("Unable to authorize request", log.Write.Exception.Message);
     }
 
     [Theory]
@@ -367,55 +363,53 @@ public class ServiceConnectionTests(ITestOutputHelper output) : VerifiableLogged
     [Fact]
     public async Task ServiceConnectionWithTransportLayerClosedShouldCleanupEndlessConnectClientConnections()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
-        {
-            var hubConfig = Utility.GetActualHubConfig(loggerFactory);
-            var appName = "app1";
-            var hub = "EndlessConnect";
-            var scm = new TestServiceConnectionHandler();
-            hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
-            var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
-            hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
-            DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig,
-                new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
-            using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory);
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug);
+        var hubConfig = Utility.GetActualHubConfig(loggerFactory);
+        var appName = "app1";
+        var hub = "EndlessConnect";
+        var scm = new TestServiceConnectionHandler();
+        hubConfig.Resolver.Register(typeof(IServiceConnectionManager), () => scm);
+        var ccm = new ClientConnectionManager(hubConfig, loggerFactory);
+        hubConfig.Resolver.Register(typeof(IClientConnectionManagerAspNet), () => ccm);
+        DispatcherHelper.PrepareAndGetDispatcher(new TestAppBuilder(), hubConfig,
+            new ServiceOptions { ConnectionString = ConnectionString }, appName, loggerFactory);
+        using var proxy = new TestServiceConnectionProxy(ccm, loggerFactory);
 
-            // start the server connection
-            var connectionTask = proxy.StartAsync();
-            await proxy.ConnectionInitializedTask.OrTimeout();
+        // start the server connection
+        var connectionTask = proxy.StartAsync();
+        await proxy.ConnectionInitializedTask.OrTimeout();
 
-            var clientConnection = Guid.NewGuid().ToString("N");
+        var clientConnection = Guid.NewGuid().ToString("N");
 
-            var connectTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage))
-                .OrTimeout();
+        var connectTask = scm.WaitForTransportOutputMessageAsync(typeof(GroupBroadcastDataMessage))
+            .OrTimeout();
 
-            // Application layer sends OpenConnectionMessage
-            var openConnectionMessage = new OpenConnectionMessage(clientConnection, [], null,
-                $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
-            await proxy.WriteMessageAsync(openConnectionMessage);
-            var connectMessage = (await connectTask) as GroupBroadcastDataMessage;
-            Assert.NotNull(connectMessage);
-            Assert.Equal($"hg-{hub}.note", connectMessage.GroupName);
+        // Application layer sends OpenConnectionMessage
+        var openConnectionMessage = new OpenConnectionMessage(clientConnection, [], null,
+            $"?transport=webSockets&connectionToken=conn1&connectionData=%5B%7B%22name%22%3A%22{hub}%22%7D%5D");
+        await proxy.WriteMessageAsync(openConnectionMessage);
+        var connectMessage = (await connectTask) as GroupBroadcastDataMessage;
+        Assert.NotNull(connectMessage);
+        Assert.Equal($"hg-{hub}.note", connectMessage.GroupName);
 
-            var message = connectMessage.Payloads["json"]
-                .GetJsonMessageFromSingleFramePayload<HubResponseItem>();
+        var message = connectMessage.Payloads["json"]
+            .GetJsonMessageFromSingleFramePayload<HubResponseItem>();
 
-            Assert.Equal("Connected", message.A[0]);
+        Assert.Equal("Connected", message.A[0]);
 
-            Assert.Single(ccm.ClientConnections);
+        Assert.Single(ccm.ClientConnections);
 
-            // close transport layer
-            proxy.TestConnectionContext.Application.Output.Complete();
+        // close transport layer
+        proxy.TestConnectionContext.Application.Output.Complete();
 
-            // wait for application task to timeout
-            await proxy.WaitForConnectionClose.OrTimeout(30000);
-            Assert.Equal(ServiceConnectionStatus.Disconnected, proxy.Status);
+        // wait for application task to timeout
+        await proxy.WaitForConnectionClose.OrTimeout(30000);
+        Assert.Equal(ServiceConnectionStatus.Disconnected, proxy.Status);
 
-            // cleaned up clearly
-            Assert.Empty(ccm.ClientConnections);
+        // cleaned up clearly
+        Assert.Empty(ccm.ClientConnections);
 
-            logCollector.Expects("ApplicationTaskTimedOut");
-        }
+        logCollector.Expects("ApplicationTaskTimedOut");
     }
 
     [Fact]

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceEndpointProviderTests.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+
 using Microsoft.IdentityModel.Tokens;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
@@ -16,9 +18,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests;
 public class ServiceEndpointProviderTests
 {
     private const string SigningKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    private static readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SigningKey));
+    private static readonly SymmetricSecurityKey SecurityKey = new(Encoding.UTF8.GetBytes(SigningKey));
     private const string DefaultConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0";
-
 
     [Theory]
     [InlineData("Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Port=8080;Version=1.0", "http://localhost/aspnetclient")]
@@ -30,7 +31,7 @@ public class ServiceEndpointProviderTests
 
         var clientToken = await provider.GenerateClientAccessTokenAsync(null, new Claim[]
         {
-            new Claim("type1", "value1")
+            new("type1", "value1")
         });
 
         var handler = new JwtSecurityTokenHandler();
@@ -39,7 +40,7 @@ public class ServiceEndpointProviderTests
             ValidateIssuer = false,
             IssuerSigningKey = SecurityKey,
             ValidAudience = expectedAudience
-        }, out var token);
+        }, out _);
 
         var customClaims = principal.FindAll("type1").ToList();
         Assert.Single(customClaims);
@@ -97,7 +98,7 @@ public class ServiceEndpointProviderTests
             ValidateIssuer = false,
             IssuerSigningKey = SecurityKey,
             ValidAudience = expectedAudience
-        }, out var token);
+        }, out _);
 
         Assert.Equal("user1", principal.FindFirst(ClaimTypes.NameIdentifier).Value);
     }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ServiceMessageBusTests.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Messaging;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageParserTest.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageParserTest.cs
@@ -6,12 +6,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Infrastructure;
 using Microsoft.AspNet.SignalR.Messaging;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Newtonsoft.Json;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
@@ -19,8 +22,8 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests;
 public class SignalRMessageParserTest
 {
     private readonly IDependencyResolver _resolver = GetDefaultResolver();
-    private readonly MemoryPool _pool = new MemoryPool();
-    private readonly JsonSerializer _serializer = new JsonSerializer();
+    private readonly MemoryPool _pool = new();
+    private readonly JsonSerializer _serializer = new();
 
     [Theory]
     [InlineData("")]
@@ -132,7 +135,6 @@ public class SignalRMessageParserTest
         Assert.Empty(msgs);
     }
 
-
     [Theory]
     [InlineData("connection1", "msg")]
     [InlineData("a.connection1", null)]
@@ -147,7 +149,7 @@ public class SignalRMessageParserTest
 
         var message = SignalRMessageUtility.CreateMessage(PrefixHelper.GetHubName(connectionId), input);
         var excludedConnectionIds = new string[] { GenerateRandomName(), GenerateRandomName() };
-        message.Filter = GetFilter(excludedConnectionIds.Select(s => PrefixHelper.GetConnectionId(s)).ToList());
+        message.Filter = GetFilter(excludedConnectionIds.Select(PrefixHelper.GetConnectionId).ToList());
 
         if (exceptionType != null)
         {
@@ -179,7 +181,7 @@ public class SignalRMessageParserTest
 
         var message = SignalRMessageUtility.CreateMessage(PrefixHelper.GetHubConnectionId(connectionId), input);
         var excludedConnectionIds = new string[] { GenerateRandomName(), GenerateRandomName() };
-        message.Filter = GetFilter(excludedConnectionIds.Select(s => PrefixHelper.GetConnectionId(s)).ToList());
+        message.Filter = GetFilter(excludedConnectionIds.Select(PrefixHelper.GetConnectionId).ToList());
 
         if (exceptionType != null)
         {
@@ -207,7 +209,7 @@ public class SignalRMessageParserTest
         var fullName = PrefixHelper.GetHubGroupName(hub + "." + groupName);
         var message = SignalRMessageUtility.CreateMessage(fullName, input);
         var excludedConnectionIds = new string[] { GenerateRandomName(), GenerateRandomName() };
-        message.Filter = GetFilter(excludedConnectionIds.Select(s => PrefixHelper.GetConnectionId(s)).ToList());
+        message.Filter = GetFilter(excludedConnectionIds.Select(PrefixHelper.GetConnectionId).ToList());
 
         var msgs = parser.GetMessages(message).ToList();
         Assert.Single(msgs);
@@ -231,7 +233,7 @@ public class SignalRMessageParserTest
 
         var message = SignalRMessageUtility.CreateMessage(PrefixHelper.GetHubUserId(hub + "." + userName), input);
         var excludedConnectionIds = new string[] { GenerateRandomName(), GenerateRandomName() };
-        message.Filter = GetFilter(excludedConnectionIds.Select(s => PrefixHelper.GetConnectionId(s)).ToList());
+        message.Filter = GetFilter(excludedConnectionIds.Select(PrefixHelper.GetConnectionId).ToList());
 
         if (exceptionType != null)
         {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageUtility.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/SignalRMessageUtility.cs
@@ -5,20 +5,23 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
+
 using Microsoft.AspNet.SignalR.Infrastructure;
 using Microsoft.AspNet.SignalR.Json;
 using Microsoft.AspNet.SignalR.Messaging;
 using Microsoft.Azure.SignalR.Protocol;
+
 using Newtonsoft.Json;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 internal static class SignalRMessageUtility
 {
-    private static readonly ServiceProtocol DefaultServiceProtocol = new ServiceProtocol();
-    private static readonly JsonSerializer DefaultJsonSerializer = new JsonSerializer();
-    private static readonly MemoryPool DefaultPool = new MemoryPool();
+    private static readonly ServiceProtocol DefaultServiceProtocol = new();
+    private static readonly JsonSerializer DefaultJsonSerializer = new();
+    private static readonly MemoryPool DefaultPool = new();
 
     public static ReadOnlyMemory<byte> GenerateSingleFrameBuffer(this ReadOnlyMemory<byte> inner)
     {
@@ -50,12 +53,11 @@ internal static class SignalRMessageUtility
 
     public static Message CreateMessage(string key, object value)
     {
-        ArraySegment<byte> messageBuffer = GetMessageBuffer(value);
+        var messageBuffer = GetMessageBuffer(value);
 
         var message = new Message(Guid.NewGuid().ToString("N"), key, messageBuffer);
 
-        var command = value as Command;
-        if (command != null)
+        if (value is Command command)
         {
             // Set the command id
             message.CommandId = command.Id;
@@ -83,30 +85,25 @@ internal static class SignalRMessageUtility
 
     private static ArraySegment<byte> SerializeMessageValue(object value)
     {
-        using (var writer = new MemoryPoolTextWriter(DefaultPool))
+        using var writer = new MemoryPoolTextWriter(DefaultPool);
+        if (value is IJsonWritable selfSerializer)
         {
-
-            var selfSerializer = value as IJsonWritable;
-
-            if (selfSerializer != null)
-            {
-                selfSerializer.WriteJson(writer);
-            }
-            else
-            {
-                DefaultJsonSerializer.Serialize(writer, value);
-            }
-
-            writer.Flush();
-
-            var data = writer.Buffer;
-
-            var buffer = new byte[data.Count];
-
-            Buffer.BlockCopy(data.Array, data.Offset, buffer, 0, data.Count);
-
-            return new ArraySegment<byte>(buffer);
+            selfSerializer.WriteJson(writer);
         }
+        else
+        {
+            DefaultJsonSerializer.Serialize(writer, value);
+        }
+
+        writer.Flush();
+
+        var data = writer.Buffer;
+
+        var buffer = new byte[data.Count];
+
+        Buffer.BlockCopy(data.Array, data.Offset, buffer, 0, data.Count);
+
+        return new ArraySegment<byte>(buffer);
     }
 
     private sealed class Response<T>

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestAppBuilder.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestAppBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Owin;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestClientConnectionManager.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -13,11 +14,11 @@ internal sealed class TestClientConnectionManager(IServiceConnection serviceConn
 {
     private readonly IServiceConnection _serviceConnection = serviceConnection;
 
-    private readonly ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>> _waitForConnectionOpen = new ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>>();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>> _waitForConnectionOpen = new();
 
-    public ConcurrentDictionary<string, TestTransport> CurrentTransports = new ConcurrentDictionary<string, TestTransport>();
+    public ConcurrentDictionary<string, TestTransport> CurrentTransports = new();
 
-    private readonly ConcurrentDictionary<string, IClientConnection> _connections = new ConcurrentDictionary<string, IClientConnection>();
+    private readonly ConcurrentDictionary<string, IClientConnection> _connections = new();
 
     public IEnumerable<IClientConnection> ClientConnections => _connections.Values;
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestEndpointRouter.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestEndpointRouter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.Owin;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestHubManager.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestHubManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.AspNet.SignalR.Hubs;
 using Microsoft.AspNet.SignalR.Json;
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionHandler.cs
@@ -6,13 +6,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 internal sealed class TestServiceConnectionHandler : ServiceConnectionManager
 {
-    private readonly ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>> _waitForTransportOutputMessage = new ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>>();
+    private readonly ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>> _waitForTransportOutputMessage = new();
 
     public TestServiceConnectionHandler() : this(null, null)
     {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestServiceConnectionProxy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
@@ -25,11 +26,11 @@ internal class TestServiceConnectionProxy(IClientConnectionManagerAspNet clientC
                                               null,
                                               new AckHandler()), IDisposable
 {
-    private static readonly ServiceProtocol SharedServiceProtocol = new ServiceProtocol();
+    private static readonly ServiceProtocol SharedServiceProtocol = new();
 
-    private readonly ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>> _waitForOutgoingMessage = new ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>>();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<ServiceMessage>> _waitForOutgoingMessage = new();
 
-    private readonly TaskCompletionSource<object> _connectionClosedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<object> _connectionClosedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public TestConnectionContext TestConnectionContext { get; private set; }
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestTransport.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestClasses/TestTransport.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR.Transports;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 public class TestTransport : IServiceTransport
 {
-    private readonly TaskCompletionSource<object> _lifetimeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<object> _lifetimeTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public long MessageCount = 0;
     public Func<string, Task> Received { get; set; }
@@ -23,7 +24,10 @@ public class TestTransport : IServiceTransport
         return Task.FromResult<string>(null);
     }
 
-    public void OnDisconnected() => _lifetimeTcs.TrySetResult(null);
+    public void OnDisconnected()
+    {
+        _lifetimeTcs.TrySetResult(null);
+    }
 
     public void OnReceived(string value)
     {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -20,7 +21,7 @@ internal sealed class TestConnectionContext : ConnectionContext
 
         var pipeOptions = new PipeOptions();
         var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
-        var proxyToApplication = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+        _ = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
 
         Transport = pair.Transport;
         Application = pair.Application;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/AuthorizedChatHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/AuthorizedChatHub.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.SignalR;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ChatHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ChatHub.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -63,7 +64,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 
         public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
         {
-            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
         }
 
         public void SendUser(string name, string userId, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 
         public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
         {
-            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
         }
 
         public void SendUser(string name, string userId, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 
         public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
         {
-            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
         }
 
         public void SendUser(string name, string userId, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -63,7 +64,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 
         public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
         {
-            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
         }
 
         public void SendUser(string name, string userId, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
 
         public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
         {
-            Clients.Groups(new List<string> { groupName }, connectionIdExcept).echo(name, message);
+            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
         }
 
         public void SendUser(string name, string userId, string message)

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TraceManagerLoggerProviderTest.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TraceManagerLoggerProviderTest.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Microsoft.AspNet.SignalR.Tracing;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.Extensions.Logging;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;


### PR DESCRIPTION
This pull request includes several changes aimed at improving code readability and consistency in the test files of the `Microsoft.Azure.SignalR.AspNet` project. The most important changes include adding missing using statements, refactoring object initializations, and modifying the `TestHub` class to use a readonly field.

Improvements to code readability and consistency:

* Added missing using statements across multiple test files to ensure all necessary dependencies are included. [[1]](diffhunk://#diff-a1ff095d5e317eadf609f5cf3ea482c5866c76122984cc5dca91590c9d3ebf82R6-R9) [[2]](diffhunk://#diff-2b264dcd23052fec341588bfe1ef27b9291546d889916d08d3e600ee18c50670R8-R11) [[3]](diffhunk://#diff-0ab42c1f35d89ae40c6651e5b5a16cfc4ea0046f15390bd59c2d7928188fd4f4R5) [[4]](diffhunk://#diff-46289e5b4dc5387b486ee1e3d9618294a06ae3056900ae83002466fcdc96b482R9-R16) [[5]](diffhunk://#diff-71d47b939f350111929fe102818de18f1c9cebd23944e84d983db9c2dd9596d1R5) [[6]](diffhunk://#diff-36b4c10ab54cebdf857ef11eb64b57dca0342c7f9ddfb65e08a59dec6a56a106R10-R15) [[7]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcR8-R15)
* Refactored object initializations to use the target-typed new expression for brevity and clarity. [[1]](diffhunk://#diff-36b4c10ab54cebdf857ef11eb64b57dca0342c7f9ddfb65e08a59dec6a56a106L69-R71) [[2]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL27-R29) [[3]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL52-R57) [[4]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL85-R102) [[5]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL157-R162) [[6]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL185-R190) [[7]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL210-R212) [[8]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL220-R230) [[9]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL242-R252) [[10]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL264-R274) [[11]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL291-R301) [[12]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL320-R330) [[13]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL349-R359) [[14]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL369-R386) [[15]](diffhunk://#diff-0b122ec5112cb33bbef507f09bda59b40c1c874a73378cc59fb0ed40e56ab4fcL395)
* Modified the `TestHub` class to use a readonly field for `TestHubConnectionManager` to ensure it is only set during object construction and not modified afterward.