### PR TITLE
nit: run code cleanup on Management tests

### DIFF
--- a/test/Microsoft.Azure.SignalR.Management.Tests/AutoHealthCheckRouterFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/AutoHealthCheckRouterFacts.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         public void TestAutoHealthCheckRouterWithSingleEndpoint()
         {
             var router = new AutoHealthCheckRouter();
-            var endpoints = new ServiceEndpoint[] { new ServiceEndpoint(FakeEndpointUtils.GetFakeConnectionString(1).First()) { Online = false } };
+            var endpoints = new ServiceEndpoint[] { new(FakeEndpointUtils.GetFakeConnectionString(1).First()) { Online = false } };
             Assert.Equal(endpoints[0], router.GetNegotiateEndpoint(null, endpoints));
         }
     }

--- a/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/DependencyInjectionExtensionFacts.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -21,7 +22,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using Newtonsoft.Json;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -315,7 +318,7 @@ public class DependencyInjectionExtensionFacts
     [MemberData(nameof(CustomizeHttpClientTimeoutTestData))]
     public async Task CustomizeHttpClientTimeoutTestAsync(string httpClientName, Func<ServiceHubContext, Task> testFunc)
     {
-        for (int i = 0; i < 10; i++)
+        for (var i = 0; i < 10; i++)
         {
             using var serviceManager = new ServiceManagerBuilder()
                 .WithOptions(o =>

--- a/test/Microsoft.Azure.SignalR.Management.Tests/InternalServiceHubContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/InternalServiceHubContextFacts.cs
@@ -8,13 +8,16 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
 using Moq;
 using Moq.Protected;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/NegotiateProcessorFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/NegotiateProcessorFacts.cs
@@ -7,10 +7,13 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+
 using Moq;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests;

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Negotiation/NegotiationFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Negotiation/NegotiationFacts.cs
@@ -3,9 +3,11 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Resilient/ExponentialBackoffPolicyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Resilient/ExponentialBackoffPolicyTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests.Resilient;

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Resilient/HttpClientRetryFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Resilient/HttpClientRetryFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -8,13 +8,16 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+
 using Moq;
 using Moq.Protected;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests;
@@ -24,8 +27,9 @@ using HttpHandlerSetup = Moq.Language.Flow.ISetup<HttpMessageHandler, Task<HttpR
 public class HttpClientRetryFacts
 {
     private const string HubName = "hub";
-    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] NonMessageApiTransientHttpErrorSetup = new Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[]
-    {
+
+    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] NonMessageApiTransientHttpErrorSetup =
+    [
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout)),
@@ -35,7 +39,7 @@ public class HttpClientRetryFacts
             await Task.Delay(-1, token);
             return new HttpResponseMessage(HttpStatusCode.OK);
         })
-    };
+    ];
 
     public static readonly IEnumerable<object[]> NullRetryOptionsTestData = NonMessageApiTransientHttpErrorSetup.Zip(new Action<Exception>[]
     {
@@ -71,8 +75,8 @@ public class HttpClientRetryFacts
         assert(exception);
     }
 
-    public static readonly Func<ServiceHubContext, Task>[] NonMessageApis = new Func<ServiceHubContext, Task>[]
-    {
+    public static readonly Func<ServiceHubContext, Task>[] NonMessageApis =
+    [
         hubContext=>hubContext.Groups.AddToGroupAsync("connectionId", "groupName"),
         hubContext=>hubContext.Groups.RemoveFromGroupAsync("connectionId", "groupName"),
         hubContext=>hubContext.Groups.RemoveFromAllGroupsAsync("connectionId"),
@@ -83,7 +87,7 @@ public class HttpClientRetryFacts
         hubContext=>hubContext.ClientManager.UserExistsAsync("userId"),
         hubContext=>hubContext.ClientManager.ConnectionExistsAsync("connectionId"),
         hubContext=>hubContext.ClientManager.CloseConnectionAsync("connectionId", "reason"),
-    };
+    ];
 
     public static readonly IEnumerable<object[]> FixedDelayRetryTestData =
         from pair in NonMessageApiTransientHttpErrorSetup.Zip(new Action<AggregateException>[]
@@ -102,24 +106,27 @@ public class HttpClientRetryFacts
 
     [Theory]
     [MemberData(nameof(FixedDelayRetryTestData))]
-    public async Task FixedDelayRetryTestNonMessageApi(Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>> setup, Action<AggregateException> assert, Func<ServiceHubContext, Task> api)
+    public async Task FixedDelayRetryTestNonMessageApi(
+        Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>> setup,
+        Action<AggregateException> assert,
+        Func<ServiceHubContext, Task> api)
     {
         await FixedDelayRetryTestCore(setup, assert, api, Constants.HttpClientNames.Resilient);
     }
 
-    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] MessageApiTransientHttpErrorSetup = new Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[]
-    {
+    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] MessageApiTransientHttpErrorSetup =
+    [
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadGateway))
-    };
+    ];
 
-    public static readonly Func<ServiceHubContext, Task>[] MessageApis = new Func<ServiceHubContext, Task>[]
-    {
+    public static readonly Func<ServiceHubContext, Task>[] MessageApis =
+    [
         hubContext=>hubContext.Clients.All.SendAsync("method"),
         hubContext=>hubContext.Clients.Client("abc").SendAsync("method"),
         hubContext=>hubContext.Clients.Group("groupName").SendAsync("method"),
         hubContext=>hubContext.Clients.User("userName").SendAsync("method"),
-    };
+    ];
 
     public static readonly IEnumerable<object[]> FixedDelayRetryTestMessageApiTestData =
         from setup in MessageApiTransientHttpErrorSetup
@@ -163,12 +170,12 @@ public class HttpClientRetryFacts
         handlerMock.Protected().Verify("SendAsync", Times.Exactly(4), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
     }
 
-    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] NonMessageApi_NotTransientHttpErrorSetup = new Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[]
-    {
+    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] NonMessageApi_NotTransientHttpErrorSetup =
+    [
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized))
-    };
+    ];
 
     public static IEnumerable<object[]> NotRetryable_RetryTestNonMessageApiTestData =
         from pair in NonMessageApi_NotTransientHttpErrorSetup.Zip(new Action<Exception>[]
@@ -187,8 +194,8 @@ public class HttpClientRetryFacts
         await NonRetryableError_RetryTestCore(setup, assert, api, Constants.HttpClientNames.Resilient);
     }
 
-    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] MessageApi_NotTransientHttpErrorSetup = new Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[]
-    {
+    private static readonly Func<HttpHandlerSetup, Moq.Language.Flow.IReturnsResult<HttpMessageHandler>>[] MessageApi_NotTransientHttpErrorSetup =
+    [
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest)),
         (setup) => setup.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound)),
@@ -199,7 +206,7 @@ public class HttpClientRetryFacts
             await Task.Delay(-1, token);
             return new HttpResponseMessage(HttpStatusCode.OK);
         })
-    };
+    ];
 
     public static IEnumerable<object[]> NotRetryable_RetryTest_MessageApiTestData =
     from pair in MessageApi_NotTransientHttpErrorSetup.Zip(new Action<Exception>[]

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestApiProviderFacts.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests;
@@ -18,12 +20,14 @@ public class RestApiProviderFacts
 
     private const string ConnectionString = $"Endpoint={Endpoint};AccessKey={AccessKey};Version=1.0;";
 
-    private static readonly RestApiProvider RestApiProvider = new RestApiProvider(new ServiceEndpoint(ConnectionString));
+    private static readonly RestApiProvider RestApiProvider = new(new ServiceEndpoint(ConnectionString));
 
-    public static IEnumerable<object[]> GetTestData() =>
-        from context in GetContext()
-        from pair in GetTestDataByContext(context)
-        select pair;
+    public static IEnumerable<object[]> GetTestData()
+    {
+        return from context in GetContext()
+               from pair in GetTestDataByContext(context)
+               select pair;
+    }
 
     [Theory]
     [MemberData(nameof(GetTestData))]

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestHealthCheckServiceFacts.cs
@@ -8,12 +8,15 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
+
 using Moq;
 using Moq.Protected;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/JsonObjectSerializerHubProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/JsonObjectSerializerHubProtocolFacts.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/PayloadBuilderResolverFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/PayloadBuilderResolverFacts.cs
@@ -5,11 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Azure.Core.Serialization;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/SerailizerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/SerailizerFacts.cs
@@ -7,15 +7,20 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+
 using Azure.Core.Serialization;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
 using Moq;
+
 using Newtonsoft.Json;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/WithHubProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/Serialization/WithHubProtocolFacts.cs
@@ -6,26 +6,31 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Azure.Core.Serialization;
+
 using MessagePack;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+
 using Moq;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests
 {
     public class WithHubProtocolFacts
     {
-        private static readonly JsonHubProtocol Json = new JsonHubProtocol(Options.Create(new JsonHubProtocolOptions()
+        private static readonly JsonHubProtocol Json = new(Options.Create(new JsonHubProtocolOptions()
         {
             PayloadSerializerOptions = new() { WriteIndented = true }
         }));
-        private static readonly MessagePackHubProtocol MessagePack = new MessagePackHubProtocol();
+        private static readonly MessagePackHubProtocol MessagePack = new();
         public static IEnumerable<object[]> AddProtocolTestData()
         {
             yield return new object[] { Json };

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerFacts.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
@@ -14,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsFacts.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Linq;
+
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsSetupFact.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceManagerOptionsSetupFact.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests

--- a/test/Microsoft.Azure.SignalR.Management.Tests/StronglyTypedServiceHubContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/StronglyTypedServiceHubContextFacts.cs
@@ -6,12 +6,15 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/TaskExtensionFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/TaskExtensionFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Management.Tests


### PR DESCRIPTION
This pull request includes several changes primarily focused on code style improvements and minor refactoring in the test files of the `Microsoft.Azure.SignalR.Management.Tests` project. The most important changes are as follows:

Code style improvements:

* Added blank lines between `using` directives to separate groups of related namespaces for better readability across multiple test files. [[1]](diffhunk://#diff-f62b8edbaeb9cbded78f67845d2f555812832c2549a9d87e07ceda149e95a809R5-R7) [[2]](diffhunk://#diff-13fb28a89b627e06ceb4aeda9de7b6c7d6efe77987657971d2ca9d7f8ee7044aR14) [[3]](diffhunk://#diff-cecbac276891eb25e1b3adee39801d43ffdd3596da12ce9011917c0a6a10788bR11-R20) [[4]](diffhunk://#diff-2599c813f41ed83adb061ecb9218cc7950617e8a9119ecda4070419259e78fbeR10-R16) [[5]](diffhunk://#diff-0ef778469de14c542446314af7f446d095955efc3e818ff82031ce85f6ec224dR6-R10) [[6]](diffhunk://#diff-d83b33aa95791f0143f766a76ddb4365cd708add749341af58536e4a4a0f689dR6-R8) [[7]](diffhunk://#diff-9e799acafc3390761ff12656827d7979c9eafad2137633851f504dea19afb7a0R11-R25) [[8]](diffhunk://#diff-1ced34be17fb106955d92bca7dc065c9cd9707aa25db2c18a4c1ce1b77bc2cb9R8-R10) [[9]](diffhunk://#diff-022b09930e2a9f89dfff51ae27093f37717b2165426e70cda135b16f722e1e75R11-R19) [[10]](diffhunk://#diff-d1354c51d5dc22117fc1a164e6b9b87e45ad1f669b5bbaf8a8e32a6495f8e81cR7-R9) [[11]](diffhunk://#diff-8b0765adac020dc0de1d5349121c790e57fa36dc6fdb82a353b93b9f2ca1581bR8-R15) [[12]](diffhunk://#diff-b35426ec8daaad951463e3381e5c34a5eb91fde0236233d2de47641cc95cf631R10-R23) [[13]](diffhunk://#diff-dec8c4d5be0a9f9441777192fbf732b377f71522b63fb48ab6c0655d2a74b6b1R9-R33) [[14]](diffhunk://#diff-7ca75e10ab17197590df645f59104700653e6443463d3acfbb290bdf7b27bb10R10-R18) [[15]](diffhunk://#diff-c52bdc61f1d57ad7a4e3739d131a8b4ea8812c7102929e2ee3bcbe14a3944fdfR6-R9) [[16]](diffhunk://#diff-3680c41717b3fe4b7aa22852a673ed8fad942b82a5b9f800630f4dc0194dd640R5-R8) [[17]](diffhunk://#diff-052a74e0a3ad32c56268964d40543b3a043e1f4d7281c38c68c9fcbcb570b9e3R9-R17) [[18]](diffhunk://#diff-0335c3d4fbb115355912de09706aadcbefbd485896f7a7207d17f59ff07c12c9R7)

Minor refactoring:

* Simplified object instantiation by using target-typed `new` expressions in `AutoHealthCheckRouterFacts.cs` and `RestApiProviderFacts.cs`. [[1]](diffhunk://#diff-f62b8edbaeb9cbded78f67845d2f555812832c2549a9d87e07ceda149e95a809L16-R18) [[2]](diffhunk://#diff-1ced34be17fb106955d92bca7dc065c9cd9707aa25db2c18a4c1ce1b77bc2cb9L21-R30)
* Changed loop variable type from `int` to `var` in `DependencyInjectionExtensionFacts.cs` to use implicit typing.
* Simplified the instantiation of `JsonHubProtocol` and `MessagePackHubProtocol` with target-typed `new` expressions in `WithHubProtocolFacts.cs`.