### PR TITLE
nit: run code cleanup on Common tests

### DIFF
--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AccessKeyTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthRestApiTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthRestApiTests.cs
@@ -7,8 +7,10 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Azure.Core;
 using Azure.Identity;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/AuthUtilityTests.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+
 using Azure.Identity;
 
 using Xunit;
@@ -104,6 +105,9 @@ public class AuthUtilityTests
             yield return new object[] { key, false };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/ConnectionStringParserTests.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+
 using Azure.Identity;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth;
@@ -236,6 +238,9 @@ public class ConnectionStringParserTests
             yield return new object[] { $"endpoint={HttpsEndpoint}/;accesskey={DefaultKey}", HttpsEndpoint };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraAccessKeyTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraAccessKeyTests.cs
@@ -12,8 +12,10 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Azure.Core;
 using Azure.Identity;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth;
@@ -270,7 +272,7 @@ public class MicrosoftEntraAccessKeyTests
         UpdateAtField?.SetValue(key, DateTime.UtcNow - TimeSpan.FromMinutes(6));
         Assert.False(key.Available);
         Assert.True(key.NeedRefresh);
-        
+
         var task1 = key.GenerateAccessTokenAsync(DefaultAudience, [], TimeSpan.FromMinutes(1), AccessTokenAlgorithm.HS256);
         var task2 = key.GenerateAccessTokenAsync(DefaultAudience, [], TimeSpan.FromMinutes(1), AccessTokenAlgorithm.HS256);
         await Assert.ThrowsAsync<AzureSignalRAccessTokenNotAuthorizedException>(async () => await Task.WhenAll(task1, task2));
@@ -387,7 +389,10 @@ public class MicrosoftEntraAccessKeyTests
             yield return [new AzureSignalRRuntimeException(DefaultUri, new InvalidOperationException("inner-exception-message"), HttpStatusCode.NotFound, "http"), AzureSignalRRuntimeException.ErrorMessage];
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     private sealed class TestHttpClientFactory(HttpResponseMessage message) : IHttpClientFactory
@@ -416,7 +421,10 @@ public class MicrosoftEntraAccessKeyTests
             _content = content;
         }
 
-        internal static HttpContent From(string content) => new TextHttpContent(content);
+        internal static HttpContent From(string content)
+        {
+            return new TextHttpContent(content);
+        }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
         {

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraApplicationTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Auth/MicrosoftEntraApplicationTests.cs
@@ -1,12 +1,18 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
+
 using Azure.Core;
 using Azure.Identity;
+
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Auth;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/BackOffPolicyFacts.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -139,7 +141,7 @@ public class BackOffPolicyFacts(ITestOutputHelper output) : VerifiableLoggedTest
             var currentProbe = testData.Params[index];
             testData.Results[index] = new ProbeResult();
 
-            Func<Task<bool>> probeFunc = async () =>
+            async Task<bool> probeFunc()
             {
                 var result = testData.Results[index];
                 result.ActualCallTime = DateTime.UtcNow - startTime;
@@ -152,9 +154,9 @@ public class BackOffPolicyFacts(ITestOutputHelper output) : VerifiableLoggedTest
                     throw new InvalidOperationException("exception from probe func");
                 }
                 return currentProbe.Result;
-            };
+            }
 
-            Func<Task> testFunc = async () =>
+            async Task testFunc()
             {
                 try
                 {
@@ -166,7 +168,7 @@ public class BackOffPolicyFacts(ITestOutputHelper output) : VerifiableLoggedTest
                 {
                     testData.Results[index].ActualException = ex;
                 }
-            };
+            }
 
             probeTestTasks[index] = testFunc();
         }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ClaimsUtilityTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ClaimsUtilityTests.cs
@@ -5,13 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests
 {
     public class ClaimsUtilityTests
     {
-        private static readonly Claim[] JwtAuthenticatedClaims = new Claim[] { new Claim("dummy", "dummy"), new Claim("name", "name"), new Claim("role", "admin"), new Claim("aud", "aud") };
+        private static readonly Claim[] JwtAuthenticatedClaims = new Claim[] { new("dummy", "dummy"), new("name", "name"), new("role", "admin"), new("aud", "aud") };
         private static readonly (ClaimsIdentity identity, string userId, Func<IEnumerable<Claim>> provider, string expectedAuthenticationType, int expectedClaimsCount)[] _claimsParameters =
         {
             (new ClaimsIdentity(), null, null, null, 0),
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         {
             // preserved system claims are renamed and reverted back
             var claims = ClaimsUtility.BuildJwtClaims(
-                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("iss", "A"), new Claim("jti", "B") })), null, null).ToArray();
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new("iss", "A"), new("jti", "B") })), null, null).ToArray();
             Assert.Equal("asrs.u.iss", claims[0].Type);
             Assert.Equal("asrs.u.jti", claims[1].Type);
 
@@ -74,7 +75,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         {
             // only the first sub claim is considered as valid to the service
             var claims = ClaimsUtility.BuildJwtClaims(
-                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("sub", "A"), new Claim("sub", "B") })), null, null).ToArray();
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new("sub", "A"), new("sub", "B") })), null, null).ToArray();
             Assert.Equal("sub", claims[0].Type);
             Assert.Equal("asrs.u.sub", claims[1].Type);
 
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             Assert.True(ci.HasClaim("sub", "B"));
 
             claims = ClaimsUtility.BuildJwtClaims(
-                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("sub", "A"), new Claim("sub", "B") })), "C", null).ToArray();
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new("sub", "A"), new("sub", "B") })), "C", null).ToArray();
             Assert.Equal("asrs.s.uid", claims[0].Type);
             Assert.Equal("sub", claims[1].Type);
             Assert.Equal("asrs.u.sub", claims[2].Type);
@@ -102,7 +103,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
 
             // single sub claim is considered as valid
             claims = ClaimsUtility.BuildJwtClaims(
-                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("sub", "A") })), null, null).ToArray();
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new("sub", "A") })), null, null).ToArray();
             Assert.Single(claims);
             Assert.Equal("sub", claims[0].Type);
 
@@ -114,7 +115,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             Assert.True(ci.HasClaim("sub", "A"));
 
             claims = ClaimsUtility.BuildJwtClaims(
-                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim("sub", "A") })), "C", null).ToArray();
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new("sub", "A") })), "C", null).ToArray();
             Assert.Equal("asrs.s.uid", claims[0].Type);
             Assert.Equal("sub", claims[1].Type);
 

--- a/test/Microsoft.Azure.SignalR.Common.Tests/CustomizedTimerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/CustomizedTimerTests.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -147,8 +149,9 @@ public class CustomizedTimerTests(ITestOutputHelper output) : VerifiableLoggedTe
         }
     }
 
-    private static ServiceConnectionContainerBase.CustomizedPingTimer CreatePingTimer(ILoggerFactory loggerFactory, Action counter) =>
-        CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
+    private static ServiceConnectionContainerBase.CustomizedPingTimer CreatePingTimer(ILoggerFactory loggerFactory, Action counter)
+    {
+        return CustomizedPingTimerFactory.CreateCustomizedPingTimer(loggerFactory.CreateLogger(
             nameof(BasicStartStopTest)), nameof(BasicStartStopTest),
             () =>
             {
@@ -156,6 +159,7 @@ public class CustomizedTimerTests(ITestOutputHelper output) : VerifiableLoggedTe
                 return Task.CompletedTask;
             },
             BaseTs, BaseTs);
+    }
 
     private sealed class CustomizedPingTimerFactory : ServiceConnectionContainerBase
     {
@@ -163,7 +167,9 @@ public class CustomizedTimerTests(ITestOutputHelper output) : VerifiableLoggedTe
         {
         }
 
-        internal static CustomizedPingTimer CreateCustomizedPingTimer(ILogger logger, string name, Func<Task> func, TimeSpan due, TimeSpan interval) =>
-            new CustomizedPingTimer(logger, name, func, due, interval);
+        internal static CustomizedPingTimer CreateCustomizedPingTimer(ILogger logger, string name, Func<Task> func, TimeSpan due, TimeSpan interval)
+        {
+            return new CustomizedPingTimer(logger, name, func, due, interval);
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/IConfigurationExtensionsFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Endpoints/IConfigurationExtensionsFacts.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Exceptions/AzureSignalRUnauthorizedExceptionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Exceptions/AzureSignalRUnauthorizedExceptionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.Exceptions;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/PauseHandlerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/PauseHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/RestClients/RestClientFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/RestClients/RestClientFacts.cs
@@ -4,8 +4,10 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.RestClients

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnectionContainerBaseTests.cs
@@ -6,10 +6,13 @@ using System.Buffers;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+
 using Moq;
+
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -3,10 +3,13 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+
 using Moq;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.ServiceConnections;

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceEndpointFacts.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using Azure.Identity;
+
 using Xunit;
 
 #nullable enable
@@ -81,12 +83,12 @@ public class ServiceEndpointFacts
         var serverEndpoint = new Uri("http://serverEndpoint:123/path");
         var endpoint = "https://test.service.signalr.net";
         var serviceEndpoints = new ServiceEndpoint[]{
-            new ServiceEndpoint(new Uri(endpoint), new DefaultAzureCredential())
+            new(new Uri(endpoint), new DefaultAzureCredential())
             {
                 ClientEndpoint = clientEndpoint,
                 ServerEndpoint = serverEndpoint
             },
-            new ServiceEndpoint($"Endpoint={endpoint};AccessKey={DefaultKey}")
+            new($"Endpoint={endpoint};AccessKey={DefaultKey}")
             {
                 ClientEndpoint = clientEndpoint,
                 ServerEndpoint = serverEndpoint
@@ -385,7 +387,10 @@ public class ServiceEndpointFacts
             };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     public class EndpointEndWithSlash : IEnumerable<object[]>
@@ -398,7 +403,10 @@ public class ServiceEndpointFacts
             yield return new object[] { $"endpoint={HttpsEndpoint}/;accesskey={DefaultKey}", HttpsEndpoint };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     public class EndpointAndPortTestData : IEnumerable<object[]>
@@ -428,7 +436,10 @@ public class ServiceEndpointFacts
             yield return new object[] { $"ENDPOINT={HttpsEndpoint}:500;ACCESSKEY={DefaultKey};PORT=443", HttpsEndpoint + "/", HttpsEndpoint };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 
     public class ClientEndpointTestData : IEnumerable<object[]>
@@ -441,6 +452,9 @@ public class ServiceEndpointFacts
             yield return new object[] { $"endpoint={HttpsEndpoint};authType=aad;clientEndpoint={HttpsClientEndpoint}:443", HttpsClientEndpoint + ":443" };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceMessageTracingIdTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceMessageTracingIdTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Azure.SignalR.Protocol;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests
@@ -24,14 +25,14 @@ namespace Microsoft.Azure.SignalR.Common.Tests
         {
             var msg1 = new BroadcastDataMessage(null).WithTracingId();
 
-            Assert.NotNull(msg1 as IMessageWithTracingId);
+            Assert.NotNull(msg1);
             Assert.Null((msg1 as IMessageWithTracingId).TracingId);
 
             using (new ClientConnectionScope(null, null, true))
             {
                 var msg2 = new BroadcastDataMessage(null).WithTracingId();
 
-                Assert.NotNull(msg2 as IMessageWithTracingId);
+                Assert.NotNull(msg2);
                 Assert.NotNull((msg2 as IMessageWithTracingId).TracingId);
             }
 
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.SignalR.Common.Tests
             {
                 var msg3 = new BroadcastDataMessage(null).WithTracingId();
 
-                Assert.NotNull(msg3 as IMessageWithTracingId);
+                Assert.NotNull(msg3);
                 Assert.NotNull((msg3 as IMessageWithTracingId).TracingId);
             }
         }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/TaskExtensionsTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/TaskExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Xunit;
 
 #nullable enable

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/MockAsyncEnumerable.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/MockAsyncEnumerable.cs
@@ -8,18 +8,28 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.SignalR.Common.Tests;
 public class MockAsyncEnumerable<T>(IEnumerable<T> values) : IAsyncEnumerable<T>
 {
-    public static IAsyncEnumerable<Tp> From<Tp>(params Tp[] items) =>
-        new MockAsyncEnumerable<Tp>(items);
+    public static IAsyncEnumerable<Tp> From<Tp>(params Tp[] items)
+    {
+        return new MockAsyncEnumerable<Tp>(items);
+    }
 
-    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
-        new MockAsyncEnumerator<T>(values.GetEnumerator());
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return new MockAsyncEnumerator<T>(values.GetEnumerator());
+    }
 
     private sealed class MockAsyncEnumerator<Tp>(IEnumerator<Tp> enumerator) : IAsyncEnumerator<Tp>
     {
         public Tp Current => enumerator.Current;
 
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
 
-        public ValueTask<bool> MoveNextAsync() => ValueTask.FromResult(enumerator.MoveNext());
+        public ValueTask<bool> MoveNextAsync()
+        {
+            return ValueTask.FromResult(enumerator.MoveNext());
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/BinaryPayloadMessageContentTest.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/BinaryPayloadMessageContentTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -7,50 +7,50 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+
 using MessagePack;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
+
 using Xunit;
 
-namespace Microsoft.Azure.SignalR.Common.Tests
-{
-    public class BinaryPayloadMessageContentTest
-    {
-        [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "<Pending>")]
-        public void OneHubProtocolTest()
-        {
-            var payload = new PayloadMessage { Target = "target", Arguments = new object[] { "a", 1 } };
-            var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol() };
-            using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
-            var actualBytes = new MemoryStream();
-            httpContent.CopyToAsync(actualBytes, null, default).GetAwaiter().GetResult();
-            var expectedBytes = new ArrayBufferWriter<byte>();
-            var messagePackWriter = new MessagePackWriter(expectedBytes);
-            messagePackWriter.WriteMapHeader(1);
-            messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.MessagePack));
-            messagePackWriter.Write(protocols[0].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
-            messagePackWriter.Flush();
-            Assert.True(expectedBytes.WrittenSpan.SequenceEqual(actualBytes.ToArray()));
-        }
+namespace Microsoft.Azure.SignalR.Common.Tests;
 
-        [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "<Pending>")]
-        public void TwoHubProtocolTest()
-        {
-            var payload = new PayloadMessage { Target = "target", Arguments = new object[] { "a", 1 } };
-            var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol(), new JsonHubProtocol() };
-            using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
-            var actualBytes = new MemoryStream();
-            httpContent.CopyToAsync(actualBytes, null, default).GetAwaiter().GetResult();
-            var expectedBytes = new ArrayBufferWriter<byte>();
-            var messagePackWriter = new MessagePackWriter(expectedBytes);
-            messagePackWriter.WriteMapHeader(2);
-            messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.MessagePack));
-            messagePackWriter.Write(protocols[0].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
-            messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.Json));
-            messagePackWriter.Write(protocols[1].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
-            messagePackWriter.Flush();
-            Assert.True(expectedBytes.WrittenSpan.SequenceEqual(actualBytes.ToArray()));
-        }
+public class BinaryPayloadMessageContentTest
+{
+    [Fact]
+    public async Task OneHubProtocolTest()
+    {
+        var payload = new PayloadMessage { Target = "target", Arguments = ["a", 1] };
+        var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol() };
+        using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
+        var actualBytes = new MemoryStream();
+        await httpContent.CopyToAsync(actualBytes, null, default);
+        var expectedBytes = new ArrayBufferWriter<byte>();
+        var messagePackWriter = new MessagePackWriter(expectedBytes);
+        messagePackWriter.WriteMapHeader(1);
+        messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.MessagePack));
+        messagePackWriter.Write(protocols[0].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
+        messagePackWriter.Flush();
+        Assert.True(expectedBytes.WrittenSpan.SequenceEqual(actualBytes.ToArray()));
+    }
+
+    [Fact]
+    public async Task TwoHubProtocolTest()
+    {
+        var payload = new PayloadMessage { Target = "target", Arguments = ["a", 1] };
+        var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol(), new JsonHubProtocol() };
+        using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
+        var actualBytes = new MemoryStream();
+        await httpContent.CopyToAsync(actualBytes, null, default);
+        var expectedBytes = new ArrayBufferWriter<byte>();
+        var messagePackWriter = new MessagePackWriter(expectedBytes);
+        messagePackWriter.WriteMapHeader(2);
+        messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.MessagePack));
+        messagePackWriter.Write(protocols[0].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
+        messagePackWriter.WriteString(Encoding.UTF8.GetBytes(Constants.Protocol.Json));
+        messagePackWriter.Write(protocols[1].GetMessageBytes(new InvocationMessage(payload.Target, payload.Arguments)).Span);
+        messagePackWriter.Flush();
+        Assert.True(expectedBytes.WrittenSpan.SequenceEqual(actualBytes.ToArray()));
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/BinaryPayloadMessageContentTest.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/BinaryPayloadMessageContentTest.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 
 using MessagePack;
 
@@ -19,13 +18,14 @@ namespace Microsoft.Azure.SignalR.Common.Tests;
 public class BinaryPayloadMessageContentTest
 {
     [Fact]
-    public async Task OneHubProtocolTest()
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "<Pending>")]
+    public void OneHubProtocolTest()
     {
-        var payload = new PayloadMessage { Target = "target", Arguments = ["a", 1] };
+        var payload = new PayloadMessage { Target = "target", Arguments = new object[] { "a", 1 } };
         var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol() };
         using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
         var actualBytes = new MemoryStream();
-        await httpContent.CopyToAsync(actualBytes, null, default);
+        httpContent.CopyToAsync(actualBytes, null, default).GetAwaiter().GetResult();
         var expectedBytes = new ArrayBufferWriter<byte>();
         var messagePackWriter = new MessagePackWriter(expectedBytes);
         messagePackWriter.WriteMapHeader(1);
@@ -36,13 +36,14 @@ public class BinaryPayloadMessageContentTest
     }
 
     [Fact]
-    public async Task TwoHubProtocolTest()
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "<Pending>")]
+    public void TwoHubProtocolTest()
     {
-        var payload = new PayloadMessage { Target = "target", Arguments = ["a", 1] };
+        var payload = new PayloadMessage { Target = "target", Arguments = new object[] { "a", 1 } };
         var protocols = new List<IHubProtocol>() { new MessagePackHubProtocol(), new JsonHubProtocol() };
         using var httpContent = new BinaryPayloadMessageContent(payload, protocols);
         var actualBytes = new MemoryStream();
-        await httpContent.CopyToAsync(actualBytes, null, default);
+        httpContent.CopyToAsync(actualBytes, null, default).GetAwaiter().GetResult();
         var expectedBytes = new ArrayBufferWriter<byte>();
         var messagePackWriter = new MessagePackWriter(expectedBytes);
         messagePackWriter.WriteMapHeader(2);

--- a/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/JsonPayloadMessageContentTest.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/Utils/Rest/JsonPayloadMessageContentTest.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Azure.Core.Serialization;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests

--- a/test/Microsoft.Azure.SignalR.Common.Tests/WeakServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/WeakServiceConnectionContainerTests.cs
@@ -5,6 +5,7 @@ using System;
 
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ITestClientSet.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ITestClientSet.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
         int Count { get; }
         void AddListener(string methodName, Action<string> handler);
         Task SendAsync(string methodName, int sendCount = -1, params string[] messages);
-        Task SendAsync(string methodName, int [] sendInds, params string[] messages);
+        Task SendAsync(string methodName, int[] sendInds, params string[] messages);
         Task ManageGroupAsync(string methodName, IDictionary<int, string> connectionGroupMap);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ITestServer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ITestServer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.Tests.Common
 {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ServiceE2EFactsBase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/ServiceE2EFactsBase.cs
@@ -34,15 +34,9 @@ namespace Microsoft.Azure.SignalR.Tests.Common
             new object[] { "SendToGroup", GetGroupSize(DefaultSendGroupIndex), new Func<string, ITestClientSet, Task>(GroupTask) },
         };
 
-        private static IDictionary<int, string> ConnectionGroupMap
-        {
-            get
-            {
-                return (from i in Enumerable.Range(0, DefaultClientCount) select new { ind = i, groupName = GetGroupName(i) }).ToDictionary(t => t.ind, t => t.groupName);
-            }
-        }
+        private static IDictionary<int, string> ConnectionGroupMap => (from i in Enumerable.Range(0, DefaultClientCount) select new { ind = i, groupName = GetGroupName(i) }).ToDictionary(t => t.ind, t => t.groupName);
 
-        
+
 
         public ServiceE2EFactsBase(ITestServerFactory testServerFactory, ITestClientSetFactory testClientSetFactory, ITestOutputHelper output) : base(output)
         {
@@ -85,18 +79,22 @@ namespace Microsoft.Azure.SignalR.Tests.Common
             await Task.Delay(DefaultDelayMilliseconds);
         }
 
-        private static string GetGroupName(int ind) => $"group_{ind % 2}";
+        private static string GetGroupName(int ind)
+        {
+            return $"group_{ind % 2}";
+        }
 
-        protected static int GetGroupSize(int ind) => (from entry in ConnectionGroupMap where GetGroupName(ind) == entry.Value select entry).Count();
+        protected static int GetGroupSize(int ind)
+        {
+            return (from entry in ConnectionGroupMap where GetGroupName(ind) == entry.Value select entry).Count();
+        }
 
         private static void Shuffle<T>(T[] array)
         {
             for (var i = array.Length - 1; i > 0; i--)
             {
                 var k = StaticRandom.Next(i + 1);
-                var value = array[k];
-                array[k] = array[i];
-                array[i] = value;
+                (array[i], array[k]) = (array[k], array[i]);
             }
         }
     }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/TestHubConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/TestHubConnectionManager.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public IList<string> Users => _connectedUsers.Keys.ToList();
 
-        private readonly ConcurrentDictionary<string, bool> _connectedConnections = new ConcurrentDictionary<string, bool>();
-        private readonly ConcurrentDictionary<string, bool> _connectedUsers = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, bool> _connectedConnections = new();
+        private readonly ConcurrentDictionary<string, bool> _connectedUsers = new();
 
         private readonly ConcurrentDictionary<int, TaskCompletionSource<string>> _connectionCountTcs =
-            new ConcurrentDictionary<int, TaskCompletionSource<string>>();
+            new();
 
         private int _count;
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/TestServerBase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/E2ETest/TestServerBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.Tests.Common
@@ -20,7 +21,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
 
         public async Task<string> StartAsync(Dictionary<string, string> configuration = null)
         {
-            for (int retry = 0; retry < MaxRetry; retry++)
+            for (var retry = 0; retry < MaxRetry; retry++)
             {
                 try
                 {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/JwtTokenHelper.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/JwtTokenHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.SignalR.Tests;
 
 internal static class JwtTokenHelper
 {
-    public static readonly JwtSecurityTokenHandler JwtHandler = new JwtSecurityTokenHandler();
+    public static readonly JwtSecurityTokenHandler JwtHandler = new();
 
     public static string GenerateExpectedAccessToken(JwtSecurityToken token, string audience, AccessKey accessKey, IEnumerable<Claim> customClaims = null)
     {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/LogRecord.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/LogRecord.cs
@@ -1,7 +1,8 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.Azure.SignalR.Tests.Common

--- a/test/Microsoft.Azure.SignalR.Tests.Common/LogSinkProvider.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/LogSinkProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common
     // TestSink does not have an event
     internal class LogSinkProvider : ILoggerProvider
     {
-        private readonly ConcurrentQueue<LogRecord> _logs = new ConcurrentQueue<LogRecord>();
+        private readonly ConcurrentQueue<LogRecord> _logs = new();
 
         public event Action<LogRecord> RecordLogged;
 
@@ -25,7 +26,10 @@ namespace Microsoft.Azure.SignalR.Tests.Common
         {
         }
 
-        public IEnumerable<LogRecord> GetLogs() => _logs;
+        public IEnumerable<LogRecord> GetLogs()
+        {
+            return _logs;
+        }
 
         public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.SignalR.AspNet.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/test/Microsoft.Azure.SignalR.Tests.Common/ReloadableMemorySource.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/ReloadableMemorySource.cs
@@ -9,8 +9,14 @@ namespace Microsoft.Azure.SignalR.Tests.Common
     {
         private readonly ReloadableMemoryProvider _provider;
 
-        public ReloadableMemorySource(ReloadableMemoryProvider provider) => _provider = provider;
+        public ReloadableMemorySource(ReloadableMemoryProvider provider)
+        {
+            _provider = provider;
+        }
 
-        public IConfigurationProvider Build(IConfigurationBuilder builder) => _provider;
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return _provider;
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/BlockingMessageBus.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/BlockingMessageBus.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
+
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactDiscoverer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryFactDiscoverer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.AspNetCore.Testing.xunit;
 
 using Xunit.Abstractions;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCase.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -57,8 +58,9 @@ public class RetryTestCase : XunitTestCase, IRetryableTestCase
                                               IMessageBus messageBus,
                                               object[] constructorArguments,
                                               ExceptionAggregator aggregator,
-                                              CancellationTokenSource cancellationTokenSource) =>
-        RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
+                                              CancellationTokenSource cancellationTokenSource)
+    {
+        return RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
             blockingMessageBus => new XunitTestCaseRunner(this,
                                                           DisplayName,
                                                           SkipReason,
@@ -68,6 +70,7 @@ public class RetryTestCase : XunitTestCase, IRetryableTestCase
                                                           aggregator,
                                                           cancellationTokenSource)
                 .RunAsync());
+    }
 
     public override void Serialize(IXunitSerializationInfo data)
     {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCaseRunner.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTestCaseRunner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryAttribute.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit.Sdk;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
@@ -48,11 +48,13 @@ public class RetryTheoryDiscoveryAtRuntimeCase : XunitTestCase, IRetryableTestCa
     /// <inheritdoc />
     public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus,
         object[] constructorArguments, ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource) =>
-        RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return RetryTestCaseRunner.RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
             blockingMessageBus => new XunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,
                     diagnosticMessageSink, blockingMessageBus, aggregator, cancellationTokenSource)
                 .RunAsync());
+    }
 
     public override void Serialize(IXunitSerializationInfo data)
     {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/SkipIfConnectionStringNotPresentAttribute.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/SkipIfConnectionStringNotPresentAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Microsoft.AspNetCore.Testing.xunit;
 
 namespace Microsoft.Azure.SignalR.Tests.Common

--- a/test/Microsoft.Azure.SignalR.Tests.Common/SkipIfMultiEndpointsAbsentFactAttribute.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/SkipIfMultiEndpointsAbsentFactAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests.Common

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TaskExtensions.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TaskExtensions.cs
@@ -34,11 +34,15 @@ public static class TaskExtensions
         await task;
     }
 
-    public static Task<T> OrTimeout<T>(this ValueTask<T> task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null) =>
-        OrTimeout(task, new TimeSpan(0, 0, 0, 0, milliseconds), memberName, filePath, lineNumber);
+    public static Task<T> OrTimeout<T>(this ValueTask<T> task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
+    {
+        return OrTimeout(task, new TimeSpan(0, 0, 0, 0, milliseconds), memberName, filePath, lineNumber);
+    }
 
-    public static Task<T> OrTimeout<T>(this ValueTask<T> task, TimeSpan timeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null) =>
-        task.AsTask().OrTimeout(timeout, memberName, filePath, lineNumber);
+    public static Task<T> OrTimeout<T>(this ValueTask<T> task, TimeSpan timeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
+    {
+        return task.AsTask().OrTimeout(timeout, memberName, filePath, lineNumber);
+    }
 
     public static Task<T> OrTimeout<T>(this Task<T> task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
     {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestBaseServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestBaseServiceConnectionContainer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestClientConnectionManager.cs
@@ -15,11 +15,23 @@ internal class TestClientConnectionManager : IClientConnectionManager
 
     public int Count => throw new System.NotImplementedException();
 
-    public bool TryAddClientConnection(IClientConnection connection) => _dict.TryAdd(connection.ConnectionId, connection);
+    public bool TryAddClientConnection(IClientConnection connection)
+    {
+        return _dict.TryAdd(connection.ConnectionId, connection);
+    }
 
-    public bool TryGetClientConnection(string connectionId, out IClientConnection connection) => _dict.TryGetValue(connectionId, out connection);
+    public bool TryGetClientConnection(string connectionId, out IClientConnection connection)
+    {
+        return _dict.TryGetValue(connectionId, out connection);
+    }
 
-    public bool TryRemoveClientConnection(string connectionId, out IClientConnection connection) => _dict.TryRemove(connectionId, out connection);
+    public bool TryRemoveClientConnection(string connectionId, out IClientConnection connection)
+    {
+        return _dict.TryRemove(connectionId, out connection);
+    }
 
-    public Task WhenAllCompleted() => Task.CompletedTask;
+    public Task WhenAllCompleted()
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnection.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common;
 
 internal class TestServiceConnection : ServiceConnectionBase
 {
-    private readonly TaskCompletionSource<object?> _created = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<object?> _created = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly bool _throws;
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainerFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainerFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceEndpoint.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceEndpoint.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
 using Azure.Core;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;
@@ -7,7 +11,7 @@ namespace Microsoft.Azure.SignalR.Tests.Common;
 
 internal class TestServiceEndpoint : ServiceEndpoint
 {
-    private static Uri DefaultEndpoint = new Uri("https://localhost");
+    private static readonly Uri DefaultEndpoint = new("https://localhost");
 
     private const string DefaultConnectionString = "Endpoint=https://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ;Version=1.0";
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceEndpointProvider.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceEndpointProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceMessageHandler.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceMessageHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests.Common;
@@ -13,7 +14,10 @@ internal sealed class TestServiceMessageHandler : IServiceMessageHandler
     {
     }
 
-    public Task HandlePingAsync(PingMessage pingMessage) => Task.CompletedTask;
+    public Task HandlePingAsync(PingMessage pingMessage)
+    {
+        return Task.CompletedTask;
+    }
 
     public void HandleAck(AckMessage serviceMessage)
     {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestConfiguration.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestConfiguration.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.SignalR.Tests.Common
 {
     public class TestConfiguration
     {
-        public static readonly TestConfiguration Instance = new TestConfiguration();
+        public static readonly TestConfiguration Instance = new();
 
         public IConfiguration Configuration { get; }
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/VerifiableLoggedTest.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/VerifiableLoggedTest.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/VerifyNoErrorsScope.cs
@@ -16,7 +16,7 @@ internal class VerifyLogScope : IVerifiableLog
     private readonly IDisposable _wrappedDisposable;
     private readonly LogSinkProvider _sink;
 
-    private readonly List<Func<LogRecord, bool>> _expectedLogs = new();
+    private readonly List<Func<LogRecord, bool>> _expectedLogs = [];
 
     public ILoggerFactory LoggerFactory { get; }
 
@@ -29,7 +29,10 @@ internal class VerifyLogScope : IVerifiableLog
         LoggerFactory.AddProvider(_sink);
     }
 
-    public LogRecord Expects(string logEventName) => Expects(i => i.Write.EventId.Name == logEventName);
+    public LogRecord Expects(string logEventName)
+    {
+        return Expects(i => i.Write.EventId.Name == logEventName);
+    }
 
     public LogRecord Expects(Func<LogRecord, bool> predicate)
     {
@@ -38,7 +41,10 @@ internal class VerifyLogScope : IVerifiableLog
         return matches[0];
     }
 
-    public IReadOnlyList<LogRecord> ExpectsMany(string logEventName) => ExpectsMany(i => i.Write.EventId.Name == logEventName);
+    public IReadOnlyList<LogRecord> ExpectsMany(string logEventName)
+    {
+        return ExpectsMany(i => i.Write.EventId.Name == logEventName);
+    }
 
     public IReadOnlyList<LogRecord> ExpectsMany(Func<LogRecord, bool> predicate)
     {
@@ -69,13 +75,13 @@ internal class VerifyLogScope : IVerifiableLog
         }).ToArray();
         if (results.Length > 0)
         {
-            string errorMessage = $"{results.Length} error(s) logged.";
+            var errorMessage = $"{results.Length} error(s) logged.";
             errorMessage += Environment.NewLine;
             errorMessage += string.Join(Environment.NewLine, results.Select(record =>
             {
                 var r = record.Write;
 
-                string lineMessage = r.LoggerName + " - " + r.EventId.ToString() + " - " + r.Formatter(r.State, r.Exception);
+                var lineMessage = r.LoggerName + " - " + r.EventId.ToString() + " - " + r.Formatter(r.State, r.Exception);
                 if (r.Exception != null)
                 {
                     lineMessage += Environment.NewLine;

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRFacts.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.SignalR.Common;
@@ -17,8 +18,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -76,7 +79,7 @@ public class AddAzureSignalRFacts : VerifiableLoggedTest
             var config = new ConfigurationBuilder()
                 .Build();
             var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR( o =>
+                .AddAzureSignalR(o =>
                 {
                     o.InitialHubServerConnectionCount = 15;
                     o.MaxHubServerConnectionCount = 3;
@@ -134,7 +137,7 @@ public class AddAzureSignalRFacts : VerifiableLoggedTest
     {
         using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
-            Func<HttpContext, bool> diagnosticClientFilter = context => context.Request.Query["diag"][0] != null;
+            static bool diagnosticClientFilter(HttpContext context) => context.Request.Query["diag"][0] != null;
             var services = new ServiceCollection();
             var config = new ConfigurationBuilder().Build();
             var serviceProvider = services.AddSignalR()
@@ -242,9 +245,9 @@ public class AddAzureSignalRFacts : VerifiableLoggedTest
                     {"Azure:SignalR:ServerStickyMode", modeFromConfig }
                 })
                 .Build();
-            ServerStickyMode capturedMode = ServerStickyMode.Disabled;
+            var capturedMode = ServerStickyMode.Disabled;
             var serviceProvider = services.AddSignalR()
-                .AddAzureSignalR(o => 
+                .AddAzureSignalR(o =>
                 {
                     capturedMode = o.ServerStickyMode;
                 })
@@ -336,7 +339,7 @@ public class AddAzureSignalRFacts : VerifiableLoggedTest
                 Assert.Single(options.Endpoints);
                 Assert.Equal(secondaryValue, options.Endpoints[0].ConnectionString);
             }
-            
+
             // Endpoints from Endpoints and ConnectionString config are merged inside the EndpointManager
             var endpoints = serviceProvider.GetRequiredService<IServiceEndpointManager>().Endpoints.Keys.ToArray();
             if (secondaryValue == null)

--- a/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRWithConnectionNameFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AddAzureSignalRWithConnectionNameFacts.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -385,7 +387,7 @@ public class AddAzureSignalRWithConnectionNameFacts : VerifiableLoggedTest
                 Assert.Single(options.Endpoints);
                 Assert.Equal(secondaryValue, options.Endpoints[0].ConnectionString);
             }
-            
+
             // Endpoints from Endpoints and ConnectionString config are merged inside the EndpointManager
             var endpoints = serviceProvider.GetRequiredService<IServiceEndpointManager>().Endpoints.Keys.ToArray();
             if (secondaryValue == null)

--- a/test/Microsoft.Azure.SignalR.Tests/AzureSignalRMarkerServiceFact.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/AzureSignalRMarkerServiceFact.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
 using System.Threading;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -63,7 +65,7 @@ public class AzureSignalRMarkerServiceFact
             .AddSingleton<IHostApplicationLifetime>(new EmptyApplicationLifetime())
             .AddSingleton<IConfiguration>(config)
             .BuildServiceProvider();
-    
+
         var app = new ApplicationBuilder(serviceProvider);
         app.UseRouting();
         app.UseEndpoints(routes =>

--- a/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientConnectionContextFacts.cs
@@ -9,11 +9,14 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+
 using Xunit;
 using Xunit.Abstractions;
+
 using ServiceProtocol = Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -206,108 +209,104 @@ public class ClientConnectionContextFacts : VerifiableLoggedTest
     [Fact]
     public async Task TestPauseResume()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information);
+        using var serviceConnection = new TestServiceConnection();
+
+        var pipeOptions = new PipeOptions();
+        var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+
+        var hubProtocol = new JsonHubProtocol();
+
+        var connectionId = "testConnectionId";
+
+        var connection = new ClientConnectionContext(new(connectionId, Array.Empty<Claim>())
         {
-            using var serviceConnection = new TestServiceConnection();
+            Protocol = hubProtocol.Name,
+        })
+        {
+            Application = pair.Application,
+            ServiceConnection = serviceConnection,
+            Logger = loggerFactory.CreateLogger<ServiceConnection>(),
+        };
 
-            var pipeOptions = new PipeOptions();
-            var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+        var outgoingTask = connection.ProcessOutgoingMessagesAsync(hubProtocol);
 
-            var hubProtocol = new JsonHubProtocol();
+        // write handshake response
+        var response = HandshakeResponseMessage.Empty;
+        HandshakeProtocol.WriteResponseMessage(response, pair.Transport.Output);
+        await pair.Transport.Output.FlushAsync();
 
-            var connectionId = "testConnectionId";
+        await connection.HandshakeResponseTask.OrTimeout(); ;
+        await connection.PauseAsync();
 
-            var connection = new ClientConnectionContext(new(connectionId, Array.Empty<Claim>())
-            {
-                Protocol = hubProtocol.Name,
-            })
-            {
-                Application = pair.Application,
-                ServiceConnection = serviceConnection,
-                Logger = loggerFactory.CreateLogger<ServiceConnection>(),
-            };
+        var invocationId = "foo";
+        var expect = new CompletionMessage(invocationId, "no error", null, false);
+        hubProtocol.WriteMessage(expect, pair.Transport.Output);
+        await pair.Transport.Output.FlushAsync();
 
-            var outgoingTask = connection.ProcessOutgoingMessagesAsync(hubProtocol);
+        await Task.Delay(3000);
+        await connection.ResumeAsync();
 
-            // write handshake response
-            var response = HandshakeResponseMessage.Empty;
-            HandshakeProtocol.WriteResponseMessage(response, pair.Transport.Output);
-            await pair.Transport.Output.FlushAsync();
+        pair.Transport.Output.Complete();
+        await outgoingTask.OrTimeout();
+        await serviceConnection.CompleteAsync();
 
-            await connection.HandshakeResponseTask.OrTimeout(); ;
-            await connection.PauseAsync();
-
-            var invocationId = "foo";
-            var expect = new CompletionMessage(invocationId, "no error", null, false);
-            hubProtocol.WriteMessage(expect, pair.Transport.Output);
-            await pair.Transport.Output.FlushAsync();
-
-            await Task.Delay(3000);
-            await connection.ResumeAsync();
-
-            pair.Transport.Output.Complete();
-            await outgoingTask.OrTimeout();
-            await serviceConnection.CompleteAsync();
-
-            Assert.Equal(2, serviceConnection.Messages.Count);
-            Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[0]);
-            var actual = Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[1]);
-            Assert.Equal(connectionId, actual.ConnectionId);
-            Assert.Equal(hubProtocol.GetMessageBytes(expect).ToArray(), actual.Payload.ToArray());
-            logCollector.Expects("OutgoingTaskPaused");
-            logCollector.Expects("OutgoingTaskResume");
-        }
+        Assert.Equal(2, serviceConnection.Messages.Count);
+        Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[0]);
+        var actual = Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[1]);
+        Assert.Equal(connectionId, actual.ConnectionId);
+        Assert.Equal(hubProtocol.GetMessageBytes(expect).ToArray(), actual.Payload.ToArray());
+        logCollector.Expects("OutgoingTaskPaused");
+        logCollector.Expects("OutgoingTaskResume");
     }
 
     [Fact]
     public async Task TestPauseAck()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information);
+        using var serviceConnection = new TestServiceConnection();
+
+        var pipeOptions = new PipeOptions();
+        var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+
+        var hubProtocol = new JsonHubProtocol();
+
+        var connectionId = "testConnectionId";
+
+        var connection = new ClientConnectionContext(new(connectionId, Array.Empty<Claim>())
         {
-            using var serviceConnection = new TestServiceConnection();
+            Protocol = hubProtocol.Name,
+        })
+        {
+            Application = pair.Application,
+            ServiceConnection = serviceConnection,
+            Logger = loggerFactory.CreateLogger<ServiceConnection>(),
+        };
 
-            var pipeOptions = new PipeOptions();
-            var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+        var outgoingTask = connection.ProcessOutgoingMessagesAsync(hubProtocol);
 
-            var hubProtocol = new JsonHubProtocol();
+        // write handshake response
+        var response = HandshakeResponseMessage.Empty;
+        HandshakeProtocol.WriteResponseMessage(response, pair.Transport.Output);
+        await pair.Transport.Output.FlushAsync();
 
-            var connectionId = "testConnectionId";
+        await connection.HandshakeResponseTask.OrTimeout(); ;
 
-            var connection = new ClientConnectionContext(new(connectionId, Array.Empty<Claim>())
-            {
-                Protocol = hubProtocol.Name,
-            })
-            {
-                Application = pair.Application,
-                ServiceConnection = serviceConnection,
-                Logger = loggerFactory.CreateLogger<ServiceConnection>(),
-            };
+        await connection.PauseAsync();
+        await connection.PauseAckAsync();
+        await connection.PauseAckAsync(); // should receive exactly 1 ack
 
-            var outgoingTask = connection.ProcessOutgoingMessagesAsync(hubProtocol);
+        pair.Transport.Output.Complete();
+        await outgoingTask.OrTimeout();
+        await serviceConnection.CompleteAsync();
 
-            // write handshake response
-            var response = HandshakeResponseMessage.Empty;
-            HandshakeProtocol.WriteResponseMessage(response, pair.Transport.Output);
-            await pair.Transport.Output.FlushAsync();
-
-            await connection.HandshakeResponseTask.OrTimeout(); ;
-
-            await connection.PauseAsync();
-            await connection.PauseAckAsync();
-            await connection.PauseAckAsync(); // should receive exactly 1 ack
-
-            pair.Transport.Output.Complete();
-            await outgoingTask.OrTimeout();
-            await serviceConnection.CompleteAsync();
-
-            Assert.Equal(2, serviceConnection.Messages.Count);
-            Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[0]);
-            var message = Assert.IsType<ServiceProtocol.ConnectionFlowControlMessage>(serviceConnection.Messages[1]);
-            Assert.Equal(connectionId, message.ConnectionId);
-            Assert.Equal(ServiceProtocol.ConnectionType.Client, message.ConnectionType);
-            Assert.Equal(ServiceProtocol.ConnectionFlowControlOperation.PauseAck, message.Operation);
-            logCollector.Expects("OutgoingTaskPauseAck");
-        }
+        Assert.Equal(2, serviceConnection.Messages.Count);
+        Assert.IsType<ServiceProtocol.ConnectionDataMessage>(serviceConnection.Messages[0]);
+        var message = Assert.IsType<ServiceProtocol.ConnectionFlowControlMessage>(serviceConnection.Messages[1]);
+        Assert.Equal(connectionId, message.ConnectionId);
+        Assert.Equal(ServiceProtocol.ConnectionType.Client, message.ConnectionType);
+        Assert.Equal(ServiceProtocol.ConnectionFlowControlOperation.PauseAck, message.Operation);
+        logCollector.Expects("OutgoingTaskPauseAck");
     }
 
     private sealed class TestServiceConnection : IServiceConnection, IDisposable

--- a/test/Microsoft.Azure.SignalR.Tests/ClientConnectionManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientConnectionManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ClientInvocationManagerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/EndpointRouterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/EndpointRouterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -51,7 +52,7 @@ public class EndpointRouterTests
         var endpointA = GenerateServiceEndpoint(quotaOfScaleUpInstance, 0, 80, "a");
         var endpointB = GenerateServiceEndpoint(100, 0, 70, "b");
         var endpointC = GenerateServiceEndpoint(100, 0, 70, "c");
-        var el = new List<ServiceEndpoint>() {endpointA, endpointB, endpointC};
+        var el = new List<ServiceEndpoint>() { endpointA, endpointB, endpointC };
         context.BenchTest(loops, () =>
         {
             var ep = drt.GetNegotiateEndpoint(null, el);
@@ -84,7 +85,8 @@ public class EndpointRouterTests
             ServerConnectionCount = serverConnectionCount
         };
         return new ServiceEndpoint("Endpoint=https://url;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;",
-            EndpointType.Primary, name) { EndpointMetrics = endpointMetrics };
+            EndpointType.Primary, name)
+        { EndpointMetrics = endpointMetrics };
     }
 
     private sealed class RandomContext

--- a/test/Microsoft.Azure.SignalR.Tests/HubMessageSerializerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/HubMessageSerializerTests.cs
@@ -6,10 +6,12 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultClientInvocationManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultHubProtocolResolver.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/DefaultHubProtocolResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/HandshakeUtils.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/HandshakeUtils.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 #nullable enable
 namespace Microsoft.Azure.SignalR.Tests
@@ -17,48 +18,46 @@ namespace Microsoft.Azure.SignalR.Tests
 
         public static async Task<HandshakeRequestMessage> ReceiveHandshakeRequestAsync(PipeReader input)
         {
-            using (var cts = new CancellationTokenSource(DefaultHandshakeTimeout))
+            using var cts = new CancellationTokenSource(DefaultHandshakeTimeout);
+            while (true)
             {
-                while (true)
+                var result = await input.ReadAsync(cts.Token);
+
+                var buffer = result.Buffer;
+                var consumed = buffer.Start;
+                var examined = buffer.End;
+
+                try
                 {
-                    var result = await input.ReadAsync(cts.Token);
-
-                    var buffer = result.Buffer;
-                    var consumed = buffer.Start;
-                    var examined = buffer.End;
-
-                    try
+                    if (!buffer.IsEmpty)
                     {
-                        if (!buffer.IsEmpty)
+                        if (ServiceProtocol.TryParseMessage(ref buffer, out var message))
                         {
-                            if (ServiceProtocol.TryParseMessage(ref buffer, out var message))
+                            consumed = buffer.Start;
+                            examined = consumed;
+
+                            if (message is not HandshakeRequestMessage handshakeRequest)
                             {
-                                consumed = buffer.Start;
-                                examined = consumed;
-
-                                if (message is not HandshakeRequestMessage handshakeRequest)
-                                {
-                                    throw new InvalidDataException(
-                                        $"{message!.GetType().Name} received when waiting for handshake request.");
-                                }
-
-                                return handshakeRequest.Version != ServiceProtocol.Version
-                                    ? throw new InvalidDataException("Protocol version not supported.")
-                                    : handshakeRequest;
+                                throw new InvalidDataException(
+                                    $"{message!.GetType().Name} received when waiting for handshake request.");
                             }
-                        }
 
-                        if (result.IsCompleted)
-                        {
-                            // Not enough data, and we won't be getting any more data.
-                            throw new InvalidOperationException(
-                                "Service connectioned disconnected before sending a handshake request");
+                            return handshakeRequest.Version != ServiceProtocol.Version
+                                ? throw new InvalidDataException("Protocol version not supported.")
+                                : handshakeRequest;
                         }
                     }
-                    finally
+
+                    if (result.IsCompleted)
                     {
-                        input.AdvanceTo(consumed, examined);
+                        // Not enough data, and we won't be getting any more data.
+                        throw new InvalidOperationException(
+                            "Service connectioned disconnected before sending a handshake request");
                     }
+                }
+                finally
+                {
+                    input.AdvanceTo(consumed, examined);
                 }
             }
         }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/ServiceConnectionProxy.cs
@@ -27,13 +27,13 @@ internal sealed class ServiceConnectionProxy : IClientConnectionManager, IClient
 
     private readonly PipeOptions _clientPipeOptions;
 
-    private readonly ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>> _waitForConnectionOpen = new ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>>();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<ConnectionContext>> _waitForConnectionOpen = new();
 
-    private readonly ConcurrentDictionary<string, TaskCompletionSource<object>> _waitForConnectionClose = new ConcurrentDictionary<string, TaskCompletionSource<object>>();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<object>> _waitForConnectionClose = new();
 
-    private readonly ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>> _waitForApplicationMessage = new ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>>();
+    private readonly ConcurrentDictionary<Type, TaskCompletionSource<ServiceMessage>> _waitForApplicationMessage = new();
 
-    private readonly ConcurrentDictionary<int, TaskCompletionSource<ConnectionContext>> _waitForServerConnection = new ConcurrentDictionary<int, TaskCompletionSource<ConnectionContext>>();
+    private readonly ConcurrentDictionary<int, TaskCompletionSource<ConnectionContext>> _waitForServerConnection = new();
 
     private int _connectedServerConnectionCount;
 
@@ -235,7 +235,10 @@ internal sealed class ServiceConnectionProxy : IClientConnectionManager, IClient
         return _waitForServerConnection.GetOrAdd(count, key => new TaskCompletionSource<ConnectionContext>()).Task;
     }
 
-    public bool TryAddClientConnection(IClientConnection connection) => TryAddClientConnection(connection as ClientConnectionContext);
+    public bool TryAddClientConnection(IClientConnection connection)
+    {
+        return TryAddClientConnection(connection as ClientConnectionContext);
+    }
 
     public bool TryRemoveClientConnection(string connectionId, out IClientConnection connection)
     {

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestClientConnectionFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.SignalR.Protocol;
 

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnection.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestOptionsMonitor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.SignalR.Tests
             var config = new ConfigurationBuilder().Build();
 
             var services = new ServiceCollection();
-            var endpoints = new List<ServiceEndpoint>() { new ServiceEndpoint($"Endpoint=https://testconnectionstring;AccessKey=1") };
+            var endpoints = new List<ServiceEndpoint>() { new($"Endpoint=https://testconnectionstring;AccessKey=1") };
             var serviceProvider = services.AddLogging()
                 .AddSignalR().AddAzureSignalR(o => o.Endpoints = endpoints.ToArray())
                 .Services
@@ -29,8 +30,14 @@ namespace Microsoft.Azure.SignalR.Tests
 
         public ServiceOptions CurrentValue => _monitor.CurrentValue;
 
-        public ServiceOptions Get(string name) => _monitor.Get(name);
+        public ServiceOptions Get(string name)
+        {
+            return _monitor.Get(name);
+        }
 
-        public IDisposable OnChange(Action<ServiceOptions, string> listener) => _monitor.OnChange(listener);
+        public IDisposable OnChange(Action<ServiceOptions, string> listener)
+        {
+            return _monitor.OnChange(listener);
+        }
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -12,9 +13,9 @@ namespace Microsoft.Azure.SignalR.Tests;
 
 internal sealed class TestServiceConnectionManager<THub> : IServiceConnectionManager<THub> where THub : Hub
 {
-    private readonly ConcurrentDictionary<Type, int> _writeAsyncCallCount = new ConcurrentDictionary<Type, int>();
+    private readonly ConcurrentDictionary<Type, int> _writeAsyncCallCount = new();
 
-    private readonly ConcurrentDictionary<Type, int> _partitionedWriteAsyncCallCount = new ConcurrentDictionary<Type, int>();
+    private readonly ConcurrentDictionary<Type, int> _partitionedWriteAsyncCallCount = new();
 
     public ServiceMessage ServiceMessage { get; private set; }
 
@@ -59,7 +60,13 @@ internal sealed class TestServiceConnectionManager<THub> : IServiceConnectionMan
         return Task.CompletedTask;
     }
 
-    public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token) => Task.CompletedTask;
+    public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
 
-    public Task CloseClientConnections(CancellationToken token) => Task.CompletedTask;
+    public Task CloseClientConnections(CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Logging/MessageLogTests.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests
@@ -16,80 +18,78 @@ namespace Microsoft.Azure.SignalR.Tests
         public void MessageLogTest()
         {
             var logger = new TestLogger();
-            using (var s = new ClientConnectionScope(null, null, true))
-            {
-                // broadcast
-                MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(null, 123UL));
-                Assert.Equal(Format(MessageLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
+            using var s = new ClientConnectionScope(null, null, true);
+            // broadcast
+            MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(null, 123UL));
+            Assert.Equal(Format(MessageLog.StartToBroadcastMessageTemplate, 123UL), logger.LogStr);
 
-                MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(new[] { "x", "y" }, new Dictionary<string, ReadOnlyMemory<byte>>(), 123UL));
-                Assert.Equal(Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
+            MessageLog.StartToBroadcastMessage(logger, new BroadcastDataMessage(new[] { "x", "y" }, new Dictionary<string, ReadOnlyMemory<byte>>(), 123UL));
+            Assert.Equal(Format(MessageLog.StartToBroadcastMessageWithExcludedConnectionTemplate, 123UL, 2, "x, y"), logger.LogStr);
 
-                // send to connections
-                MessageLog.StartToSendMessageToConnection(logger, new ConnectionDataMessage("id1", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionTemplate, 123UL, "id1"), logger.LogStr);
-                
-                MessageLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
+            // send to connections
+            MessageLog.StartToSendMessageToConnection(logger, new ConnectionDataMessage("id1", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionTemplate, 123UL, "id1"), logger.LogStr);
 
-                // send to user/users
-                MessageLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
+            MessageLog.StartToSendMessageToConnections(logger, new MultiConnectionDataMessage(new[] { "id1", "id2" }, null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToConnectionsTemplate, 123UL, 2, "id1, id2"), logger.LogStr);
 
-                MessageLog.FailedToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL), new InvalidOperationException());
-                Assert.Equal(Format(MessageLog.FailedToSendMessageTemplate, 123UL), logger.LogStr);
+            // send to user/users
+            MessageLog.StartToSendMessageToUser(logger, new UserDataMessage("user", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToUserTemplate, 123UL, "user"), logger.LogStr);
 
-                MessageLog.SucceededToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.SucceededToSendMessageTemplate, 123UL), logger.LogStr);
-                
-                MessageLog.ReceiveMessageFromService(logger, new ConnectionDataMessage("c", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.ReceivedMessageFromClientConnectionTemplate, 123UL, "c"), logger.LogStr);
-                
-                MessageLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
+            MessageLog.FailedToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL), new InvalidOperationException());
+            Assert.Equal(Format(MessageLog.FailedToSendMessageTemplate, 123UL), logger.LogStr);
 
-                // send to group/groups
-                MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
+            MessageLog.SucceededToSendMessage(logger, new UserDataMessage("user", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.SucceededToSendMessageTemplate, 123UL), logger.LogStr);
 
-                MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", new[] { "c1", "c2" }, null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
+            MessageLog.ReceiveMessageFromService(logger, new ConnectionDataMessage("c", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.ReceivedMessageFromClientConnectionTemplate, 123UL, "c"), logger.LogStr);
 
-                MessageLog.StartToBroadcastMessageToGroups(logger, new MultiGroupBroadcastDataMessage(new[] { "g1", "g2" }, null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
+            MessageLog.StartToSendMessageToUsers(logger, new MultiUserDataMessage(new[] { "u1", "u2" }, null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToUsersTemplate, 123UL, 2, "u1, u2"), logger.LogStr);
 
-                // connection join/leave group
-                MessageLog.StartToAddConnectionToGroup(logger, new JoinGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+            // send to group/groups
+            MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupTemplate, 123UL, "g"), logger.LogStr);
 
-                MessageLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
-                
-                MessageLog.StartToCloseConnection(logger, new CloseConnectionMessage("c", "e") { TracingId = 123UL});
-                Assert.Equal(Format(MessageLog.StartToSendMessageToCloseConnectionTemplate, 123UL, "c", "e"), logger.LogStr);
-                
-                MessageLog.StartToCheckIfConnectionExists(logger, new CheckConnectionExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckConnectionTemplate, 123UL, "c"), logger.LogStr);
-                
-                MessageLog.StartToCheckIfUserExists(logger, new CheckUserExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfUserExistsTemplate, 123UL, "c"), logger.LogStr);
-                
-                MessageLog.StartToCheckIfGroupExists(logger, new CheckGroupExistenceWithAckMessage("c", 12, 123UL));
-                Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfGroupExistsTemplate, 123UL, "c"), logger.LogStr);
-                
-                // user join/leave group
-                MessageLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
-                
-                MessageLog.StartToCheckIfUserInGroup(logger, new CheckUserInGroupWithAckMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToCheckIfUserInGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+            MessageLog.StartToBroadcastMessageToGroup(logger, new GroupBroadcastDataMessage("g", new[] { "c1", "c2" }, null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupWithExcludedConnectionsTemplate, 123UL, "g", 2, "c1, c2"), logger.LogStr);
 
-                MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+            MessageLog.StartToBroadcastMessageToGroups(logger, new MultiGroupBroadcastDataMessage(new[] { "g1", "g2" }, null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToBroadcastMessageToGroupsTemplate, 123UL, 2, "g1, g2"), logger.LogStr);
 
-                MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", null, tracingId: 123UL));
-                Assert.Equal(Format(MessageLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
-            }
+            // connection join/leave group
+            MessageLog.StartToAddConnectionToGroup(logger, new JoinGroupWithAckMessage("c", "g", tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToAddConnectionToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+
+            MessageLog.StartToRemoveConnectionFromGroup(logger, new LeaveGroupWithAckMessage("c", "g", tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToRemoveConnectionFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+
+            MessageLog.StartToCloseConnection(logger, new CloseConnectionMessage("c", "e") { TracingId = 123UL });
+            Assert.Equal(Format(MessageLog.StartToSendMessageToCloseConnectionTemplate, 123UL, "c", "e"), logger.LogStr);
+
+            MessageLog.StartToCheckIfConnectionExists(logger, new CheckConnectionExistenceWithAckMessage("c", 12, 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToCheckConnectionTemplate, 123UL, "c"), logger.LogStr);
+
+            MessageLog.StartToCheckIfUserExists(logger, new CheckUserExistenceWithAckMessage("c", 12, 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfUserExistsTemplate, 123UL, "c"), logger.LogStr);
+
+            MessageLog.StartToCheckIfGroupExists(logger, new CheckGroupExistenceWithAckMessage("c", 12, 123UL));
+            Assert.Equal(Format(MessageLog.StartToSendMessageToCheckIfGroupExistsTemplate, 123UL, "c"), logger.LogStr);
+
+            // user join/leave group
+            MessageLog.StartToAddUserToGroup(logger, new UserJoinGroupMessage("c", "g", tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToAddUserToGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+
+            MessageLog.StartToCheckIfUserInGroup(logger, new CheckUserInGroupWithAckMessage("c", "g", tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToCheckIfUserInGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+
+            MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", "g", tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToRemoveUserFromGroupTemplate, 123UL, "c", "g"), logger.LogStr);
+
+            MessageLog.StartToRemoveUserFromGroup(logger, new UserLeaveGroupMessage("c", null, tracingId: 123UL));
+            Assert.Equal(Format(MessageLog.StartToRemoveUserFromAllGroupsTemplate, 123UL, "c"), logger.LogStr);
         }
 
         private static string Format(string logTemplate, params object[] values)

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -19,8 +20,10 @@ using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 using Xunit.Abstractions;
+
 using SignalRProtocol = Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -473,15 +476,14 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
     [Fact]
     public async Task TestContainerWithTwoEndpointWithAllOfflineSucceedsWithWarning()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var sem = new TestServiceEndpointManager(
-                new ServiceEndpoint(ConnectionString1),
-                new ServiceEndpoint(ConnectionString2));
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var sem = new TestServiceEndpointManager(
+            new ServiceEndpoint(ConnectionString1),
+            new ServiceEndpoint(ConnectionString2));
 
-            var router = new TestEndpointRouter();
-            var container = new TestMultiEndpointServiceConnectionContainer("hub",
-                e => new TestServiceConnectionContainer(new List<IServiceConnection> {
+        var router = new TestEndpointRouter();
+        var container = new TestMultiEndpointServiceConnectionContainer("hub",
+            e => new TestServiceConnectionContainer(new List<IServiceConnection> {
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -489,30 +491,28 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
-            }, e), sem, router, loggerFactory);
+        }, e), sem, router, loggerFactory);
 
-            // All the connections started
-            _ = container.StartAsync();
-            await container.ConnectionInitializedTask;
-            await container.WriteAckableMessageAsync(DefaultGroupMessage);
-            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
+        // All the connections started
+        _ = container.StartAsync();
+        await container.ConnectionInitializedTask;
+        await container.WriteAckableMessageAsync(DefaultGroupMessage);
+        var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
 
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-        }
+        Assert.Single(warns);
+        Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
     }
 
     [Fact]
     public async Task TestContainerWithTwoOfflineEndpointWriteAckableMessageSucceedsWithWarning()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
-        {
-            var sem = new TestServiceEndpointManager(
-            new ServiceEndpoint(ConnectionString1),
-            new ServiceEndpoint(ConnectionString2));
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var sem = new TestServiceEndpointManager(
+        new ServiceEndpoint(ConnectionString1),
+        new ServiceEndpoint(ConnectionString2));
 
-            var router = new TestEndpointRouter();
-            var container = new TestMultiEndpointServiceConnectionContainer("hub", e => new TestServiceConnectionContainer(new List<IServiceConnection> {
+        var router = new TestEndpointRouter();
+        var container = new TestMultiEndpointServiceConnectionContainer("hub", e => new TestServiceConnectionContainer(new List<IServiceConnection> {
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
@@ -522,14 +522,13 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                 }, e), sem, router, loggerFactory);
 
-            _ = container.StartAsync();
-            await container.ConnectionInitializedTask;
+        _ = container.StartAsync();
+        await container.ConnectionInitializedTask;
 
-            await container.WriteAckableMessageAsync(DefaultGroupMessage);
-            var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
-            Assert.Single(warns);
-            Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
-        }
+        await container.WriteAckableMessageAsync(DefaultGroupMessage);
+        var warns = logCollector.ExpectsMany(s => s.Write.LogLevel == LogLevel.Warning);
+        Assert.Single(warns);
+        Assert.Equal("Message JoinGroupWithAckMessage is not sent because no endpoint is returned from the endpoint router.", warns[0].Write.Message);
     }
 
     [Fact]

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.SignalR.Tests
         private const string ConnectionString3 = "Endpoint=http://localhost3;AccessKey=fake_key;";
         private const string ConnectionString4 = "Endpoint=http://localhost4;AccessKey=fake_key;";
 
-        private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new JwtSecurityTokenHandler();
+        private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
 
         [Theory]
         [InlineData(typeof(CustomUserIdProvider), CustomUserId)]
@@ -332,9 +332,9 @@ namespace Microsoft.Azure.SignalR.Tests
                     o.ApplicationName = "testprefix";
                     o.Endpoints = new ServiceEndpoint[]
                     {
-                        new ServiceEndpoint(ConnectionString2),
-                        new ServiceEndpoint(ConnectionString3, name: "chosen"),
-                        new ServiceEndpoint(ConnectionString4),
+                        new(ConnectionString2),
+                        new(ConnectionString3, name: "chosen"),
+                        new(ConnectionString4),
                     };
                 })
                 .Services
@@ -371,9 +371,9 @@ namespace Microsoft.Azure.SignalR.Tests
                 .AddAzureSignalR(
                 o => o.Endpoints = new ServiceEndpoint[]
                 {
-                    new ServiceEndpoint(ConnectionString2),
-                    new ServiceEndpoint(ConnectionString3, name: "chosen"),
-                    new ServiceEndpoint(ConnectionString4),
+                    new(ConnectionString2),
+                    new(ConnectionString3, name: "chosen"),
+                    new(ConnectionString4),
                 })
                 .Services
                 .AddLogging()
@@ -716,27 +716,42 @@ namespace Microsoft.Azure.SignalR.Tests
 
         private sealed class NullUserIdProvider : IUserIdProvider
         {
-            public string GetUserId(HubConnectionContext connection) => null;
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return null;
+            }
         }
 
         private sealed class ConnectionIdUserIdProvider : IUserIdProvider
         {
-            public string GetUserId(HubConnectionContext connection) => connection.ConnectionId;
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return connection.ConnectionId;
+            }
         }
 
         private sealed class ConnectionAbortedTokenUserIdProvider : IUserIdProvider
         {
-            public string GetUserId(HubConnectionContext connection) => connection.ConnectionAborted.IsCancellationRequested.ToString();
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return connection.ConnectionAborted.IsCancellationRequested.ToString();
+            }
         }
 
         private sealed class ItemsUserIdProvider : IUserIdProvider
         {
-            public string GetUserId(HubConnectionContext connection) => connection.Items.ToString();
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return connection.Items.ToString();
+            }
         }
 
         private sealed class ProtocolUserIdProvider : IUserIdProvider
         {
-            public string GetUserId(HubConnectionContext connection) => connection.Protocol.Name;
+            public string GetUserId(HubConnectionContext connection)
+            {
+                return connection.Protocol.Name;
+            }
         }
 
         private sealed class Chat : Hub

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerBaseTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,54 +28,52 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
     [InlineData(3, 1, 0)]
     public async Task TestServersPing(int startCount, int stopCount, int expectedWarn)
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
-        {
-            var connections = new List<IServiceConnection>
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug);
+        var connections = new List<IServiceConnection>
             {
                 new SimpleTestServiceConnection(),
                 new SimpleTestServiceConnection(),
                 new SimpleTestServiceConnection()
             };
-            using var container =
-                new TestServiceConnectionContainer(
-                    connections,
-                    factory: new SimpleTestServiceConnectionFactory(),
-                    logger: loggerFactory.CreateLogger<TestServiceConnectionContainer>());
+        using var container =
+            new TestServiceConnectionContainer(
+                connections,
+                factory: new SimpleTestServiceConnectionFactory(),
+                logger: loggerFactory.CreateLogger<TestServiceConnectionContainer>());
 
-            await container.StartAsync();
-            await container.ConnectionInitializedTask;
-            var tasks = new List<Task>();
+        await container.StartAsync();
+        await container.ConnectionInitializedTask;
+        var tasks = new List<Task>();
 
-            while (startCount > 0)
-            {
-                tasks.Add(container.StartGetServersPing());
-                startCount--;
-            }
-            await Task.WhenAll(tasks);
+        while (startCount > 0)
+        {
+            tasks.Add(container.StartGetServersPing());
+            startCount--;
+        }
+        await Task.WhenAll(tasks);
 
-            // default interval is 5s, add 2s for delay, validate any one connection write servers ping.
-            if (tasks.Count > 0)
+        // default interval is 5s, add 2s for delay, validate any one connection write servers ping.
+        if (tasks.Count > 0)
+        {
+            await Task.WhenAny(connections.Select(c =>
             {
-                await Task.WhenAny(connections.Select(c =>
-                {
-                    var connection = c as SimpleTestServiceConnection;
-                    return connection.ServersPingTask.OrTimeout(7000);
-                }));
-            }
+                var connection = c as SimpleTestServiceConnection;
+                return connection.ServersPingTask.OrTimeout(7000);
+            }));
+        }
 
-            tasks.Clear();
-            while (stopCount > 0)
-            {
-                tasks.Add(container.StopGetServersPing());
-                stopCount--;
-            }
-            await Task.WhenAll(tasks);
-            var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
-            Assert.Equal(expectedWarn, warns.Count);
-            if (expectedWarn > 0)
-            {
-                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
-            }
+        tasks.Clear();
+        while (stopCount > 0)
+        {
+            tasks.Add(container.StopGetServersPing());
+            stopCount--;
+        }
+        await Task.WhenAll(tasks);
+        var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
+        Assert.Equal(expectedWarn, warns.Count);
+        if (expectedWarn > 0)
+        {
+            Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
         }
     }
 
@@ -85,73 +84,71 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
     [InlineData(1, 3, 2, 2, 2)] // first time error stop won't break second time write.
     public async Task TestServersPingWorkSecondTime(int firstStart, int firstStop, int secondStart, int secondStop, int expectedWarn)
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
-        {
-            var connections = new List<IServiceConnection>
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug);
+        var connections = new List<IServiceConnection>
             {
                 new SimpleTestServiceConnection(),
                 new SimpleTestServiceConnection(),
                 new SimpleTestServiceConnection()
             };
-            using var container =
-                new TestServiceConnectionContainer(
-                    connections,
-                    factory: new SimpleTestServiceConnectionFactory(),
-                    logger: loggerFactory.CreateLogger<TestServiceConnectionContainer>());
+        using var container =
+            new TestServiceConnectionContainer(
+                connections,
+                factory: new SimpleTestServiceConnectionFactory(),
+                logger: loggerFactory.CreateLogger<TestServiceConnectionContainer>());
 
-            await container.StartAsync();
-            await container.ConnectionInitializedTask;
+        await container.StartAsync();
+        await container.ConnectionInitializedTask;
 
-            var tasks = new List<Task>();
+        var tasks = new List<Task>();
 
-            // first time scale
-            while (firstStart > 0)
+        // first time scale
+        while (firstStart > 0)
+        {
+            tasks.Add(container.StartGetServersPing());
+            firstStart--;
+        }
+        await Task.WhenAll(tasks);
+
+        tasks.Clear();
+        while (firstStop > 0)
+        {
+            tasks.Add(container.StopGetServersPing());
+            firstStop--;
+        }
+        await Task.WhenAll(tasks);
+
+        // second time scale
+        tasks.Clear();
+        while (secondStart > 0)
+        {
+            tasks.Add(container.StartGetServersPing());
+            secondStart--;
+        }
+        await Task.WhenAll(tasks);
+
+        // default interval is 5s, add 2s for delay, validate any one connection write servers ping.
+        if (tasks.Count > 0)
+        {
+            await Task.WhenAny(connections.Select(c =>
             {
-                tasks.Add(container.StartGetServersPing());
-                firstStart--;
-            }
-            await Task.WhenAll(tasks);
+                var connection = c as SimpleTestServiceConnection;
+                return connection.ServersPingTask.OrTimeout(7000);
+            }));
+        }
 
-            tasks.Clear();
-            while (firstStop > 0)
-            {
-                tasks.Add(container.StopGetServersPing());
-                firstStop--;
-            }
-            await Task.WhenAll(tasks);
-
-            // second time scale
-            tasks.Clear();
-            while (secondStart > 0)
-            {
-                tasks.Add(container.StartGetServersPing());
-                secondStart--;
-            }
-            await Task.WhenAll(tasks);
-
-            // default interval is 5s, add 2s for delay, validate any one connection write servers ping.
-            if (tasks.Count > 0)
-            {
-                await Task.WhenAny(connections.Select(c =>
-                {
-                    var connection = c as SimpleTestServiceConnection;
-                    return connection.ServersPingTask.OrTimeout(7000);
-                }));
-            }
-
-            tasks.Clear();
-            while (secondStop > 0)
-            {
-                tasks.Add(container.StopGetServersPing());
-                secondStop--;
-            }
-            await Task.WhenAll(tasks);
-            var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
-            Assert.Equal(expectedWarn, warns.Count);
-            if (expectedWarn > 0)
-            {
-                Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
-            }
+        tasks.Clear();
+        while (secondStop > 0)
+        {
+            tasks.Add(container.StopGetServersPing());
+            secondStop--;
+        }
+        await Task.WhenAll(tasks);
+        var warns = logCollector.ExpectsMany("TimerAlreadyStopped");
+        Assert.Equal(expectedWarn, warns.Count);
+        if (expectedWarn > 0)
+        {
+            Assert.Contains(warns, s => s.Write.Message.Contains("Failed to stop Servers timer as it's not started"));
         }
     }
 
@@ -213,14 +210,17 @@ public class ServiceConnectionContainerBaseTests : VerifiableLoggedTest
 
     private sealed class SimpleTestServiceConnectionFactory : IServiceConnectionFactory
     {
-        public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, AckHandler ackHandler, ServiceConnectionType type) => new SimpleTestServiceConnection();
+        public IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, AckHandler ackHandler, ServiceConnectionType type)
+        {
+            return new SimpleTestServiceConnection();
+        }
     }
 
     private sealed class SimpleTestServiceConnection : IServiceConnection
     {
-        private readonly TaskCompletionSource<bool> _offline = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _offline = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private readonly TaskCompletionSource<bool> _serversPing = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _serversPing = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task ConnectionInitializedTask => Task.Delay(TimeSpan.FromSeconds(1));
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionContainerTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -26,7 +26,6 @@ using Xunit.Abstractions;
 using SignalRProtocol = Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests;
-#nullable disable
 public class ServiceConnectionTests : VerifiableLoggedTest
 {
     public ServiceConnectionTests(ITestOutputHelper output) : base(output)
@@ -36,138 +35,132 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestServiceConnectionHandleOfflineMessageTask()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information);
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(loggerFactory);
+        var protocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
         {
-            var ccm = new TestClientConnectionManager();
-            var ccf = new ClientConnectionFactory(loggerFactory);
-            var protocol = new ServiceProtocol();
-            var hubProtocol = new JsonHubProtocol();
-            TestConnection transportConnection = null;
-            var connectionFactory = new TestConnectionFactory(conn =>
-            {
-                transportConnection = conn;
-                return Task.CompletedTask;
-            });
-            var services = new ServiceCollection();
-            var builder = new ConnectionBuilder(services.BuildServiceProvider());
-            builder.UseConnectionHandler<TestConnectionHandler>();
-            var handler = builder.Build();
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<TestConnectionHandler>();
+        var handler = builder.Build();
 
-            var serviceConnection = CreateServiceConnection(protocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
-            var connectionTask = serviceConnection.StartAsync();
+        var serviceConnection = CreateServiceConnection(protocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
+        var connectionTask = serviceConnection.StartAsync();
 
-            // completed handshake
-            await serviceConnection.ConnectionInitializedTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
+        // completed handshake
+        await serviceConnection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
 
-            // send offline message
-            var message = new ConnectionFlowControlMessage(serviceConnection.ConnectionId, ConnectionFlowControlOperation.Offline, ConnectionType.Server);
-            await transportConnection.Application.Output.WriteAsync(protocol.GetMessageBytes(message));
+        // send offline message
+        var message = new ConnectionFlowControlMessage(serviceConnection.ConnectionId, ConnectionFlowControlOperation.Offline, ConnectionType.Server);
+        await transportConnection.Application.Output.WriteAsync(protocol.GetMessageBytes(message));
 
-            // complete reading to end the connection
-            transportConnection.Application.Output.Complete();
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
 
-            await connectionTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
-            logCollector.Expects("ReceivedConnectionOffline");
-        }
+        await connectionTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+        logCollector.Expects("ReceivedConnectionOffline");
     }
 
     [Fact]
     public async Task TestServiceConnectionHandlePauseMessageTask()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information);
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(loggerFactory);
+        var serviceProtocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
         {
-            var ccm = new TestClientConnectionManager();
-            var ccf = new ClientConnectionFactory(loggerFactory);
-            var serviceProtocol = new ServiceProtocol();
-            var hubProtocol = new JsonHubProtocol();
-            TestConnection transportConnection = null;
-            var connectionFactory = new TestConnectionFactory(conn =>
-            {
-                transportConnection = conn;
-                return Task.CompletedTask;
-            });
-            var services = new ServiceCollection();
-            var builder = new ConnectionBuilder(services.BuildServiceProvider());
-            builder.UseConnectionHandler<TestConnectionHandler>();
-            var handler = builder.Build();
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<TestConnectionHandler>();
+        var handler = builder.Build();
 
-            var serviceConnection = CreateServiceConnection(serviceProtocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
-            var connectionTask = serviceConnection.StartAsync();
+        var serviceConnection = CreateServiceConnection(serviceProtocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
+        var connectionTask = serviceConnection.StartAsync();
 
-            // completed handshake
-            await serviceConnection.ConnectionInitializedTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
+        // completed handshake
+        await serviceConnection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
 
-            // wait for a client connection
-            var clientConnection = await CreateClientConnectionAsync(serviceProtocol, hubProtocol, ccm, transportConnection);
+        // wait for a client connection
+        var clientConnection = await CreateClientConnectionAsync(serviceProtocol, hubProtocol, ccm, transportConnection);
 
-            // send 2 pause message, expect only 1 pause ack message
-            var pauseMessage = new ConnectionFlowControlMessage(clientConnection.ConnectionId, ConnectionFlowControlOperation.Pause, ConnectionType.Client);
-            await transportConnection.Application.Output.WriteAsync(serviceProtocol.GetMessageBytes(pauseMessage));
-            await transportConnection.Application.Output.WriteAsync(serviceProtocol.GetMessageBytes(pauseMessage));
+        // send 2 pause message, expect only 1 pause ack message
+        var pauseMessage = new ConnectionFlowControlMessage(clientConnection.ConnectionId, ConnectionFlowControlOperation.Pause, ConnectionType.Client);
+        await transportConnection.Application.Output.WriteAsync(serviceProtocol.GetMessageBytes(pauseMessage));
+        await transportConnection.Application.Output.WriteAsync(serviceProtocol.GetMessageBytes(pauseMessage));
 
-            // read pause ack message
-            var result = await transportConnection.Application.Input.ReadAsync().OrTimeout();
-            var buffer = result.Buffer;
-            Assert.True(serviceProtocol.TryParseMessage(ref buffer, out var m));
-            var pauseAckMessage = Assert.IsType<ConnectionFlowControlMessage>(m);
-            Assert.Equal(pauseMessage.ConnectionId, pauseAckMessage.ConnectionId);
-            Assert.Equal(ConnectionFlowControlOperation.PauseAck, pauseAckMessage.Operation);
-            Assert.Equal(ConnectionType.Client, pauseAckMessage.ConnectionType);
+        // read pause ack message
+        var result = await transportConnection.Application.Input.ReadAsync().OrTimeout();
+        var buffer = result.Buffer;
+        Assert.True(serviceProtocol.TryParseMessage(ref buffer, out var m));
+        var pauseAckMessage = Assert.IsType<ConnectionFlowControlMessage>(m);
+        Assert.Equal(pauseMessage.ConnectionId, pauseAckMessage.ConnectionId);
+        Assert.Equal(ConnectionFlowControlOperation.PauseAck, pauseAckMessage.Operation);
+        Assert.Equal(ConnectionType.Client, pauseAckMessage.ConnectionType);
 
-            // complete reading to end the connection
-            transportConnection.Application.Output.Complete();
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
 
-            await connectionTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
-            logCollector.Expects("OutgoingTaskPaused");
-            logCollector.Expects("OutgoingTaskPauseAck");
-        }
+        await connectionTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+        logCollector.Expects("OutgoingTaskPaused");
+        logCollector.Expects("OutgoingTaskPauseAck");
     }
 
     [Fact]
     public async Task TestServiceConnectionHandleResumeMessageTask()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Information);
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(loggerFactory);
+        var protocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
         {
-            var ccm = new TestClientConnectionManager();
-            var ccf = new ClientConnectionFactory(loggerFactory);
-            var protocol = new ServiceProtocol();
-            var hubProtocol = new JsonHubProtocol();
-            TestConnection transportConnection = null;
-            var connectionFactory = new TestConnectionFactory(conn =>
-            {
-                transportConnection = conn;
-                return Task.CompletedTask;
-            });
-            var services = new ServiceCollection();
-            var builder = new ConnectionBuilder(services.BuildServiceProvider());
-            builder.UseConnectionHandler<TestConnectionHandler>();
-            var handler = builder.Build();
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<TestConnectionHandler>();
+        var handler = builder.Build();
 
-            var serviceConnection = CreateServiceConnection(protocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
-            var connectionTask = serviceConnection.StartAsync();
+        var serviceConnection = CreateServiceConnection(protocol, hubProtocol, ccm, ccf, connectionFactory, loggerFactory, handler);
+        var connectionTask = serviceConnection.StartAsync();
 
-            // completed handshake
-            await serviceConnection.ConnectionInitializedTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
+        // completed handshake
+        await serviceConnection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, serviceConnection.Status);
 
-            // wait for a client connection
-            var clientConnection = await CreateClientConnectionAsync(protocol, hubProtocol, ccm, transportConnection);
+        // wait for a client connection
+        var clientConnection = await CreateClientConnectionAsync(protocol, hubProtocol, ccm, transportConnection);
 
-            // send resume message
-            var message = new ConnectionFlowControlMessage(clientConnection.ConnectionId, ConnectionFlowControlOperation.Resume, ConnectionType.Client);
-            await transportConnection.Application.Output.WriteAsync(protocol.GetMessageBytes(message));
+        // send resume message
+        var message = new ConnectionFlowControlMessage(clientConnection.ConnectionId, ConnectionFlowControlOperation.Resume, ConnectionType.Client);
+        await transportConnection.Application.Output.WriteAsync(protocol.GetMessageBytes(message));
 
-            // complete reading to end the connection
-            transportConnection.Application.Output.Complete();
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
 
-            await connectionTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
-            logCollector.Expects("OutgoingTaskResume");
-        }
+        await connectionTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Disconnected, serviceConnection.Status);
+        logCollector.Expects("OutgoingTaskResume");
     }
 
     [Fact]
@@ -280,129 +273,125 @@ public class ServiceConnectionTests : VerifiableLoggedTest
     [Fact]
     public async Task TestServiceConnectionWithErrorApplicationTask()
     {
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(loggerFactory);
+        var protocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
         {
-            var ccm = new TestClientConnectionManager();
-            var ccf = new ClientConnectionFactory(loggerFactory);
-            var protocol = new ServiceProtocol();
-            var hubProtocol = new JsonHubProtocol();
-            TestConnection transportConnection = null;
-            var connectionFactory = new TestConnectionFactory(conn =>
-            {
-                transportConnection = conn;
-                return Task.CompletedTask;
-            });
-            var services = new ServiceCollection();
-            var errorTcs = new TaskCompletionSource<Exception>();
-            var connectionHandler = new ErrorConnectionHandler(errorTcs);
-            services.AddSingleton(connectionHandler);
-            var builder = new ConnectionBuilder(services.BuildServiceProvider());
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+        var errorTcs = new TaskCompletionSource<Exception>();
+        var connectionHandler = new ErrorConnectionHandler(errorTcs);
+        services.AddSingleton(connectionHandler);
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
 
-            builder.UseConnectionHandler<ErrorConnectionHandler>();
-            var handler = builder.Build();
+        builder.UseConnectionHandler<ErrorConnectionHandler>();
+        var handler = builder.Build();
 
-            var connection = new ServiceConnection(
-                protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
-                "serverId", Guid.NewGuid().ToString("N"), null, null, null, new DefaultClientInvocationManager(),
-                new DefaultHubProtocolResolver(new[] { hubProtocol }, NullLogger<DefaultHubProtocolResolver>.Instance), null);
+        var connection = new ServiceConnection(
+            protocol, ccm, connectionFactory, loggerFactory, handler, ccf,
+            "serverId", Guid.NewGuid().ToString("N"), null, null, null, new DefaultClientInvocationManager(),
+            new DefaultHubProtocolResolver(new[] { hubProtocol }, NullLogger<DefaultHubProtocolResolver>.Instance), null);
 
-            var connectionTask = connection.StartAsync();
+        var connectionTask = connection.StartAsync();
 
-            // completed handshake
-            await connection.ConnectionInitializedTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
-            var clientConnectionId = Guid.NewGuid().ToString();
-            var waitClientTask = ccm.WaitForClientConnectionAsync(clientConnectionId);
-            await transportConnection.Application.Output.WriteAsync(
-                protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, Array.Empty<Claim>()) { Protocol = hubProtocol.Name }));
+        // completed handshake
+        await connection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
+        var clientConnectionId = Guid.NewGuid().ToString();
+        var waitClientTask = ccm.WaitForClientConnectionAsync(clientConnectionId);
+        await transportConnection.Application.Output.WriteAsync(
+            protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, Array.Empty<Claim>()) { Protocol = hubProtocol.Name }));
 
-            var clientConnection = await waitClientTask.OrTimeout();
+        var clientConnection = await waitClientTask.OrTimeout();
 
-            errorTcs.SetException(new InvalidOperationException("error operation"));
+        errorTcs.SetException(new InvalidOperationException("error operation"));
 
-            await clientConnection.LifetimeTask.OrTimeout();
+        await clientConnection.LifetimeTask.OrTimeout();
 
-            // Should complete the connection when application throws
-            await ccm.WaitForClientConnectionRemovalAsync(clientConnectionId).OrTimeout();
+        // Should complete the connection when application throws
+        await ccm.WaitForClientConnectionRemovalAsync(clientConnectionId).OrTimeout();
 
-            // Application task should not affect the underlying service connection
-            Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
+        // Application task should not affect the underlying service connection
+        Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
 
-            // complete reading to end the connection
-            transportConnection.Application.Output.Complete();
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
 
-            await connectionTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
-            Assert.Empty(ccm.ClientConnections);
-            logCollector.Expects("SendLoopStopped");
-            logCollector.Expects("ApplicationTaskFailed");
-        }
+        await connectionTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
+        Assert.Empty(ccm.ClientConnections);
+        logCollector.Expects("SendLoopStopped");
+        logCollector.Expects("ApplicationTaskFailed");
     }
 
     [Fact]
     public async Task TestServiceConnectionWithEndlessApplicationTaskNeverEnds()
     {
         var clientConnectionId = Guid.NewGuid().ToString();
-        using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning))
+        using var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Warning);
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 1);
+        var protocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
         {
-            var ccm = new TestClientConnectionManager();
-            var ccf = new ClientConnectionFactory(loggerFactory, closeTimeOutMilliseconds: 1);
-            var protocol = new ServiceProtocol();
-            var hubProtocol = new JsonHubProtocol();
-            TestConnection transportConnection = null;
-            var connectionFactory = new TestConnectionFactory(conn =>
-            {
-                transportConnection = conn;
-                return Task.CompletedTask;
-            });
-            var services = new ServiceCollection();
-            var connectionHandler = new EndlessConnectionHandler();
-            services.AddSingleton(connectionHandler);
-            var builder = new ConnectionBuilder(services.BuildServiceProvider());
-            builder.UseConnectionHandler<EndlessConnectionHandler>();
-            var handler = builder.Build();
-            var hubProtocolResolver = new DefaultHubProtocolResolver(new[] { hubProtocol }, NullLogger<DefaultHubProtocolResolver>.Instance);
-            var connection = new ServiceConnection(protocol,
-                                                   ccm,
-                                                   connectionFactory,
-                                                   loggerFactory,
-                                                   handler,
-                                                   ccf,
-                                                   "serverId",
-                                                   Guid.NewGuid().ToString("N"),
-                                                   null,
-                                                   null,
-                                                   null,
-                                                   new DefaultClientInvocationManager(),
-                                                   hubProtocolResolver,
-                                                   null);
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+        var connectionHandler = new EndlessConnectionHandler();
+        services.AddSingleton(connectionHandler);
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<EndlessConnectionHandler>();
+        var handler = builder.Build();
+        var hubProtocolResolver = new DefaultHubProtocolResolver(new[] { hubProtocol }, NullLogger<DefaultHubProtocolResolver>.Instance);
+        var connection = new ServiceConnection(protocol,
+                                               ccm,
+                                               connectionFactory,
+                                               loggerFactory,
+                                               handler,
+                                               ccf,
+                                               "serverId",
+                                               Guid.NewGuid().ToString("N"),
+                                               null,
+                                               null,
+                                               null,
+                                               new DefaultClientInvocationManager(),
+                                               hubProtocolResolver,
+                                               null);
 
-            var connectionTask = connection.StartAsync();
+        var connectionTask = connection.StartAsync();
 
-            // completed handshake
-            await connection.ConnectionInitializedTask.OrTimeout();
-            Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
-            var waitClientTask = ccm.WaitForClientConnectionAsync(clientConnectionId);
-            await transportConnection.Application.Output.WriteAsync(
-                protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, Array.Empty<Claim>()) { Protocol = hubProtocol.Name }));
+        // completed handshake
+        await connection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
+        var waitClientTask = ccm.WaitForClientConnectionAsync(clientConnectionId);
+        await transportConnection.Application.Output.WriteAsync(
+            protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, Array.Empty<Claim>()) { Protocol = hubProtocol.Name }));
 
-            var clientConnection = await waitClientTask.OrTimeout();
+        var clientConnection = await waitClientTask.OrTimeout();
 
-            // complete reading to end the connection
-            transportConnection.Application.Output.Complete();
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
 
-            // Assert timeout
-            var lifetime = clientConnection.LifetimeTask;
-            var task = await Task.WhenAny(lifetime, Task.Delay(1000));
-            Assert.NotEqual(lifetime, task);
+        // Assert timeout
+        var lifetime = clientConnection.LifetimeTask;
+        var task = await Task.WhenAny(lifetime, Task.Delay(1000));
+        Assert.NotEqual(lifetime, task);
 
-            Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
+        Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
 
-            // since the service connection ends, the client connection is cleaned up from the collection...
-            Assert.Empty(ccm.ClientConnections);
-            var log = logCollector.Expects("DetectedLongRunningApplicationTask");
-            Assert.Equal($"The connection {clientConnectionId} has a long running application logic that prevents the connection from complete after 1 milliseconds.", log.Write.Message);
-        }
+        // since the service connection ends, the client connection is cleaned up from the collection...
+        Assert.Empty(ccm.ClientConnections);
+        var log = logCollector.Expects("DetectedLongRunningApplicationTask");
+        Assert.Equal($"The connection {clientConnectionId} has a long running application logic that prevents the connection from complete after 1 milliseconds.", log.Write.Message);
     }
 
     [Fact]
@@ -994,7 +983,7 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
     private sealed class TestConnectionHandler : ConnectionHandler
     {
-        private readonly TaskCompletionSource<object> _startedTcs = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _startedTcs = new();
 
         public Task Started => _startedTcs.Task;
 
@@ -1098,9 +1087,9 @@ public class ServiceConnectionTests : VerifiableLoggedTest
 
     private sealed class TextContentConnectionHandler : ConnectionHandler
     {
-        private readonly TaskCompletionSource<object> _startedTcs = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _startedTcs = new();
 
-        private readonly LinkedList<TaskCompletionSource<string>> _content = new LinkedList<TaskCompletionSource<string>>();
+        private readonly LinkedList<TaskCompletionSource<string>> _content = new();
 
         public Task Started => _startedTcs.Task;
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceContextFacts.cs
@@ -9,10 +9,12 @@ using System.Net;
 using System.Reflection;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Primitives;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -211,7 +213,7 @@ public class ServiceContextFacts
             },
             new object[]
             {
-                new CultureInfo("zh-CN") { DateTimeFormat = { ShortDatePattern = "MM#dd#yyyy" } }, 
+                new CultureInfo("zh-CN") { DateTimeFormat = { ShortDatePattern = "MM#dd#yyyy" } },
                 new CultureInfo("fr-CA") { DateTimeFormat = { ShortDatePattern = "yyyy|MM|dd" } }
             }
     };
@@ -220,12 +222,11 @@ public class ServiceContextFacts
     [MemberData(nameof(TestCultures))]
     public async Task ServiceConnectionContextCultureManagerTest(CultureInfo expectCulture, CultureInfo expectUICulture)
     {
-        var (originalCulture, originalUICulture) = (CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+        var (_, _) = (CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
 
         var timeoutSeconds = 1;
         var cultureManager = new DefaultCultureFeatureManager(timeoutSeconds);
-
-        var requestIdProvider = new DefaultConnectionRequestIdProvider();
+        _ = new DefaultConnectionRequestIdProvider();
         var requestId1 = "1";
         var requestId2 = "2";
         var expectFeature = new RequestCultureFeature(new RequestCulture(expectCulture, expectUICulture), null);
@@ -236,7 +237,7 @@ public class ServiceContextFacts
         Assert.True(cultureManager.TryRemoveCultureFeature(requestId1, out var actualFeature));
         Assert.Equal(expectFeature, actualFeature);
 
-        await Task.Delay(timeoutSeconds * 1000 + 100);
+        await Task.Delay((timeoutSeconds * 1000) + 100);
         cultureManager.Cleanup();
         Assert.False(cultureManager.TryRemoveCultureFeature(requestId2, out var _));
     }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceEndpointProviderFacts.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -31,16 +33,16 @@ public class ServiceEndpointProviderFacts
 
     private static readonly ServiceEndpointProvider[] EndpointProviderArray =
     {
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithoutVersion), _optionsWithoutAppName),
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithPreviewVersion), _optionsWithoutAppName),
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithV1Version), _optionsWithoutAppName)
+        new(new ServiceEndpoint(ConnectionStringWithoutVersion), _optionsWithoutAppName),
+        new(new ServiceEndpoint(ConnectionStringWithPreviewVersion), _optionsWithoutAppName),
+        new(new ServiceEndpoint(ConnectionStringWithV1Version), _optionsWithoutAppName)
     };
 
     private static readonly ServiceEndpointProvider[] EndpointProviderArrayWithPrefix =
     {
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithoutVersion), _optionsWithAppName),
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithPreviewVersion), _optionsWithAppName),
-        new ServiceEndpointProvider(new ServiceEndpoint(ConnectionStringWithV1Version), _optionsWithAppName)
+        new(new ServiceEndpoint(ConnectionStringWithoutVersion), _optionsWithAppName),
+        new(new ServiceEndpoint(ConnectionStringWithPreviewVersion), _optionsWithAppName),
+        new(new ServiceEndpoint(ConnectionStringWithV1Version), _optionsWithAppName)
     };
 
     private static readonly (string path, string queryString, string expectedQuery)[] PathAndQueryArray =
@@ -172,7 +174,7 @@ public class ServiceEndpointProviderFacts
     [MemberData(nameof(DefaultEndpointProviders))]
     internal async Task GenerateClientAccessToken(IServiceEndpointProvider provider)
     {
-        var requestId = Guid.NewGuid().ToString();
+        _ = Guid.NewGuid().ToString();
         var tokenString = await provider.GenerateClientAccessTokenAsync(HubName);
         var token = JwtTokenHelper.JwtHandler.ReadJwtToken(tokenString);
 

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -14,6 +15,7 @@ using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -14,6 +15,7 @@ using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 using SignalRProtocol = Microsoft.AspNetCore.SignalR.Protocol;
@@ -26,7 +28,7 @@ public class ServiceLifetimeManagerFacts
 
     internal static readonly ILogger<ServiceLifetimeManager<TestHub>> Logger = NullLogger<ServiceLifetimeManager<TestHub>>.Instance;
 
-    internal static readonly AzureSignalRMarkerService Marker = new AzureSignalRMarkerService();
+    internal static readonly AzureSignalRMarkerService Marker = new();
 
     protected static readonly IHubProtocolResolver HubProtocolResolver =
         new DefaultHubProtocolResolver(new SignalRProtocol.IHubProtocol[]
@@ -42,13 +44,13 @@ public class ServiceLifetimeManagerFacts
 
     private const string TestMethod = "TestMethod";
 
-    private static readonly List<string> TestUsers = new List<string> { "user1", "user2" };
+    private static readonly List<string> TestUsers = new() { "user1", "user2" };
 
-    private static readonly List<string> TestGroups = new List<string> { "group1", "group2" };
+    private static readonly List<string> TestGroups = new() { "group1", "group2" };
 
     private static readonly object[] TestArgs = { "TestArgs" };
 
-    private static readonly List<string> TestConnectionIds = new List<string> { "connection1", "connection2" };
+    private static readonly List<string> TestConnectionIds = new() { "connection1", "connection2" };
 
     public ServiceLifetimeManagerFacts()
     {
@@ -400,7 +402,10 @@ public class ServiceLifetimeManagerFacts
 
         public int Version => throw new NotImplementedException();
 
-        public ReadOnlyMemory<byte> GetMessageBytes(SignalRProtocol.HubMessage message) => ""u8.ToArray();
+        public ReadOnlyMemory<byte> GetMessageBytes(SignalRProtocol.HubMessage message)
+        {
+            return ""u8.ToArray();
+        }
 
         public bool IsVersionSupported(int version)
         {

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFactsForNet70.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFactsForNet70.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.SignalR.Tests;
 
 public class ServiceLifetimeManagerFactsForNet70 : ServiceLifetimeManagerFacts
 {
-    private static readonly List<string> TestConnectionIds = new List<string> { "connection1", "connection2" };
+    private static readonly List<string> TestConnectionIds = new() { "connection1", "connection2" };
 
     [Theory]
     [InlineData("json", true)]
@@ -157,8 +158,10 @@ public class ServiceLifetimeManagerFactsForNet70 : ServiceLifetimeManagerFacts
 
     private static ClientConnectionContext GetClientConnectionContextWithConnection(string connectionId = null, string protocol = null)
     {
-        var connectMessage = new OpenConnectionMessage(connectionId, Array.Empty<Claim>());
-        connectMessage.Protocol = protocol;
+        var connectMessage = new OpenConnectionMessage(connectionId, Array.Empty<Claim>())
+        {
+            Protocol = protocol
+        };
         return new ClientConnectionContext(connectMessage);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceMessageTests.cs
@@ -9,8 +9,10 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Azure.Core;
 using Azure.Identity;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -20,8 +22,10 @@ using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 using Xunit.Abstractions;
+
 using SignalRProtocol = Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -29,7 +33,7 @@ namespace Microsoft.Azure.SignalR.Tests;
 public class ServiceMessageTests : VerifiableLoggedTest
 {
     private const string SigningKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    
+
     private const string DefaultAudience = "https://localhost";
 
     private const string LocalConnectionString = "endpoint=https://localhost;accessKey=" + SigningKey;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceOptionsSetupFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceOptionsSetupFacts.cs
@@ -3,7 +3,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.Extensions.Configuration;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests;
@@ -14,7 +16,7 @@ public class ServiceOptionsSetupFacts
 
     private static readonly string[] ConnectionStringKeys = new[] { Constants.Keys.ConnectionStringDefaultKey, Constants.Keys.ConnectionStringSecondaryKey };
 
-    private static readonly Dictionary<string, (string, EndpointType)> EndpointDict = new Dictionary<string, (string, EndpointType)>
+    private static readonly Dictionary<string, (string, EndpointType)> EndpointDict = new()
     {
         {"a",("a",EndpointType.Primary) },
         {"secondary",("secondary",EndpointType.Primary) },

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestClientConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestClientConnectionManager.cs
@@ -13,13 +13,13 @@ internal sealed class TestClientConnectionManager : IClientConnectionManager
 {
     public int CompleteIndex = -1;
 
-    private readonly ClientConnectionManager _ccm = new ClientConnectionManager();
+    private readonly ClientConnectionManager _ccm = new();
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<ClientConnectionContext>> _tcs =
-        new ConcurrentDictionary<string, TaskCompletionSource<ClientConnectionContext>>();
+        new();
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<ClientConnectionContext>> _tcsForRemoval
-        = new ConcurrentDictionary<string, TaskCompletionSource<ClientConnectionContext>>();
+        = new();
 
     private readonly StrongBox<int> _index;
 
@@ -52,7 +52,10 @@ internal sealed class TestClientConnectionManager : IClientConnectionManager
         return tcs.Task;
     }
 
-    public bool TryAddClientConnection(IClientConnection connection) => TryAddClientConnection(connection as ClientConnectionContext);
+    public bool TryAddClientConnection(IClientConnection connection)
+    {
+        return TryAddClientConnection(connection as ClientConnectionContext);
+    }
 
     public bool TryRemoveClientConnection(string connectionId, out IClientConnection connection)
     {

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestHubContext.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestHubContext.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
 using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.Azure.SignalR.Tests;

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestServiceConnectionContainer.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestServiceConnectionForCloseAsync.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestServiceConnectionForCloseAsync.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 

--- a/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestSimpleServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestClasses/TestSimpleServiceConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 

--- a/test/Microsoft.Azure.SignalR.Tests/TestConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestConnectionContext.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -18,7 +19,7 @@ internal sealed class TestConnectionContext : ConnectionContext
 
         var pipeOptions = new PipeOptions();
         var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
-        var proxyToApplication = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
+        _ = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
 
         Transport = pair.Transport;
         Application = pair.Application;

--- a/test/Microsoft.Azure.SignalR.Tests/TestHubs/ConnectedHub.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestHubs/ConnectedHub.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 

--- a/test/Microsoft.Azure.SignalR.Tests/TestHubs/SimpleHub.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestHubs/SimpleHub.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
 using System;
+using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 

--- a/test/Microsoft.Azure.SignalR.Tests/Utils.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Utils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Tests


### PR DESCRIPTION
This pull request includes several changes to improve code readability and maintainability in the `Microsoft.Azure.SignalR.Common.Tests` project. The changes primarily involve adding missing `using` statements, refactoring methods for better clarity, and updating license information.

### Code readability improvements:

* Added missing `using` statements in multiple test files to ensure all necessary namespaces are included. [[1]](diffhunk://#diff-2a13c7acf9525bd07c211695218a1ff4e15c1ea461281ee6a49f99a16fe47e54R6) [[2]](diffhunk://#diff-dec5458f590bba2f593ca169dfcc8d70c175138adcf24d871a32649223ffb6a1R10-R13) [[3]](diffhunk://#diff-45d73b3de2ea73e8d2fb5401eb8fa3b1a5b24bdeb42de8049499e707555d93dcR9) [[4]](diffhunk://#diff-ae15dac9d2ca0489bc2c5ceabcaa1f25f4a996711b7ff4001e8cdc5dd4b9a915R8-R10) [[5]](diffhunk://#diff-7f2c02110edf23669c4fe801830b9c0abbdf73f099b39971ae8ecb42367d0110R15-R18) [[6]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8R7-R10) [[7]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bR8-R15) [[8]](diffhunk://#diff-c8533fcfb0972eb2ae41d2ead84af9e8385d416048708ed0490cf31675e7a84bR8-R13) [[9]](diffhunk://#diff-bd29bac3be4c987ba8f69236456373a21bdb5b4cd10ab80745112f7039d2e6c1R5-R8) [[10]](diffhunk://#diff-0e7f287e894ed24239ea494e4f5a64568f38cd35e784eb4053a4965d23d7f9f0R6) [[11]](diffhunk://#diff-7d634646940b52853f1494dc2a8582de3e07c4ff77491040696c7595014d21a0R5) [[12]](diffhunk://#diff-6eab09be2a4bfdeda6a2a194cfa8216eed456c2914e0eb95a2941d2fdeb758a1R7-R10) [[13]](diffhunk://#diff-c4056e54539e766f54ca5b9257ba17ddcb7d6723602b5be72b0e17fa5e6f2270R9-R15) [[14]](diffhunk://#diff-93356fcc71f44eeecec157ed5947f2d4fe72e57ed523e378244ab47b1d08e47fR6-R12) [[15]](diffhunk://#diff-3b13ca2385679fa1b6be3c282fb7bf16bb2c253164e8a937c21604c473e690e8R7-R9)

### Method refactoring:

* Refactored `IEnumerator IEnumerable.GetEnumerator()` methods to use block syntax for better readability. [[1]](diffhunk://#diff-45d73b3de2ea73e8d2fb5401eb8fa3b1a5b24bdeb42de8049499e707555d93dcL107-R111) [[2]](diffhunk://#diff-ae15dac9d2ca0489bc2c5ceabcaa1f25f4a996711b7ff4001e8cdc5dd4b9a915L239-R244) [[3]](diffhunk://#diff-7f2c02110edf23669c4fe801830b9c0abbdf73f099b39971ae8ecb42367d0110L390-R395) [[4]](diffhunk://#diff-3b13ca2385679fa1b6be3c282fb7bf16bb2c253164e8a937c21604c473e690e8L388-R393)
* Refactored `CreatePingTimer` and `CreateCustomizedPingTimer` methods to use block syntax for clarity.
* Refactored `RunProbeTests` method to use local functions for `probeFunc` and `testFunc` for better structure. [[1]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L142-R144) [[2]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L155-R159) [[3]](diffhunk://#diff-8a770198aafdea6d5d0bbe0cd734e05f704aec1cd6206f04316a3e0e307eaeb8L169-R171)

### License information:

* Added missing license information to the top of `MicrosoftEntraApplicationTests.cs` file.

### Code simplification:

* Simplified object initialization in `ClaimsUtilityTests` and `ServiceEndpointFacts` by using target-typed `new` expressions. [[1]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bL59-R60) [[2]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bL77-R78) [[3]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bL90-R91) [[4]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bL105-R106) [[5]](diffhunk://#diff-65730fb33797c4c24be92ca22e8e08cbb9eb8a3cd62f1318a94ef6f2c2de246bL117-R118) [[6]](diffhunk://#diff-3b13ca2385679fa1b6be3c282fb7bf16bb2c253164e8a937c21604c473e690e8L84-R91)