### PR TITLE
add ICustomHeaderProvider for ConnectionFactory

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.SignalR.AspNet;
+
+#nullable enable
+
+internal class ConnectionFactory : ConnectionFactoryBase
+{
+    public ConnectionFactory(IServerNameProvider nameProvider, ILoggerFactory loggerFactory) : base(nameProvider, loggerFactory)
+    {
+    }
+
+    protected override void SetCustomHeaders(IDictionary<string, string> headers)
+    {
+        return;
+    }
+}

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -21,8 +20,6 @@ namespace Microsoft.Azure.SignalR.AspNet;
 internal partial class ServiceConnection : ServiceConnectionBase
 {
     private const string ReconnectMessage = "asrs:reconnect";
-
-    private static readonly Dictionary<string, string> CustomHeader = new() { { Constants.AsrsUserAgent, ProductInfo.GetProductInfo() } };
 
     private static readonly TimeSpan CloseApplicationTimeout = TimeSpan.FromSeconds(5);
 
@@ -81,8 +78,7 @@ internal partial class ServiceConnection : ServiceConnectionBase
 
     protected override Task<ConnectionContext> CreateConnection(string target = null)
     {
-        return _connectionFactory.ConnectAsync(HubEndpoint, TransferFormat.Binary, ConnectionId, target,
-            headers: CustomHeader);
+        return _connectionFactory.ConnectAsync(HubEndpoint, TransferFormat.Binary, ConnectionId, target);
     }
 
     protected override Task DisposeConnection(ConnectionContext connection)

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -10,141 +10,140 @@ using System.Security.Claims;
 
 using Microsoft.Owin;
 
-namespace Microsoft.Azure.SignalR.AspNet
+namespace Microsoft.Azure.SignalR.AspNet;
+
+/// <summary>
+/// Configurable options when using Azure SignalR Service.
+/// </summary>
+public class ServiceOptions : IServiceEndpointOptions
 {
-    /// <summary>
-    /// Configurable options when using Azure SignalR Service.
-    /// </summary>
-    public class ServiceOptions : IServiceEndpointOptions
+    public ServiceOptions()
     {
-        /// <summary>
-        /// Gets or sets the connection string of Azure SignalR Service instance.
-        /// </summary>
-        public string ConnectionString { get; set; }
-    
-        /// <summary>
-        /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service. Default value is 5. 
-        /// Usually keep it as the default value is enough. During runtime, the SDK might start new server connections for performance tuning or load balancing. 
-        /// When you have big number of clients, you can give it a larger number for better throughput.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Please use InitialHubServerConnectionCount instead.")]
-        public int ConnectionCount
+        var count = ConfigurationManager.ConnectionStrings.Count;
+        string connectionString = null;
+        var endpoints = new List<ServiceEndpoint>();
+        var connectionStringKeyPrefix = $"{Constants.Keys.ConnectionStringDefaultKey}:";
+        for (var i = 0; i < count; i++)
         {
-            get => InitialHubServerConnectionCount;
-            set => InitialHubServerConnectionCount = value;
+            var setting = ConfigurationManager.ConnectionStrings[i];
+
+            if (setting.Name == Constants.Keys.ConnectionStringDefaultKey)
+            {
+                connectionString = setting.ConnectionString;
+            }
+            else if (setting.Name.StartsWith(connectionStringKeyPrefix) && !string.IsNullOrEmpty(setting.ConnectionString))
+            {
+                endpoints.Add(new ServiceEndpoint(setting.Name, setting.ConnectionString));
+            }
         }
 
-        /// <summary>
-        /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service.
-        /// Default value is 5. 
-        /// Usually keep it as the default value is enough. When you have big number of clients, you can give it a larger number for better throughput.
-        /// During runtime, the SDK might start new server connections for performance tuning or load balancing. 
-        /// </summary>
-        public int InitialHubServerConnectionCount { get; set; } = 5;
-
-        /// <summary>
-        /// Specifies the max server connection count allowed per hub from SDK to Azure SignalR Service. 
-        /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
-        /// By default a new server connection starts whenever needed.
-        /// When the max allowed server connection count is configured, the SDK does not start new connections when server connection count reaches the limit.
-        /// </summary>
-        public int? MaxHubServerConnectionCount { get; set; }
-
-        /// <summary>
-        /// Gets applicationName, which will be used as a prefix to apply to each hub name
-        /// </summary>
-        internal string ApplicationName { get; set; }
-        string IServiceEndpointOptions.ApplicationName => ApplicationName;
-
-        /// <summary>
-        /// Gets or sets the func to generate claims from <see cref="IOwinContext" />.
-        /// The claims will be included in the auto-generated token for clients.
-        /// </summary>
-        public Func<IOwinContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
-
-        /// <summary>
-        /// Gets or sets the func to set diagnostic client filter from <see cref="IOwinContext" />.
-        /// The clients will be regarded as diagnostic client only if the function returns true.
-        /// </summary>
-        public Func<IOwinContext, bool> DiagnosticClientFilter { get; set; } = null;
-
-        /// <summary>
-        /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
-        /// Default value is one hour.
-        /// </summary>
-        public TimeSpan AccessTokenLifetime { get; set; } = Constants.Periods.DefaultAccessTokenLifetime;
-
-        /// <summary>
-        /// Gets or sets the access token generate algorithm, supports HmacSha256 or HmacSha512
-        /// Default value is HmacSha256
-        /// </summary>
-        public AccessTokenAlgorithm AccessTokenAlgorithm { get; set; } = AccessTokenAlgorithm.HS256;
-
-        /// <summary>
-        /// Customize the multiple endpoints used
-        /// </summary>
-        public ServiceEndpoint[] Endpoints { get; set; }
-
-        /// <summary>
-        /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
-        /// By default this mode is disabled
-        /// </summary>
-        public ServerStickyMode ServerStickyMode { get; set; }
-
-        /// <summary>
-        /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
-        /// </summary>
-        public IWebProxy Proxy { get; set; }
-
-        /// <summary>
-        /// Gets or sets the interval in seconds used by the Azure SignalR Service to timeout idle LongPolling connections
-        /// Default value is 5, limited to [1, 300].
-        /// </summary>
-        public int? MaxPollIntervalInSeconds { get; set; }
-
-        public ServiceOptions()
+        // Fallback to use AppSettings
+        if (string.IsNullOrEmpty(connectionString) && endpoints.Count == 0)
         {
-            var count = ConfigurationManager.ConnectionStrings.Count;
-            string connectionString = null;
-            var endpoints = new List<ServiceEndpoint>();
-            var connectionStringKeyPrefix = $"{Constants.Keys.ConnectionStringDefaultKey}:";
-            for (var i = 0; i < count; i++)
+            foreach (var key in ConfigurationManager.AppSettings.AllKeys)
             {
-                var setting = ConfigurationManager.ConnectionStrings[i];
-
-                if (setting.Name == Constants.Keys.ConnectionStringDefaultKey)
+                if (key == Constants.Keys.ConnectionStringDefaultKey)
                 {
-                    connectionString = setting.ConnectionString;
+                    connectionString = ConfigurationManager.AppSettings[key];
                 }
-                else if (setting.Name.StartsWith(connectionStringKeyPrefix) && !string.IsNullOrEmpty(setting.ConnectionString))
+                else if (key.StartsWith(connectionStringKeyPrefix))
                 {
-                    endpoints.Add(new ServiceEndpoint(setting.Name, setting.ConnectionString));
-                }
-            }
-
-            // Fallback to use AppSettings
-            if (string.IsNullOrEmpty(connectionString) && endpoints.Count == 0)
-            {
-                foreach (var key in ConfigurationManager.AppSettings.AllKeys)
-                {
-                    if (key == Constants.Keys.ConnectionStringDefaultKey)
+                    var value = ConfigurationManager.AppSettings[key];
+                    if (!string.IsNullOrEmpty(value))
                     {
-                        connectionString = ConfigurationManager.AppSettings[key];
-                    }
-                    else if (key.StartsWith(connectionStringKeyPrefix))
-                    {
-                        var value = ConfigurationManager.AppSettings[key];
-                        if (!string.IsNullOrEmpty(value))
-                        {
-                            endpoints.Add(new ServiceEndpoint(key, value));
-                        }
+                        endpoints.Add(new ServiceEndpoint(key, value));
                     }
                 }
             }
-
-            ConnectionString = connectionString;
-            Endpoints = endpoints.ToArray();
         }
+
+        ConnectionString = connectionString;
+        Endpoints = endpoints.ToArray();
     }
+
+    /// <summary>
+    /// Gets or sets the access token generate algorithm, supports HmacSha256 or HmacSha512
+    /// Default value is HmacSha256
+    /// </summary>
+    public AccessTokenAlgorithm AccessTokenAlgorithm { get; set; } = AccessTokenAlgorithm.HS256;
+
+    /// <summary>
+    /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
+    /// Default value is one hour.
+    /// </summary>
+    public TimeSpan AccessTokenLifetime { get; set; } = Constants.Periods.DefaultAccessTokenLifetime;
+
+    /// <summary>
+    /// Gets or sets the interval in seconds used by the Azure SignalR Service to timeout idle LongPolling connections
+    /// Default value is 5, limited to [1, 300].
+    /// </summary>
+    public int? MaxPollIntervalInSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
+    /// </summary>
+    public IWebProxy Proxy { get; set; }
+
+    /// <summary>
+    /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
+    /// By default this mode is disabled
+    /// </summary>
+    public ServerStickyMode ServerStickyMode { get; set; }
+
+    string IServiceEndpointOptions.ApplicationName => ApplicationName;
+
+    /// <summary>
+    /// Gets or sets the func to generate claims from <see cref="IOwinContext" />.
+    /// The claims will be included in the auto-generated token for clients.
+    /// </summary>
+    public Func<IOwinContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service. Default value is 5.
+    /// Usually keep it as the default value is enough. During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// When you have big number of clients, you can give it a larger number for better throughput.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Please use InitialHubServerConnectionCount instead.")]
+    public int ConnectionCount
+    {
+        get => InitialHubServerConnectionCount;
+        set => InitialHubServerConnectionCount = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the connection string of Azure SignalR Service instance.
+    /// </summary>
+    public string ConnectionString { get; set; }
+    /// <summary>
+    /// Gets or sets the func to set diagnostic client filter from <see cref="IOwinContext" />.
+    /// The clients will be regarded as diagnostic client only if the function returns true.
+    /// </summary>
+    public Func<IOwinContext, bool> DiagnosticClientFilter { get; set; } = null;
+
+    /// <summary>
+    /// Customize the multiple endpoints used
+    /// </summary>
+    public ServiceEndpoint[] Endpoints { get; set; }
+
+    /// <summary>
+    /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service.
+    /// Default value is 5.
+    /// Usually keep it as the default value is enough. When you have big number of clients, you can give it a larger number for better throughput.
+    /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// </summary>
+    public int InitialHubServerConnectionCount { get; set; } = 5;
+
+    /// <summary>
+    /// Specifies the max server connection count allowed per hub from SDK to Azure SignalR Service.
+    /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// By default a new server connection starts whenever needed.
+    /// When the max allowed server connection count is configured, the SDK does not start new connections when server connection count reaches the limit.
+    /// </summary>
+    public int? MaxHubServerConnectionCount { get; set; }
+
+    /// <summary>
+    /// Gets applicationName, which will be used as a prefix to apply to each hub name
+    /// </summary>
+    internal string ApplicationName { get; set; }
 }

--- a/src/Microsoft.Azure.SignalR.Common/Constants.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Constants.cs
@@ -131,11 +131,13 @@ internal static class Constants
 
     public static class Headers
     {
-        public const string AsrsHeaderPrefix = "X-ASRS-";
+        public const string AsrsHeaderPrefix = "ASRS-";
 
-        public const string AsrsServerId = AsrsHeaderPrefix + "Server-Id";
+        public const string AsrsInternalHeaderPrefix = "X-ASRS-";
 
-        public const string AsrsMessageTracingId = AsrsHeaderPrefix + "Message-Tracing-Id";
+        public const string AsrsServerId = AsrsInternalHeaderPrefix + "Server-Id";
+
+        public const string AsrsMessageTracingId = AsrsInternalHeaderPrefix + "Message-Tracing-Id";
 
         public const string MicrosoftErrorCode = "x-ms-error-code";
     }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IConnectionFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,8 +16,7 @@ internal interface IConnectionFactory
                                          TransferFormat transferFormat,
                                          string connectionId,
                                          string target,
-                                         CancellationToken cancellationToken = default,
-                                         IDictionary<string, string>? headers = null);
+                                         CancellationToken cancellationToken = default);
 
     // Current plan for IAsyncDisposable is that DisposeAsync will NOT take a CancellationToken
     // https://github.com/dotnet/csharplang/blob/195efa07806284d7b57550e7447dc8bd39c156bf/proposals/async-streams.md#iasyncdisposable

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,15 +15,16 @@ namespace Microsoft.Azure.SignalR;
 
 #nullable enable
 
-internal class ConnectionFactory : IConnectionFactory
+internal abstract class ConnectionFactoryBase : IConnectionFactory
 {
     private readonly ILoggerFactory _loggerFactory;
 
     private readonly string _serverId;
 
-    public ConnectionFactory(IServerNameProvider nameProvider, ILoggerFactory loggerFactory)
+    public ConnectionFactoryBase(IServerNameProvider nameProvider,
+                                 ILoggerFactory loggerFactory)
     {
-        _loggerFactory = loggerFactory != null ? new GracefulLoggerFactory(loggerFactory) : throw new ArgumentNullException(nameof(loggerFactory));
+        _loggerFactory = new GracefulLoggerFactory(loggerFactory);
         _serverId = nameProvider.GetName();
     }
 
@@ -30,28 +32,21 @@ internal class ConnectionFactory : IConnectionFactory
                                                       TransferFormat transferFormat,
                                                       string connectionId,
                                                       string target,
-                                                      CancellationToken cancellationToken = default,
-                                                      IDictionary<string, string>? headers = null)
+                                                      CancellationToken cancellationToken = default)
     {
         var provider = hubServiceEndpoint.Provider;
         var hubName = hubServiceEndpoint.Hub;
 
         var accessTokenProvider = provider.GetServerAccessTokenProvider(hubName, _serverId);
-
         var url = GetServiceUrl(provider, hubName, connectionId, target);
-
-        headers ??= new Dictionary<string, string>();
-        if (!string.IsNullOrEmpty(_serverId) && !headers.ContainsKey(Constants.Headers.AsrsServerId))
-        {
-            headers.Add(Constants.Headers.AsrsServerId, _serverId);
-        }
 
         var connectionOptions = new WebSocketConnectionOptions
         {
-            Headers = headers,
+            Headers = GetRequestHeaders(),
             Proxy = provider.Proxy,
         };
         var connection = new WebSocketConnectionContext(connectionOptions, _loggerFactory, accessTokenProvider);
+
         try
         {
             await connection.StartAsync(url, cancellationToken);
@@ -71,10 +66,42 @@ internal class ConnectionFactory : IConnectionFactory
         {
             return Task.CompletedTask;
         }
-
         return ((WebSocketConnectionContext)connection).StopAsync();
     }
 
+    internal IDictionary<string, string> GetRequestHeaders()
+    {
+        var headers = new Dictionary<string, string>();
+        SetCustomHeaders(headers);
+        CheckHeaders(headers, Constants.Headers.AsrsHeaderPrefix);
+        CheckHeaders(headers, Constants.Headers.AsrsInternalHeaderPrefix);
+        SetInternalHeaders(headers);
+        return headers;
+    }
+
+    internal virtual void SetInternalHeaders(IDictionary<string, string> headers)
+    {
+        // Fix issue: https://github.com/Azure/azure-signalr/issues/198
+        // .NET Framework has restriction about reserved string as the header name like "User-Agent"
+        headers[Constants.AsrsUserAgent] = ProductInfo.GetProductInfo();
+
+        if (!string.IsNullOrEmpty(_serverId) && !headers.ContainsKey(Constants.Headers.AsrsServerId))
+        {
+            headers.Add(Constants.Headers.AsrsServerId, _serverId);
+        }
+    }
+
+    protected abstract void SetCustomHeaders(IDictionary<string, string> headers);
+
+    private static void CheckHeaders(IDictionary<string, string> headers, string forbidPrefix)
+    {
+        var item = headers.Where(x => x.Key.StartsWith(forbidPrefix, StringComparison.InvariantCultureIgnoreCase));
+        if (item.Any())
+        {
+            var key = item.First().Key;
+            throw new ArgumentException($"Invalid header {key}, custom header cannot startwith '{forbidPrefix}'");
+        }
+    }
     private static Uri GetServiceUrl(IServiceEndpointProvider provider, string hubName, string connectionId, string target)
     {
         var baseUri = new UriBuilder(provider.GetServerEndpoint(hubName));
@@ -108,9 +135,9 @@ internal class ConnectionFactory : IConnectionFactory
             _inner = inner;
         }
 
-        public void Dispose()
+        public void AddProvider(ILoggerProvider provider)
         {
-            _inner.Dispose();
+            _inner.AddProvider(provider);
         }
 
         public ILogger CreateLogger(string categoryName)
@@ -119,11 +146,10 @@ internal class ConnectionFactory : IConnectionFactory
             return new GracefulLogger(innerLogger);
         }
 
-        public void AddProvider(ILoggerProvider provider)
+        public void Dispose()
         {
-            _inner.AddProvider(provider);
+            _inner.Dispose();
         }
-
         private sealed class GracefulLogger : ILogger
         {
             private readonly ILogger _inner;
@@ -131,6 +157,18 @@ internal class ConnectionFactory : IConnectionFactory
             public GracefulLogger(ILogger inner)
             {
                 _inner = inner;
+            }
+
+#nullable disable
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return _inner.BeginScope(state);
+            }
+#nullable enable
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return _inner.IsEnabled(logLevel);
             }
 
             /// <summary>
@@ -151,18 +189,6 @@ internal class ConnectionFactory : IConnectionFactory
                 }
                 _inner.Log(logLevel, eventId, state, null, formatter);
             }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return _inner.IsEnabled(logLevel);
-            }
-
-#nullable disable
-            public IDisposable BeginScope<TState>(TState state)
-            {
-                return _inner.BeginScope(state);
-            }
         }
-#nullable restore
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
@@ -71,7 +71,7 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
 
     internal IDictionary<string, string> GetRequestHeaders()
     {
-        var headers = new Dictionary<string, string>();
+        var headers = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         SetCustomHeaders(headers);
         CheckHeaders(headers, Constants.Headers.AsrsHeaderPrefix);
         CheckHeaders(headers, Constants.Headers.AsrsInternalHeaderPrefix);

--- a/src/Microsoft.Azure.SignalR.Management/ManagementConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ManagementConnectionFactory.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
-using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR.Management;
@@ -13,33 +11,24 @@ namespace Microsoft.Azure.SignalR.Management;
 #nullable enable
 
 internal class ManagementConnectionFactory(IOptions<ServiceManagerOptions> context,
-                                           ConnectionFactory connectionFactory) : IConnectionFactory
+                                           IServerNameProvider serverNameProvider,
+                                           ILoggerFactory loggerFactory)
+    : ConnectionFactoryBase(serverNameProvider, loggerFactory)
 {
     private readonly string? _productInfo = context.Value.ProductInfo;
 
-    public Task<ConnectionContext> ConnectAsync(HubServiceEndpoint endpoint,
-                                                TransferFormat transferFormat,
-                                                string connectionId,
-                                                string target,
-                                                CancellationToken cancellationToken = default,
-                                                IDictionary<string, string>? headers = null)
+    internal override void SetInternalHeaders(IDictionary<string, string> headers)
     {
+        base.SetInternalHeaders(headers);
+
         if (_productInfo != null)
         {
-            if (headers == null)
-            {
-                headers = new Dictionary<string, string> { { Constants.AsrsUserAgent, _productInfo } };
-            }
-            else
-            {
-                headers[Constants.AsrsUserAgent] = _productInfo;
-            }
+            headers[Constants.AsrsUserAgent] = _productInfo;
         }
-        return connectionFactory.ConnectAsync(endpoint, transferFormat, connectionId, target, cancellationToken, headers);
     }
 
-    public Task DisposeAsync(ConnectionContext connection)
+    protected override void SetCustomHeaders(IDictionary<string, string> headers)
     {
-        return connectionFactory.DisposeAsync(connection);
+        return;
     }
 }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ConnectionFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.SignalR;
+
+#nullable enable
+
+internal class ConnectionFactory : ConnectionFactoryBase
+{
+    private readonly IOptions<ServiceOptions> _options;
+
+    public ConnectionFactory(IServerNameProvider nameProvider,
+                             IOptions<ServiceOptions> options,
+                             ILoggerFactory loggerFactory) : base(nameProvider, loggerFactory)
+    {
+        _options = options;
+    }
+
+    protected override void SetCustomHeaders(IDictionary<string, string> headers)
+    {
+        _options.Value.CustomHeaderProvider?.Invoke(headers);
+    }
+}

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -27,10 +27,6 @@ internal partial class ServiceConnection : ServiceConnectionBase
     private const string ClientConnectionCountInHub = "#clientInHub";
 
     private const string ClientConnectionCountInServiceConnection = "#client";
-
-    // Fix issue: https://github.com/Azure/azure-signalr/issues/198
-    // .NET Framework has restriction about reserved string as the header name like "User-Agent"
-    private static readonly Dictionary<string, string> CustomHeader = new() { { Constants.AsrsUserAgent, ProductInfo.GetProductInfo() } };
 
     private readonly IConnectionFactory _connectionFactory;
 
@@ -135,7 +131,7 @@ internal partial class ServiceConnection : ServiceConnectionBase
 
     protected override Task<ConnectionContext> CreateConnection(string target = null)
     {
-        return _connectionFactory.ConnectAsync(HubEndpoint, TransferFormat.Binary, ConnectionId, target, headers: CustomHeader);
+        return _connectionFactory.ConnectAsync(HubEndpoint, TransferFormat.Binary, ConnectionId, target);
     }
 
     protected override Task DisposeConnection(ConnectionContext connection)

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -9,127 +9,134 @@ using System.Security.Claims;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
+
 #nullable enable
-namespace Microsoft.Azure.SignalR
+
+namespace Microsoft.Azure.SignalR;
+
+/// <summary>
+/// Configurable options when using Azure SignalR Service.
+/// </summary>
+public class ServiceOptions : IServiceEndpointOptions
 {
     /// <summary>
-    /// Configurable options when using Azure SignalR Service.
+    /// Gets or sets the access token generate algorithm, supports HmacSha256 or HmacSha512
+    /// Default value is HmacSha256
     /// </summary>
-    public class ServiceOptions : IServiceEndpointOptions
+    public AccessTokenAlgorithm AccessTokenAlgorithm { get; set; } = AccessTokenAlgorithm.HS256;
+
+    /// <summary>
+    /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
+    /// Default value is one hour.
+    /// </summary>
+    public TimeSpan AccessTokenLifetime { get; set; } = Constants.Periods.DefaultAccessTokenLifetime;
+
+    /// <summary>
+    /// Allow clients enable stateful reconnects for all hubs.
+    /// By default is disabled.
+    /// It can also configurate <see cref="HttpConnectionDispatcherOptions"/> by hub in net 8.
+    /// Enable stateful reconnection in client side:
+    /// * Make sure client sdk is net8 or later.
+    /// * Enable stateful reconnect in client side, e.g.: <code>builder.withStatefulReconnect()</code>
+    /// </summary>
+    public bool? AllowStatefulReconnects { get; set; }
+
+    /// <summary>
+    /// Gets applicationName, which will be used as a prefix to apply to each hub name.
+    /// Should be prefixed with alphabetic characters and only contain alpha-numeric characters or underscore.
+    /// </summary>
+    public string? ApplicationName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the func to generate claims from <see cref="HttpContext" />.
+    /// The claims will be included in the auto-generated token for clients.
+    /// </summary>
+    public Func<HttpContext, IEnumerable<Claim>>? ClaimsProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service. Default value is 5.
+    /// Usually keep it as the default value is enough. During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// When you have big number of clients, you can give it a larger number for better throughput.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Please use InitialHubServerConnectionCount instead.")]
+    public int ConnectionCount
     {
-        /// <summary>
-        /// Gets or sets the connection string of Azure SignalR Service instance.
-        /// </summary>
-        public string? ConnectionString { get; set; }
-
-        /// <summary>
-        /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service. Default value is 5. 
-        /// Usually keep it as the default value is enough. During runtime, the SDK might start new server connections for performance tuning or load balancing. 
-        /// When you have big number of clients, you can give it a larger number for better throughput.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Please use InitialHubServerConnectionCount instead.")]
-        public int ConnectionCount
-        {
-            get => InitialHubServerConnectionCount;
-            set => InitialHubServerConnectionCount = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service.
-        /// Default value is 5. 
-        /// Usually keep it as the default value is enough. When you have big number of clients, you can give it a larger number for better throughput.
-        /// During runtime, the SDK might start new server connections for performance tuning or load balancing. 
-        /// </summary>
-        public int InitialHubServerConnectionCount { get; set; } = 5;
-
-        /// <summary>
-        /// Specifies the max server connection count allowed per hub from SDK to Azure SignalR Service. 
-        /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
-        /// By default a new server connection starts whenever needed.
-        /// When the max allowed server connection count is configured, the SDK does not start new connections when server connection count reaches the limit.
-        /// </summary>
-        public int? MaxHubServerConnectionCount { get; set; }
-
-        /// <summary>
-        /// Gets applicationName, which will be used as a prefix to apply to each hub name. 
-        /// Should be prefixed with alphabetic characters and only contain alpha-numeric characters or underscore.
-        /// </summary>
-        public string? ApplicationName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the func to generate claims from <see cref="HttpContext" />.
-        /// The claims will be included in the auto-generated token for clients.
-        /// </summary>
-        public Func<HttpContext, IEnumerable<Claim>>? ClaimsProvider { get; set; }
-
-        /// <summary>
-        /// Gets or sets the func to set diagnostic client filter from <see cref="HttpContext" />.
-        /// The clients will be regarded as diagnostic client only if the function returns true.
-        /// </summary>
-        public Func<HttpContext, bool>? DiagnosticClientFilter { get; set; }
-
-        /// <summary>
-        /// Gets or sets the lifetime of auto-generated access token, which will be used to authenticate with Azure SignalR Service.
-        /// Default value is one hour.
-        /// </summary>
-        public TimeSpan AccessTokenLifetime { get; set; } = Constants.Periods.DefaultAccessTokenLifetime;
-
-        /// <summary>
-        /// Gets or sets the access token generate algorithm, supports HmacSha256 or HmacSha512
-        /// Default value is HmacSha256
-        /// </summary>
-        public AccessTokenAlgorithm AccessTokenAlgorithm { get; set; } = AccessTokenAlgorithm.HS256;
-
-        /// <summary>
-        /// Gets or sets list of endpoints
-        /// </summary>
-        public ServiceEndpoint[]? Endpoints { get; set; }
-
-        /// <summary>
-        /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
-        /// By default it is disabled
-        /// </summary>
-        public ServerStickyMode ServerStickyMode { get; set; } = ServerStickyMode.Disabled;
-
-        /// <summary>
-        /// Specifies if the client-connection assigned to this server can be migrated to another server.
-        /// Default value is 0.
-        /// 1: Only migrate client-connection if server was shutdown gracefully.
-        /// 2: Migrate client-connection even if server-connection was accidentally dropped. (Potential data losses)
-        /// </summary>
-        public GracefulShutdownOptions GracefulShutdown { get; set; } = new GracefulShutdownOptions();
-
-        /// <summary>
-        /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
-        /// </summary>
-        public IWebProxy? Proxy { get; set; }
-
-        /// <summary>
-        /// Gets or sets timeout waiting when scale multiple Azure SignalR Service endpoints.
-        /// Default value is 5 minutes
-        /// </summary>
-        public TimeSpan ServiceScaleTimeout { get; set; } = Constants.Periods.DefaultScaleTimeout;
-
-        /// <summary>
-        /// Gets or sets the interval in seconds used by the Azure SignalR Service to timeout idle LongPolling connections.
-        /// Default value is 5, limited to [1, 300].
-        /// </summary>
-        public int? MaxPollIntervalInSeconds { get; set; }
-
-        /// <summary>
-        /// Gets or sets a function which accepts <see cref="HttpContext"/> and returns a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the service should use to receive HTTP requests.
-        /// </summary>
-        public Func<HttpContext, HttpTransportType>? TransportTypeDetector { get; set; }
-
-        /// <summary>
-        /// Allow clients enable stateful reconnects for all hubs.
-        /// By default is disabled.
-        /// It can also configurate <see cref="HttpConnectionDispatcherOptions"/> by hub in net 8.
-        /// Enable stateful reconnection in client side:
-        /// * Make sure client sdk is net8 or later.
-        /// * Enable stateful reconnect in client side, e.g.: <code>builder.withStatefulReconnect()</code>
-        /// </summary>
-        public bool? AllowStatefulReconnects { get; set; }
+        get => InitialHubServerConnectionCount;
+        set => InitialHubServerConnectionCount = value;
     }
+
+    /// <summary>
+    /// Gets or sets the connection string of Azure SignalR Service instance.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the func to generate custom headers.
+    /// The headers key should not startwith "asrs-" or "x-asrs", as those are Azure SignalR Service SDK preserved headers and cannot be overwritten.
+    /// </summary>
+    public Action<IDictionary<string, string>>? CustomHeaderProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the func to set diagnostic client filter from <see cref="HttpContext" />.
+    /// The clients will be regarded as diagnostic client only if the function returns true.
+    /// </summary>
+    public Func<HttpContext, bool>? DiagnosticClientFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets list of endpoints
+    /// </summary>
+    public ServiceEndpoint[]? Endpoints { get; set; }
+
+    /// <summary>
+    /// Specifies if the client-connection assigned to this server can be migrated to another server.
+    /// Default value is 0.
+    /// 1: Only migrate client-connection if server was shutdown gracefully.
+    /// 2: Migrate client-connection even if server-connection was accidentally dropped. (Potential data losses)
+    /// </summary>
+    public GracefulShutdownOptions GracefulShutdown { get; set; } = new GracefulShutdownOptions();
+
+    /// <summary>
+    /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service.
+    /// Default value is 5.
+    /// Usually keep it as the default value is enough. When you have big number of clients, you can give it a larger number for better throughput.
+    /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// </summary>
+    public int InitialHubServerConnectionCount { get; set; } = 5;
+
+    /// <summary>
+    /// Specifies the max server connection count allowed per hub from SDK to Azure SignalR Service.
+    /// During runtime, the SDK might start new server connections for performance tuning or load balancing.
+    /// By default a new server connection starts whenever needed.
+    /// When the max allowed server connection count is configured, the SDK does not start new connections when server connection count reaches the limit.
+    /// </summary>
+    public int? MaxHubServerConnectionCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interval in seconds used by the Azure SignalR Service to timeout idle LongPolling connections.
+    /// Default value is 5, limited to [1, 300].
+    /// </summary>
+    public int? MaxPollIntervalInSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
+    /// </summary>
+    public IWebProxy? Proxy { get; set; }
+
+    /// <summary>
+    /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
+    /// By default it is disabled
+    /// </summary>
+    public ServerStickyMode ServerStickyMode { get; set; } = ServerStickyMode.Disabled;
+
+    /// <summary>
+    /// Gets or sets timeout waiting when scale multiple Azure SignalR Service endpoints.
+    /// Default value is 5 minutes
+    /// </summary>
+    public TimeSpan ServiceScaleTimeout { get; set; } = Constants.Periods.DefaultScaleTimeout;
+
+    /// <summary>
+    /// Gets or sets a function which accepts <see cref="HttpContext"/> and returns a bitmask combining one or more <see cref="HttpTransportType"/> values that specify what transports the service should use to receive HTTP requests.
+    /// </summary>
+    public Func<HttpContext, HttpTransportType>? TransportTypeDetector { get; set; }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
@@ -31,7 +31,6 @@ internal sealed class TestConnectionContext : ConnectionContext
 
         var pipeOptions = new PipeOptions();
         var pair = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
-        _ = DuplexPipe.CreateConnectionPair(pipeOptions, pipeOptions);
 
         Transport = pair.Transport;
         Application = pair.Application;

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,8 +18,7 @@ internal sealed class TestConnectionFactory : IConnectionFactory
                                                 TransferFormat transferFormat,
                                                 string connectionId,
                                                 string target,
-                                                CancellationToken cancellationToken = default,
-                                                IDictionary<string, string>? headers = null)
+                                                CancellationToken cancellationToken = default)
     {
         var connection = new TestConnectionContext();
 

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionContextFactory.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionContextFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,18 +13,15 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
 
 internal class MockServiceConnectionContextFactory(IMockService mockService) : IConnectionFactory
 {
-    public Task<ConnectionContext> ConnectAsync(
-        HubServiceEndpoint endpoint,
-        TransferFormat transferFormat,
-        string connectionId,
-        string target,
-        CancellationToken cancellationToken = default,
-        IDictionary<string, string>? headers = null)
+    public Task<ConnectionContext> ConnectAsync(HubServiceEndpoint endpoint,
+                                                TransferFormat transferFormat,
+                                                string connectionId,
+                                                string target,
+                                                CancellationToken cancellationToken = default)
     {
         // ConnectAsync merely means establish a physical connection.
         // In our case this means connect the pipes and start the message processing loops
         ConnectionContext c = new MockServiceConnectionContext(mockService, endpoint, target, connectionId);
-
         return Task.FromResult(c);
     }
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ManagementConnectionFactoryTests.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ManagementConnectionFactoryTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Management.Tests;
+
+#nullable enable
+
+public class ManagementConnectionFactoryTests
+{
+    private const string OptionsAsrsUserAgent = $"Microsoft.Azure.SignalR.Management.123456";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TestGetRequestHeaders(bool setManagementProductInfo)
+    {
+        var nameProvider = new DefaultServerNameProvider();
+
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        var options = Options.Create(new ServiceManagerOptions());
+        if (setManagementProductInfo)
+        {
+            options.Value.ProductInfo = OptionsAsrsUserAgent;
+        }
+
+        var factory = new ManagementConnectionFactory(options, nameProvider, loggerFactory);
+
+        var headers = factory.GetRequestHeaders();
+        Assert.True(headers.TryGetValue(Constants.AsrsUserAgent, out var productInfo));
+
+        Assert.True(headers.TryGetValue(Constants.Headers.AsrsServerId, out var serverId));
+        Assert.Equal(nameProvider.GetName(), serverId);
+
+        if (setManagementProductInfo)
+        {
+            Assert.StartsWith("Microsoft.Azure.SignalR.Management", productInfo);
+        }
+        else
+        {
+            Assert.StartsWith("Microsoft.Azure.SignalR.Common", productInfo);
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ConnectionFactoryTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ConnectionFactoryTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
+
+public class ConnectionFactoryTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("foo", "bar")]
+    public void TestSetCustomHeaders(string? key, string? val)
+    {
+        var nameProvider = new DefaultServerNameProvider();
+
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        var options = Options.Create(new ServiceOptions());
+
+        if (key != null && val != null)
+        {
+            options.Value.CustomHeaderProvider = headers =>
+            {
+                headers.Add(key, val);
+            };
+        }
+
+        var factory = new ConnectionFactory(nameProvider, options, loggerFactory);
+
+        var headers = factory.GetRequestHeaders();
+        Assert.True(headers.TryGetValue(Constants.AsrsUserAgent, out var productInfo));
+        Assert.StartsWith("Microsoft.Azure.SignalR.Common", productInfo);
+
+        Assert.True(headers.TryGetValue(Constants.Headers.AsrsServerId, out var serverId));
+        Assert.Equal(nameProvider.GetName(), serverId);
+
+        if (key != null && val != null)
+        {
+            Assert.True(headers.TryGetValue(key, out var actualVal));
+            Assert.Equal(val, actualVal);
+        }
+    }
+
+    [Theory]
+    [InlineData(Constants.AsrsUserAgent, "bar")]
+    [InlineData(Constants.Headers.AsrsServerId, "bar")]
+    [InlineData("asrs-x", "bar")]
+    [InlineData("x-asrs-foo", "bar")]
+    public void TestSetCustomHeadersThrows(string key, string val)
+    {
+        var nameProvider = new DefaultServerNameProvider();
+
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        var options = Options.Create(new ServiceOptions());
+
+        options.Value.CustomHeaderProvider = headers =>
+        {
+            headers.Add(key, val);
+        };
+
+        var factory = new ConnectionFactory(nameProvider, options, loggerFactory);
+
+        var exception = Assert.Throws<ArgumentException>(factory.GetRequestHeaders);
+        Assert.Contains(key, exception.Message!);
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnectionFactory.cs
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Azure.SignalR.Protocol;
 
-#nullable enable
-
 namespace Microsoft.Azure.SignalR.Tests;
+
+#nullable enable
 
 internal class TestConnectionFactory : IConnectionFactory
 {
@@ -37,8 +37,7 @@ internal class TestConnectionFactory : IConnectionFactory
                                                       TransferFormat transferFormat,
                                                       string connectionId,
                                                       string target,
-                                                      CancellationToken cancellationToken = default,
-                                                      IDictionary<string, string>? headers = null)
+                                                      CancellationToken cancellationToken = default)
     {
         Times.Add(DateTime.Now);
 

--- a/test/Microsoft.Azure.SignalR.Tests/RunSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RunSignalRTests.cs
@@ -273,8 +273,7 @@ public class RunSignalRTests : VerifiableLoggedTest
                                                                 TransferFormat transferFormat,
                                                                 string connectionId,
                                                                 string target,
-                                                                CancellationToken cancellationToken,
-                                                                IDictionary<string, string>? headers)
+                                                                CancellationToken cancellationToken)
         {
             var connection = new ControlledServiceConnectionContext();
             _taskCompletionSource.TrySetResult(connection);


### PR DESCRIPTION
This pull request includes several changes to the `Microsoft.Azure.SignalR.AspNet` and `Microsoft.Azure.SignalR.Common` projects, focusing on refactoring, code cleanup, and improvements to the connection factory. The most important changes include the creation of a new `ConnectionFactoryBase` class, removal of unnecessary headers, and updates to the `ServiceOptions` class.

Refactoring and code cleanup:

* [`src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs`](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L17-R49): Renamed from `ConnectionFactory.cs` and refactored to be an abstract class with added methods for setting custom and internal headers. [[1]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L17-R49) [[2]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L74-R104) [[3]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L111-R140)
* [`src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs`](diffhunk://#diff-91373915111d886ad1b53503ac299a9acdb358665a0e19b48788f75b40984540R1-R22): Created a new `ConnectionFactory` class inheriting from `ConnectionFactoryBase`.

Removal of unnecessary headers:

* [`src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs`](diffhunk://#diff-82cf0998b54f4bfc3ea82e50a272f3988ddadd8b0c58b615e30a0fa263ce1d8eL25-L26): Removed the `CustomHeader` dictionary and its usage in `CreateConnection` method. [[1]](diffhunk://#diff-82cf0998b54f4bfc3ea82e50a272f3988ddadd8b0c58b615e30a0fa263ce1d8eL25-L26) [[2]](diffhunk://#diff-82cf0998b54f4bfc3ea82e50a272f3988ddadd8b0c58b615e30a0fa263ce1d8eL84-R81)
* [`src/Microsoft.Azure.SignalR.Common/Interfaces/IConnectionFactory.cs`](diffhunk://#diff-c7587fab725b08b9327da13877ce8ff925534e962d8eed5873aa1bd66f59803dL20-R19): Updated the `ConnectAsync` method signature to remove the `headers` parameter.

Updates to `ServiceOptions` class:

* [`src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs`](diffhunk://#diff-d73ea6b936314a543d79e9656154917d78fc921c36eeb105211dbe943388f9a3L13-L105): Reorganized and re-added properties with XML documentation comments for better clarity and maintainability. [[1]](diffhunk://#diff-d73ea6b936314a543d79e9656154917d78fc921c36eeb105211dbe943388f9a3L13-L105) [[2]](diffhunk://#diff-d73ea6b936314a543d79e9656154917d78fc921c36eeb105211dbe943388f9a3R63-R148)

Other changes:

* [`src/Microsoft.Azure.SignalR.Common/Constants.cs`](diffhunk://#diff-2eee4fe6eb3d702a5a8a5e3fec9fe770184ebba6c293fa6cbad7d0064a0dd89cL134-R140): Modified header constants to differentiate between internal and external headers.