### PR TITLE
nit: ConnectionFactory test classes

### DIFF
--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -8,7 +8,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Microsoft.AspNet.SignalR;
@@ -34,21 +33,25 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
-public class RunAzureSignalRTests : VerifiableLoggedTest
+public class RunAzureSignalRTests(ITestOutputHelper output) : VerifiableLoggedTest(output)
 {
-    private static readonly Version VersionSupportingApplicationNamePrefix = new(1, 0, 9);
-
     private const string ServiceUrl = "http://localhost:8086";
+
     private const string ConnectionString = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
+
     private const string ConnectionStringWithRedirect = "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;ClientEndpoint=http://redirect";
+
     private const string ConnectionString2 = "Endpoint=http://localhost2;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
+
     private const string ConnectionString3 = "Endpoint=http://localhost3;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
+
     private const string ConnectionString4 = "Endpoint=http://localhost4;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;";
+
     private const string AppName = "AzureSignalRTest";
 
-    public RunAzureSignalRTests(ITestOutputHelper output) : base(output)
-    {
-    }
+    private static readonly Version VersionSupportingApplicationNamePrefix = new(1, 0, 9);
+
+    private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
 
     [Fact]
     public void TestRunAzureSignalRWithDefaultOptions()
@@ -237,12 +240,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
         {
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
             using (WebApp.Start(ServiceUrl,
-                app => app.RunAzureSignalR(AppName, hubConfig, s => s.Endpoints = new[]
-                {
+                app => app.RunAzureSignalR(AppName, hubConfig, s => s.Endpoints =
+                [
                     new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
                     new ServiceEndpoint(ConnectionString3),
                     new ServiceEndpoint(ConnectionString4)
-                })))
+                ])))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
 
@@ -273,12 +276,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                 app => app.RunAzureSignalR(AppName, hubConfig, s =>
                 {
                     s.ConnectionString = customConnectionString;
-                    s.Endpoints = new[]
-                    {
+                    s.Endpoints =
+                    [
                         new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
                         new ServiceEndpoint(ConnectionString3),
                         new ServiceEndpoint(ConnectionString4)
-                    };
+                    ];
                 })))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
@@ -307,12 +310,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                     s =>
                     {
                         s.ConnectionString = ConnectionString;
-                        s.Endpoints = new[]
-                        {
+                        s.Endpoints =
+                        [
                             new ServiceEndpoint(ConnectionString2, EndpointType.Secondary),
                             new ServiceEndpoint(ConnectionString3),
                             new ServiceEndpoint(ConnectionString4)
-                        };
+                        ];
                     })))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
@@ -338,12 +341,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, hubConfig, options =>
             {
-                options.Endpoints = new ServiceEndpoint[]
-                {
+                options.Endpoints =
+                [
                     new(ConnectionString2, EndpointType.Secondary),
                     new(ConnectionString3),
                     new(ConnectionString4)
-                };
+                ];
             })))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
@@ -369,12 +372,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, hubConfig, options =>
             {
-                options.Endpoints = new ServiceEndpoint[]
-                {
+                options.Endpoints =
+                [
                     new(ConnectionString2, EndpointType.Secondary),
                     new(ConnectionString3),
                     new(ConnectionString4)
-                };
+                ];
             })))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
@@ -403,12 +406,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             hubConfig.Resolver.Register(typeof(IEndpointRouter), () => router);
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, hubConfig, options =>
             {
-                options.Endpoints = new ServiceEndpoint[]
-                {
+                options.Endpoints =
+                [
                     new(ConnectionString2, EndpointType.Secondary),
                     new(ConnectionString3, name: "chosen"),
                     new(ConnectionString4)
-                };
+                ];
             })))
             {
                 var options = hubConfig.Resolver.Resolve<IOptions<ServiceOptions>>();
@@ -466,12 +469,12 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
 
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, hubConfig, options =>
             {
-                options.Endpoints = new ServiceEndpoint[]
-                {
+                options.Endpoints =
+                [
                     new(ConnectionString2, EndpointType.Secondary, "es"),
                     new(ConnectionString3, name: "tt3"),
                     new(ConnectionString4, name: "tt4", type: EndpointType.Secondary),
-                };
+                ];
             })))
             {
                 var connection = hubConfig.Resolver.GetService(typeof(IServiceConnectionManager)) as ServiceConnectionManager;
@@ -629,10 +632,10 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
             {
                 options.ConnectionString = ConnectionString;
-                options.ClaimsProvider = context => new Claim[]
-                {
+                options.ClaimsProvider = context =>
+                [
                 new("user", "hello"),
-                };
+                ];
                 options.AccessTokenLifetime = TimeSpan.FromDays(1);
             })))
             {
@@ -670,7 +673,11 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     {
         using (StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         {
-            bool diagnosticClientFilter(IOwinContext context) => context.Request.Query["diag"] != null;
+            static bool diagnosticClientFilter(IOwinContext context)
+            {
+                return context.Request.Query["diag"] != null;
+            }
+
             var hubConfiguration = Utility.GetTestHubConfig(loggerFactory);
             hubConfiguration.EnableDetailedErrors = true;
             using (WebApp.Start(ServiceUrl, a => a.RunAzureSignalR(AppName, hubConfiguration, options =>
@@ -703,10 +710,10 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             {
                 options.ServerStickyMode = ServerStickyMode.Preferred;
                 options.ConnectionString = ConnectionString;
-                options.ClaimsProvider = context => new Claim[]
-                {
-                new("user", "hello"),
-                };
+                options.ClaimsProvider = context =>
+                [
+                    new("user", "hello"),
+                ];
                 options.AccessTokenLifetime = TimeSpan.FromDays(1);
             })))
             {
@@ -862,6 +869,7 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
     private sealed class TestLoggerProvider : ILoggerProvider
     {
         public List<string> Loggers { get; } = [];
+
         public void Dispose()
         {
         }
@@ -883,32 +891,19 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
         }
     }
 
-    private sealed class TestRequestIdProvider : IConnectionRequestIdProvider
+    private sealed class TestRequestIdProvider(string id) : IConnectionRequestIdProvider
     {
-        private readonly string _id;
-
-        public TestRequestIdProvider(string id)
-        {
-            _id = id;
-        }
-
         public string GetRequestId(string traceIdentifer = "ut")
         {
-            return _id;
+            return id;
         }
     }
 
-    private sealed class TestServerNameProvider : IServerNameProvider
+    private sealed class TestServerNameProvider(string serverName) : IServerNameProvider
     {
-        private readonly string _serverName;
-        public TestServerNameProvider(string serverName)
-        {
-            _serverName = serverName;
-        }
-
         public string GetName()
         {
-            return _serverName;
+            return serverName;
         }
     }
 
@@ -935,7 +930,6 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
                 ConfigurationManager.AppSettings[s.Key] = s.Value;
                 return new KeyValuePair<string, string>(s.Key, original);
             }).ToList();
-
         }
 
         public void Dispose()
@@ -963,8 +957,6 @@ public class RunAzureSignalRTests : VerifiableLoggedTest
             return "hello";
         }
     }
-
-    private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
 
     private sealed class ResponseMessage
     {

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs
@@ -8,11 +8,21 @@ using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 
-namespace Microsoft.Azure.SignalR.Tests.Common;
+namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 internal sealed class TestConnectionContext : ConnectionContext
 {
     private readonly IFeatureCollection _features;
+
+    public override string ConnectionId { get; set; }
+
+    public override IFeatureCollection Features => _features;
+
+    public override IDictionary<object, object> Items { get; set; }
+
+    public override IDuplexPipe Transport { get; set; }
+
+    public IDuplexPipe Application { get; set; }
 
     public TestConnectionContext()
     {
@@ -26,13 +36,4 @@ internal sealed class TestConnectionContext : ConnectionContext
         Transport = pair.Transport;
         Application = pair.Application;
     }
-
-    public override string ConnectionId { get; set; }
-
-    public override IFeatureCollection Features => _features;
-    public override IDictionary<object, object> Items { get; set; }
-
-    public override IDuplexPipe Transport { get; set; }
-
-    public IDuplexPipe Application { get; set; }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Connections;
 
-namespace Microsoft.Azure.SignalR.Tests.Common;
+namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 #nullable enable
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/AuthorizedChatHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/AuthorizedChatHub.cs
@@ -4,10 +4,9 @@
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[Authorize, HubName("authchat")]
+public class AuthorizedChatHub : Hub
 {
-    [Authorize, HubName("authchat")]
-    public class AuthorizedChatHub : Hub
-    {
-    }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ChatHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ChatHub.cs
@@ -7,74 +7,73 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[HubName("chat")]
+public class ChatHub : Hub
 {
-    [HubName("chat")]
-    public class ChatHub : Hub
+    public override Task OnConnected()
     {
-        public override Task OnConnected()
-        {
-            Clients.Group("note").echo("Connected");
-            return Task.CompletedTask;
-        }
+        Clients.Group("note").echo("Connected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnReconnected()
-        {
-            Clients.Group("note").echo("Reconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnReconnected()
+    {
+        Clients.Group("note").echo("Reconnected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnDisconnected(bool stopCalled)
-        {
-            Clients.Group("note").echo("Disconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnDisconnected(bool stopCalled)
+    {
+        Clients.Group("note").echo("Disconnected");
+        return Task.CompletedTask;
+    }
 
-        public void BroadcastMessage(string name, string message)
-        {
-            Clients.All.broadcastMessage(name, message);
-        }
+    public void BroadcastMessage(string name, string message)
+    {
+        Clients.All.broadcastMessage(name, message);
+    }
 
-        public void Echo(string name, string message)
-        {
-            Clients.Caller.echo(name, message + " (echo from server)");
-        }
+    public void Echo(string name, string message)
+    {
+        Clients.Caller.echo(name, message + " (echo from server)");
+    }
 
-        public async Task JoinGroup(string name, string groupName)
-        {
-            await Groups.Add(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
-        }
+    public async Task JoinGroup(string name, string groupName)
+    {
+        await Groups.Add(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+    }
 
-        public async Task LeaveGroup(string name, string groupName)
-        {
-            await Groups.Remove(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
-        }
+    public async Task LeaveGroup(string name, string groupName)
+    {
+        await Groups.Remove(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+    }
 
-        public void SendGroup(string name, string groupName, string message)
-        {
-            Clients.Group(groupName).echo(name, message);
-        }
+    public void SendGroup(string name, string groupName, string message)
+    {
+        Clients.Group(groupName).echo(name, message);
+    }
 
-        public void SendGroups(string name, IList<string> groups, string message)
-        {
-            Clients.Groups(groups).echo(name, message);
-        }
+    public void SendGroups(string name, IList<string> groups, string message)
+    {
+        Clients.Groups(groups).echo(name, message);
+    }
 
-        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
-        {
-            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
-        }
+    public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+    {
+        Clients.Groups([groupName], connectionIdExcept).echo(name, message);
+    }
 
-        public void SendUser(string name, string userId, string message)
-        {
-            Clients.User(userId).echo(name, message);
-        }
+    public void SendUser(string name, string userId, string message)
+    {
+        Clients.User(userId).echo(name, message);
+    }
 
-        public void SendUsers(string name, IList<string> userIds, string message)
-        {
-            Clients.Users(userIds).echo(name, message);
-        }
+    public void SendUsers(string name, IList<string> userIds, string message)
+    {
+        Clients.Users(userIds).echo(name, message);
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessConnectHub.cs
@@ -7,77 +7,76 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[HubName("EndlessConnect")]
+public class EndlessConnectHub : Hub
 {
-    [HubName("EndlessConnect")]
-    public class EndlessConnectHub : Hub
+    public override async Task OnConnected()
     {
-        public override async Task OnConnected()
+        Clients.Group("note").echo("Connected");
+        while (true)
         {
-            Clients.Group("note").echo("Connected");
-            while (true)
-            {
-                await Task.Delay(1000);
-            }
+            await Task.Delay(1000);
         }
+    }
 
-        public override Task OnReconnected()
-        {
-            Clients.Group("note").echo("Reconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnReconnected()
+    {
+        Clients.Group("note").echo("Reconnected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnDisconnected(bool stopCalled)
-        {
-            Clients.Group("note").echo("Disconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnDisconnected(bool stopCalled)
+    {
+        Clients.Group("note").echo("Disconnected");
+        return Task.CompletedTask;
+    }
 
-        public void BroadcastMessage(string name, string message)
-        {
-            Clients.All.broadcastMessage(name, message);
-        }
+    public void BroadcastMessage(string name, string message)
+    {
+        Clients.All.broadcastMessage(name, message);
+    }
 
-        public void Echo(string name, string message)
-        {
-            Clients.Caller.echo(name, message + " (echo from server)");
-        }
+    public void Echo(string name, string message)
+    {
+        Clients.Caller.echo(name, message + " (echo from server)");
+    }
 
-        public async Task JoinGroup(string name, string groupName)
-        {
-            await Groups.Add(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
-        }
+    public async Task JoinGroup(string name, string groupName)
+    {
+        await Groups.Add(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+    }
 
-        public async Task LeaveGroup(string name, string groupName)
-        {
-            await Groups.Remove(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
-        }
+    public async Task LeaveGroup(string name, string groupName)
+    {
+        await Groups.Remove(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+    }
 
-        public void SendGroup(string name, string groupName, string message)
-        {
-            Clients.Group(groupName).echo(name, message);
-        }
+    public void SendGroup(string name, string groupName, string message)
+    {
+        Clients.Group(groupName).echo(name, message);
+    }
 
-        public void SendGroups(string name, IList<string> groups, string message)
-        {
-            Clients.Groups(groups).echo(name, message);
-        }
+    public void SendGroups(string name, IList<string> groups, string message)
+    {
+        Clients.Groups(groups).echo(name, message);
+    }
 
-        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
-        {
-            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
-        }
+    public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+    {
+        Clients.Groups([groupName], connectionIdExcept).echo(name, message);
+    }
 
-        public void SendUser(string name, string userId, string message)
-        {
-            Clients.User(userId).echo(name, message);
-        }
+    public void SendUser(string name, string userId, string message)
+    {
+        Clients.User(userId).echo(name, message);
+    }
 
-        public void SendUsers(string name, IList<string> userIds, string message)
-        {
-            Clients.Users(userIds).echo(name, message);
-        }
+    public void SendUsers(string name, IList<string> userIds, string message)
+    {
+        Clients.Users(userIds).echo(name, message);
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/EndlessInvokeHub.cs
@@ -7,78 +7,77 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[HubName("EndlessInvoke")]
+public class EndlessInvokeHub : Hub
 {
-    [HubName("EndlessInvoke")]
-    public class EndlessInvokeHub : Hub
+    public override Task OnConnected()
     {
-        public override Task OnConnected()
-        {
-            Clients.Group("note").echo("Connected");
-            return Task.CompletedTask;
-        }
+        Clients.Group("note").echo("Connected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnReconnected()
-        {
-            Clients.Group("note").echo("Reconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnReconnected()
+    {
+        Clients.Group("note").echo("Reconnected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnDisconnected(bool stopCalled)
-        {
-            Clients.Group("note").echo("Disconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnDisconnected(bool stopCalled)
+    {
+        Clients.Group("note").echo("Disconnected");
+        return Task.CompletedTask;
+    }
 
-        public void BroadcastMessage(string name, string message)
-        {
-            Clients.All.broadcastMessage(name, message);
-        }
+    public void BroadcastMessage(string name, string message)
+    {
+        Clients.All.broadcastMessage(name, message);
+    }
 
-        public void Echo(string name, string message)
-        {
-            Clients.Caller.echo(name, message + " (echo from server)");
-        }
+    public void Echo(string name, string message)
+    {
+        Clients.Caller.echo(name, message + " (echo from server)");
+    }
 
-        public async Task JoinGroup(string name, string groupName)
+    public async Task JoinGroup(string name, string groupName)
+    {
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+        while (true)
         {
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
-            while (true)
-            {
-                await Task.Delay(1000);
-            }
+            await Task.Delay(1000);
         }
+    }
 
-        public async Task LeaveGroup(string name, string groupName)
-        {
-            await Groups.Remove(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
-        }
+    public async Task LeaveGroup(string name, string groupName)
+    {
+        await Groups.Remove(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+    }
 
-        public Task SendGroup(string name, string groupName, string message)
-        {
-            Clients.Group(groupName).echo(name, message);
-            return Task.CompletedTask;
-        }
+    public Task SendGroup(string name, string groupName, string message)
+    {
+        Clients.Group(groupName).echo(name, message);
+        return Task.CompletedTask;
+    }
 
-        public void SendGroups(string name, IList<string> groups, string message)
-        {
-            Clients.Groups(groups).echo(name, message);
-        }
+    public void SendGroups(string name, IList<string> groups, string message)
+    {
+        Clients.Groups(groups).echo(name, message);
+    }
 
-        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
-        {
-            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
-        }
+    public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+    {
+        Clients.Groups([groupName], connectionIdExcept).echo(name, message);
+    }
 
-        public void SendUser(string name, string userId, string message)
-        {
-            Clients.User(userId).echo(name, message);
-        }
+    public void SendUser(string name, string userId, string message)
+    {
+        Clients.User(userId).echo(name, message);
+    }
 
-        public void SendUsers(string name, IList<string> userIds, string message)
-        {
-            Clients.Users(userIds).echo(name, message);
-        }
+    public void SendUsers(string name, IList<string> userIds, string message)
+    {
+        Clients.Users(userIds).echo(name, message);
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorConnectHub.cs
@@ -8,73 +8,72 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[HubName("ErrorConnect")]
+public class ErrorConnectHub : Hub
 {
-    [HubName("ErrorConnect")]
-    public class ErrorConnectHub : Hub
+    public override Task OnConnected()
     {
-        public override Task OnConnected()
-        {
-            throw new InvalidOperationException("error connecting");
-        }
+        throw new InvalidOperationException("error connecting");
+    }
 
-        public override Task OnReconnected()
-        {
-            Clients.Group("note").echo("Reconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnReconnected()
+    {
+        Clients.Group("note").echo("Reconnected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnDisconnected(bool stopCalled)
-        {
-            Clients.Group("note").echo("Disconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnDisconnected(bool stopCalled)
+    {
+        Clients.Group("note").echo("Disconnected");
+        return Task.CompletedTask;
+    }
 
-        public void BroadcastMessage(string name, string message)
-        {
-            Clients.All.broadcastMessage(name, message);
-        }
+    public void BroadcastMessage(string name, string message)
+    {
+        Clients.All.broadcastMessage(name, message);
+    }
 
-        public void Echo(string name, string message)
-        {
-            Clients.Caller.echo(name, message + " (echo from server)");
-        }
+    public void Echo(string name, string message)
+    {
+        Clients.Caller.echo(name, message + " (echo from server)");
+    }
 
-        public async Task JoinGroup(string name, string groupName)
-        {
-            await Groups.Add(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
-        }
+    public async Task JoinGroup(string name, string groupName)
+    {
+        await Groups.Add(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+    }
 
-        public async Task LeaveGroup(string name, string groupName)
-        {
-            await Groups.Remove(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
-        }
+    public async Task LeaveGroup(string name, string groupName)
+    {
+        await Groups.Remove(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+    }
 
-        public void SendGroup(string name, string groupName, string message)
-        {
-            Clients.Group(groupName).echo(name, message);
-        }
+    public void SendGroup(string name, string groupName, string message)
+    {
+        Clients.Group(groupName).echo(name, message);
+    }
 
-        public void SendGroups(string name, IList<string> groups, string message)
-        {
-            Clients.Groups(groups).echo(name, message);
-        }
+    public void SendGroups(string name, IList<string> groups, string message)
+    {
+        Clients.Groups(groups).echo(name, message);
+    }
 
-        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
-        {
-            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
-        }
+    public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+    {
+        Clients.Groups([groupName], connectionIdExcept).echo(name, message);
+    }
 
-        public void SendUser(string name, string userId, string message)
-        {
-            Clients.User(userId).echo(name, message);
-        }
+    public void SendUser(string name, string userId, string message)
+    {
+        Clients.User(userId).echo(name, message);
+    }
 
-        public void SendUsers(string name, IList<string> userIds, string message)
-        {
-            Clients.Users(userIds).echo(name, message);
-        }
+    public void SendUsers(string name, IList<string> userIds, string message)
+    {
+        Clients.Users(userIds).echo(name, message);
     }
 }

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/TestHubs/ErrorDisconnectHub.cs
@@ -8,74 +8,73 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Hubs;
 
-namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs
+namespace Microsoft.Azure.SignalR.AspNet.Tests.TestHubs;
+
+[HubName("ErrorDisconnect")]
+public class ErrorDisconnectHub : Hub
 {
-    [HubName("ErrorDisconnect")]
-    public class ErrorDisconnectHub : Hub
+    public override Task OnConnected()
     {
-        public override Task OnConnected()
-        {
-            Clients.Group("note").echo("Connected");
-            return Task.CompletedTask;
-        }
+        Clients.Group("note").echo("Connected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnReconnected()
-        {
-            Clients.Group("note").echo("Reconnected");
-            return Task.CompletedTask;
-        }
+    public override Task OnReconnected()
+    {
+        Clients.Group("note").echo("Reconnected");
+        return Task.CompletedTask;
+    }
 
-        public override Task OnDisconnected(bool stopCalled)
-        {
-            Clients.Group("note").echo("Disconnected");
-            throw new InvalidOperationException("error disconnecting");
-        }
+    public override Task OnDisconnected(bool stopCalled)
+    {
+        Clients.Group("note").echo("Disconnected");
+        throw new InvalidOperationException("error disconnecting");
+    }
 
-        public void BroadcastMessage(string name, string message)
-        {
-            Clients.All.broadcastMessage(name, message);
-        }
+    public void BroadcastMessage(string name, string message)
+    {
+        Clients.All.broadcastMessage(name, message);
+    }
 
-        public void Echo(string name, string message)
-        {
-            Clients.Caller.echo(name, message + " (echo from server)");
-        }
+    public void Echo(string name, string message)
+    {
+        Clients.Caller.echo(name, message + " (echo from server)");
+    }
 
-        public async Task JoinGroup(string name, string groupName)
-        {
-            await Groups.Add(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
-        }
+    public async Task JoinGroup(string name, string groupName)
+    {
+        await Groups.Add(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} joined {groupName} with connectionId {Context.ConnectionId}");
+    }
 
-        public async Task LeaveGroup(string name, string groupName)
-        {
-            await Groups.Remove(Context.ConnectionId, groupName);
-            Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
-        }
+    public async Task LeaveGroup(string name, string groupName)
+    {
+        await Groups.Remove(Context.ConnectionId, groupName);
+        Clients.Group(groupName).echo("_SYSTEM_", $"{name} leaved {groupName}");
+    }
 
-        public void SendGroup(string name, string groupName, string message)
-        {
-            Clients.Group(groupName).echo(name, message);
-        }
+    public void SendGroup(string name, string groupName, string message)
+    {
+        Clients.Group(groupName).echo(name, message);
+    }
 
-        public void SendGroups(string name, IList<string> groups, string message)
-        {
-            Clients.Groups(groups).echo(name, message);
-        }
+    public void SendGroups(string name, IList<string> groups, string message)
+    {
+        Clients.Groups(groups).echo(name, message);
+    }
 
-        public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
-        {
-            Clients.Groups([groupName], connectionIdExcept).echo(name, message);
-        }
+    public void SendGroupExcept(string name, string groupName, string[] connectionIdExcept, string message)
+    {
+        Clients.Groups([groupName], connectionIdExcept).echo(name, message);
+    }
 
-        public void SendUser(string name, string userId, string message)
-        {
-            Clients.User(userId).echo(name, message);
-        }
+    public void SendUser(string name, string userId, string message)
+    {
+        Clients.User(userId).echo(name, message);
+    }
 
-        public void SendUsers(string name, IList<string> userIds, string message)
-        {
-            Clients.Users(userIds).echo(name, message);
-        }
+    public void SendUsers(string name, IList<string> userIds, string message)
+    {
+        Clients.Users(userIds).echo(name, message);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.SignalR.Common.Tests.ServiceConnections;
+
 public class MultiEndpointMessageWriterTests
 {
     [Theory]

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/HotReloadIntegrationTestStartup.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/HotReloadIntegrationTestStartup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Security.Claims;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR;
@@ -12,115 +13,112 @@ using Microsoft.Azure.SignalR.IntegrationTests.MockService;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+internal class HotReloadIntegrationTestStartup<TParams, THub>(IConfiguration configuration) : IStartup where THub : Hub
+    where TParams : IHotReloadIntegrationTestStartupParameters, new()
 {
-    internal class HotReloadIntegrationTestStartup<TParams, THub> : IStartup where THub : Hub
-        where TParams : IHotReloadIntegrationTestStartupParameters, new()
+    public const string ApplicationName = "AppName";
+
+    public static IConfigurationRoot s_config;
+
+    public static void ReloadConfig(int index)
     {
-        public const string ApplicationName = "AppName";
-        private readonly IConfiguration _configuration;
-        public HotReloadIntegrationTestStartup(IConfiguration configuration)
+        var parameters = new TParams();
+        foreach (var s in s_config.Providers)
         {
-            _configuration = configuration;
-        }
-
-        [Obsolete]
-        public void Configure(IApplicationBuilder app)
-        {
-            app.UseAzureSignalR(configure => { configure.MapHub<THub>($"/{nameof(THub)}"); });
-            app.UseMvc();
-        }
-
-        public static IConfigurationRoot s_config = null;
-
-        public static void ReloadConfig(int index)
-        {
-            var parameters = new TParams();
-            foreach (var s in s_config.Providers)
+            if (s is ReloadableMemoryConfigurationProvider prov)
             {
-                if (s is ReloadableMemoryConfigurationProvider prov)
+                prov.Clear();
+                prov.LoadNewData(parameters.Endpoints(index));
+            }
+        }
+
+        s_config.Reload();
+    }
+
+    [Obsolete]
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseAzureSignalR(configure => { configure.MapHub<THub>($"/{nameof(THub)}"); });
+        app.UseMvc();
+    }
+
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        var p = new TParams();
+        var applicationName = configuration[ApplicationName];
+        var config = new ConfigurationBuilder()
+            .Add(new ReloadableMemoryConfigurationSource { InitialData = p.Endpoints(0) })
+            .Build();
+
+        s_config = config;
+
+        services.AddSingleton<IConfiguration>(config);
+        services.AddMvc(option => option.EnableEndpointRouting = false);
+        services.AddSignalR(options =>
+        {
+            options.EnableDetailedErrors = true;
+        })
+            .AddAzureSignalR(o =>
+            {
+                o.InitialHubServerConnectionCount = p.ConnectionCount;
+                o.GracefulShutdown.Mode = p.ShutdownMode;
+                //todo: move to params
+                o.ServiceScaleTimeout = TimeSpan.FromSeconds(3);
+                o.ClaimsProvider = context => [new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"])];  // todo: migrate to TParams
+                o.ApplicationName = applicationName;
+            });
+
+        // Here we inject MockServiceHubDispatcher and use it as a gateway to the MockService side
+        services.AddSingleton<IMockService, ConnectionTrackingMockService>();
+        services.AddSingleton<IConnectionFactory, MockServiceConnectionContextFactory>();
+        services.Replace(ServiceDescriptor.Singleton(typeof(ServiceHubDispatcher<>), typeof(MockServiceHubDispatcher<>)));
+
+        return services.BuildServiceProvider();
+    }
+
+    // Custom in memory config provider capable of dynamically changing in memory config data
+    internal class ReloadableMemoryConfigurationProvider : ConfigurationProvider, IEnumerable<KeyValuePair<string, string>>
+    {
+        private readonly ReloadableMemoryConfigurationSource _source;
+
+        public ReloadableMemoryConfigurationProvider(ReloadableMemoryConfigurationSource source)
+        {
+            _source = source;
+
+            if (_source.InitialData != null)
+            {
+                foreach (var pair in _source.InitialData)
                 {
-                    prov.Clear();
-                    prov.LoadNewData(parameters.Endpoints(index));
+                    Data.Add(pair.Key, pair.Value);
                 }
             }
-
-            s_config.Reload();
         }
 
-        public IServiceProvider ConfigureServices(IServiceCollection services)
+        public void LoadNewData(IEnumerable<KeyValuePair<string, string>> newData)
         {
-            var p = new TParams();
-            var applicationName = _configuration[ApplicationName];
-            var config = new ConfigurationBuilder()
-                .Add(new ReloadableMemoryConfigurationSource { InitialData = p.Endpoints(0) })
-                .Build();
-
-            s_config = config;
-
-            services.AddSingleton<IConfiguration>(config);
-            services.AddMvc(option => option.EnableEndpointRouting = false);
-            services.AddSignalR(options =>
+            foreach (var kv in newData)
             {
-                options.EnableDetailedErrors = true;
-            })
-                .AddAzureSignalR(o =>
-                {
-                    o.InitialHubServerConnectionCount = p.ConnectionCount;
-                    o.GracefulShutdown.Mode = p.ShutdownMode;
-                    //todo: move to params
-                    o.ServiceScaleTimeout = TimeSpan.FromSeconds(3);
-                    o.ClaimsProvider = context => new[] { new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"]) };  // todo: migrate to TParams
-                    o.ApplicationName = applicationName;
-                });
-
-            // Here we inject MockServiceHubDispatcher and use it as a gateway to the MockService side
-            services.AddSingleton<IMockService, ConnectionTrackingMockService>();
-            services.AddSingleton<IConnectionFactory, MockServiceConnectionContextFactory>();
-            services.Replace(ServiceDescriptor.Singleton(typeof(ServiceHubDispatcher<>), typeof(MockServiceHubDispatcher<>)));
-
-            return services.BuildServiceProvider();
+                Data.Add(kv);
+            }
         }
 
-        // Custom in memory config provider capable of dynamically changing in memory config data
-        internal class ReloadableMemoryConfigurationProvider : ConfigurationProvider, IEnumerable<KeyValuePair<string, string>>
+        public void Clear() => Data.Clear();
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal class ReloadableMemoryConfigurationSource : IConfigurationSource
+    {
+        public IEnumerable<KeyValuePair<string, string>> InitialData { get; set; }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            private readonly ReloadableMemoryConfigurationSource _source;
-
-            public ReloadableMemoryConfigurationProvider(ReloadableMemoryConfigurationSource source)
-            {
-                _source = source;
-
-                if (_source.InitialData != null)
-                {
-                    foreach (KeyValuePair<string, string> pair in _source.InitialData)
-                    {
-                        Data.Add(pair.Key, pair.Value);
-                    }
-                }
-            }
-
-            public void LoadNewData(IEnumerable<KeyValuePair<string, string>> newData)
-            {
-                foreach (var kv in newData)
-                {
-                    Data.Add(kv);
-                }
-            }
-
-            public void Clear() => Data.Clear();
-            public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Data.GetEnumerator();
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        internal class ReloadableMemoryConfigurationSource : IConfigurationSource
-        {
-            public IEnumerable<KeyValuePair<string, string>> InitialData { get; set; }
-
-            public IConfigurationProvider Build(IConfigurationBuilder builder)
-            {
-                return new ReloadableMemoryConfigurationProvider(this);
-            }
+            return new ReloadableMemoryConfigurationProvider(this);
         }
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IHotReloadIntegrationTestStartupParameters.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IHotReloadIntegrationTestStartupParameters.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+// Specialized startup for hot reload config tests
+internal interface IHotReloadIntegrationTestStartupParameters : IIntegrationTestStartupParameters
 {
-    // Specialized startup for hot reload config tests
-    internal interface IHotReloadIntegrationTestStartupParameters : IIntegrationTestStartupParameters
-    {
-        public KeyValuePair<string, string>[] Endpoints(int versionIndex);
-        public int EndpointsCount { get; }
-    }
+    public KeyValuePair<string, string>[] Endpoints(int versionIndex);
+    public int EndpointsCount { get; }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IIntegrationTestStartupParameters.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IIntegrationTestStartupParameters.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+// The only reason for having this interface is to overcome the lack
+// of static properties support in generic type system
+internal interface IIntegrationTestStartupParameters
 {
-    // The only reason for having this interface is to overcome the lack
-    // of static properties support in generic type system
-    internal interface IIntegrationTestStartupParameters
-    {
-        public int ConnectionCount { get; }
-        public ServiceEndpoint[] ServiceEndpoints { get; }
-        public GracefulShutdownMode ShutdownMode { get; }
-    }
+    public int ConnectionCount { get; }
+
+    public ServiceEndpoint[] ServiceEndpoints { get; }
+
+    public GracefulShutdownMode ShutdownMode { get; }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IntegrationTestStartup.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/IntegrationTestStartup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Claims;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR;
@@ -11,54 +12,48 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+internal class IntegrationTestStartup<TParams, THub>(IConfiguration configuration) : IStartup
+    where TParams : IIntegrationTestStartupParameters, new()
+    where THub : Hub
 {
-    internal class IntegrationTestStartup<TParams, THub> : IStartup 
-        where TParams: IIntegrationTestStartupParameters, new()
-        where THub: Hub
+    public const string ApplicationName = "AppName";
+
+    public void Configure(IApplicationBuilder app)
     {
-        public const string ApplicationName = "AppName";
-        private readonly IConfiguration _configuration;
-        public IntegrationTestStartup(IConfiguration configuration)
+        app.UseRouting();
+        app.UseEndpoints(configure =>
         {
-            _configuration = configuration;
-        }
+            configure.MapHub<THub>($"/{nameof(THub)}");
+        });
+        app.UseMvc();
+    }
 
-        public void Configure(IApplicationBuilder app)
-        {
-            app.UseRouting();
-            app.UseEndpoints(configure =>
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        var applicationName = configuration[ApplicationName];
+        var p = new TParams();
+
+        services.AddMvc(option => option.EnableEndpointRouting = false);
+        services.AddSignalR(options =>
             {
-                configure.MapHub<THub>($"/{nameof(THub)}");
+                options.EnableDetailedErrors = true;
+            })
+            .AddAzureSignalR(o =>
+            {
+                o.InitialHubServerConnectionCount = p.ConnectionCount;
+                o.GracefulShutdown.Mode = p.ShutdownMode;
+                o.Endpoints = p.ServiceEndpoints;
+                o.ClaimsProvider = context => [new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"])];  // todo: migrate to TParams
+                o.ApplicationName = applicationName;
             });
-            app.UseMvc();
-        }
 
-        public IServiceProvider ConfigureServices(IServiceCollection services)
-        {
-            var applicationName = _configuration[ApplicationName];
-            var p = new TParams();
+        // Here we inject MockServiceHubDispatcher and use it as a gateway to the MockService side
+        services.AddSingleton<IMockService, ConnectionTrackingMockService>();
+        services.AddSingleton<IConnectionFactory, MockServiceConnectionContextFactory>();
+        services.Replace(ServiceDescriptor.Singleton(typeof(ServiceHubDispatcher<>), typeof(MockServiceHubDispatcher<>)));
 
-            services.AddMvc(option => option.EnableEndpointRouting = false);
-            services.AddSignalR(options =>
-                {
-                    options.EnableDetailedErrors = true;
-                })
-                .AddAzureSignalR(o =>
-                {
-                    o.InitialHubServerConnectionCount = p.ConnectionCount;
-                    o.GracefulShutdown.Mode = p.ShutdownMode;
-                    o.Endpoints = p.ServiceEndpoints;
-                    o.ClaimsProvider = context => new[] { new Claim(ClaimTypes.NameIdentifier, context.Request.Query["user"]) };  // todo: migrate to TParams
-                    o.ApplicationName = applicationName;
-                });
-
-            // Here we inject MockServiceHubDispatcher and use it as a gateway to the MockService side
-            services.AddSingleton<IMockService, ConnectionTrackingMockService>();
-            services.AddSingleton<IConnectionFactory, MockServiceConnectionContextFactory>();
-            services.Replace(ServiceDescriptor.Singleton(typeof(ServiceHubDispatcher<>), typeof(MockServiceHubDispatcher<>)));
-
-            return services.BuildServiceProvider();
-        }
+        return services.BuildServiceProvider();
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnection.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.SignalR.IntegrationTests.MockService;
 using Microsoft.Azure.SignalR.Protocol;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
 /// </summary>
 internal class MockServiceConnection : IServiceConnection
 {
-    private static int Number = 0;
+    private static int Number;
 
     private readonly IMockService _mockService;
 

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionContext.cs
@@ -5,48 +5,53 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Azure.SignalR.IntegrationTests.MockService;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+internal class MockServiceConnectionContext : ConnectionContext
 {
-    internal class MockServiceConnectionContext : ConnectionContext
+    private readonly IMockService _mockService;
+
+    public override string ConnectionId { get; set; }
+
+    public override IFeatureCollection Features { get; }
+
+    public override IDictionary<object, object> Items { get; set; }
+
+    public override IDuplexPipe Transport { get; set; }
+
+    public MockServiceSideConnection MyServiceSideConnection { get; private set; }
+
+    public MockServiceConnection MyMockServiceConnetion { get; set; }
+
+    public MockServiceConnectionContext(IMockService mockService, HubServiceEndpoint endpoint, string target, string id)
     {
-        public override string ConnectionId { get; set; }
-        public override IFeatureCollection Features { get; }
-        public override IDictionary<object, object> Items { get; set; }
-        public override IDuplexPipe Transport { get; set; }
+        ConnectionId = id;
+        Features = new FeatureCollection();
+        Items = new ConcurrentDictionary<object, object>();
 
-        private IMockService _mockService;
-        public MockServiceSideConnection MyServiceSideConnection { get; private set; }
-        public MockServiceConnection MyMockServiceConnetion { get; set; }
+        var duplexPipePair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
 
-        public MockServiceConnectionContext(IMockService mockService, HubServiceEndpoint endpoint, string target, string id)
-        {
-            ConnectionId = id;
-            Features = new FeatureCollection();
-            Items = new ConcurrentDictionary<object, object>();
+        // SDK's side uses Transport property to read/write to our mock service
+        Transport = duplexPipePair.Transport;
 
-            var duplexPipePair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
+        _mockService = mockService;
+        MyServiceSideConnection = _mockService.RegisterSDKConnectionContext(this, endpoint, target, duplexPipePair.Application);
+    }
 
-            // SDK's side uses Transport property to read/write to our mock service
-            Transport = duplexPipePair.Transport;
+    public override async ValueTask DisposeAsync()
+    {
+        Transport.Output.Complete();
+        Transport.Input.Complete();
+        Transport.Input.CancelPendingRead();
 
-            _mockService = mockService;
-            MyServiceSideConnection = _mockService.RegisterSDKConnectionContext(this, endpoint, target, duplexPipePair.Application);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            Transport.Output.Complete();
-            Transport.Input.Complete();
-            Transport.Input.CancelPendingRead();
-
-            // we don't have any receiving or sending loops
-            // so we await for the other end of the pipe to finish instead
-            await MyServiceSideConnection.ProcessIncoming;
-            _mockService.UnregisterMockServiceConnection(this);
-        }
+        // we don't have any receiving or sending loops
+        // so we await for the other end of the pipe to finish instead
+        await MyServiceSideConnection.ProcessIncoming;
+        _mockService.UnregisterMockServiceConnection(this);
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceConnectionFactory.cs
@@ -9,39 +9,32 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
 
-internal class MockServiceConnectionFactory : ServiceConnectionFactory
+internal class MockServiceConnectionFactory(
+    IMockService mockService,
+    IServiceProtocol serviceProtocol,
+    IClientConnectionManager clientConnectionManager,
+    IConnectionFactory connectionFactory,
+    ILoggerFactory loggerFactory,
+    ConnectionDelegate connectionDelegate,
+    IClientConnectionFactory clientConnectionFactory,
+    IClientInvocationManager clientInvocationManager,
+    IServerNameProvider nameProvider,
+    IHubProtocolResolver hubProtocolResolver) : ServiceConnectionFactory(
+        serviceProtocol,
+        clientConnectionManager,
+        connectionFactory,
+        loggerFactory,
+        connectionDelegate,
+        clientConnectionFactory,
+        nameProvider,
+        null,
+        clientInvocationManager,
+        hubProtocolResolver,
+        null)
 {
-    private IMockService _mockService;
-    public MockServiceConnectionFactory(
-        IMockService mockService,
-        IServiceProtocol serviceProtocol,
-        IClientConnectionManager clientConnectionManager,
-        IConnectionFactory connectionFactory,
-        ILoggerFactory loggerFactory,
-        ConnectionDelegate connectionDelegate,
-        IClientConnectionFactory clientConnectionFactory,
-        IClientInvocationManager clientInvocationManager,
-        IServerNameProvider nameProvider,
-        IHubProtocolResolver hubProtocolResolver)
-        : base(
-            serviceProtocol,
-            clientConnectionManager,
-            connectionFactory,
-            loggerFactory,
-            connectionDelegate,
-            clientConnectionFactory,
-            nameProvider,
-            null,
-            clientInvocationManager,
-            hubProtocolResolver,
-            null)
-    {
-        _mockService = mockService;
-    }
-
     public override IServiceConnection Create(HubServiceEndpoint endpoint, IServiceMessageHandler serviceMessageHandler, AckHandler ackHandler, ServiceConnectionType type)
     {
         var serviceConnection = base.Create(endpoint, serviceMessageHandler, ackHandler, type);
-        return new MockServiceConnection(_mockService, serviceConnection);
+        return new MockServiceConnection(mockService, serviceConnection);
     }
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceHubDispatcher.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceHubDispatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.IntegrationTests.MockService;
@@ -10,75 +11,48 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
+
+internal class MockServiceHubDispatcher<THub>(
+    IMockService mockService,
+    IServiceProtocol serviceProtocol,
+    IHubContext<THub> context,
+    IServiceConnectionManager<THub> serviceConnectionManager,
+    IClientConnectionManager clientConnectionManager,
+    IClientInvocationManager clientInvocationManager,
+    IServiceEndpointManager serviceEndpointManager,
+    IOptions<ServiceOptions> options,
+    ILoggerFactory loggerFactory,
+    IEndpointRouter router,
+    IServerNameProvider nameProvider,
+    ServerLifetimeManager serverLifetimeManager,
+    IClientConnectionFactory clientConnectionFactory,
+    IConnectionFactory connectionFactory,
+    IServiceProvider serviceProvider,
+    IHubProtocolResolver hubProtocolResolver) : ServiceHubDispatcher<THub>(
+        serviceProtocol,
+        context,
+        serviceConnectionManager,
+        clientConnectionManager,
+        serviceEndpointManager,
+        options,
+        loggerFactory,
+        router,
+        nameProvider,
+        serverLifetimeManager,
+        clientConnectionFactory,
+        clientInvocationManager,
+        null,
+        hubProtocolResolver,
+        connectionFactory,
+        serviceProvider,
+        null) where THub : Hub
 {
-    internal class MockServiceHubDispatcher<THub> : ServiceHubDispatcher<THub> 
-        where THub : Hub 
+    internal override ServiceConnectionFactory GetServiceConnectionFactory(ConnectionDelegate connectionDelegate)
     {
-        private ILoggerFactory _loggerFactory;
-        private IClientConnectionManager _clientConnectionManager;
-        private IServiceProtocol _serviceProtocol;
-        private IClientConnectionFactory _clientConnectionFactory;
-        private readonly IServiceProvider _serviceProvider;
-        private IClientInvocationManager _clientInvocationManager;
-        private IHubProtocolResolver _hubProtocolResolver;
-
-        public MockServiceHubDispatcher(
-            IMockService mockService,
-            IServiceProtocol serviceProtocol,
-            IHubContext<THub> context,
-            IServiceConnectionManager<THub> serviceConnectionManager,
-            IClientConnectionManager clientConnectionManager,
-            IClientInvocationManager clientInvocationManager,
-            IServiceEndpointManager serviceEndpointManager,
-            IOptions<ServiceOptions> options,
-            ILoggerFactory loggerFactory,
-            IEndpointRouter router,
-            IServerNameProvider nameProvider,
-            ServerLifetimeManager serverLifetimeManager,
-            IClientConnectionFactory clientConnectionFactory,
-            IConnectionFactory connectionFactory,
-            IServiceProvider serviceProvider,
-            IHubProtocolResolver hubProtocolResolver) : base(
-                serviceProtocol,
-                context,
-                serviceConnectionManager,
-                clientConnectionManager,
-                serviceEndpointManager,
-                options,
-                loggerFactory,
-                router,
-                nameProvider,
-                serverLifetimeManager,
-                clientConnectionFactory,
-                clientInvocationManager,
-                null,
-                hubProtocolResolver,
-                connectionFactory,
-                serviceProvider,
-                null)
-        {
-            MockService = mockService;
-
-            // just store copies of these locally to keep the base class' accessor modifiers intact
-            _loggerFactory = loggerFactory;
-            _clientConnectionManager = clientConnectionManager;
-            _serviceProtocol = serviceProtocol;
-            _clientConnectionFactory = clientConnectionFactory;
-            _serviceProvider = serviceProvider;
-            _clientInvocationManager = clientInvocationManager;
-            _hubProtocolResolver = hubProtocolResolver;
-        }
-
-        internal override ServiceConnectionFactory GetServiceConnectionFactory(ConnectionDelegate connectionDelegate)
-        {
-            return ActivatorUtilities.CreateInstance<MockServiceConnectionFactory>(_serviceProvider, connectionDelegate);
-        }
-
-        // this is the gateway for the tests to control the mock service side
-        public IMockService MockService { 
-            get; 
-            private set; 
-        }
+        return ActivatorUtilities.CreateInstance<MockServiceConnectionFactory>(serviceProvider, connectionDelegate);
     }
+
+    // this is the gateway for the tests to control the mock service side
+    public IMockService MockService { get; private set; } = mockService;
 }

--- a/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceSideConnectionEndpointComparer.cs
+++ b/test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/MockServiceSideConnectionEndpointComparer.cs
@@ -3,17 +3,17 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.Azure.SignalR.IntegrationTests.MockService;
 
-namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure
-{
-    internal class MockServiceSideConnectionEndpointComparer : IEqualityComparer<MockServiceSideConnection>
-    {
-        public bool Equals(MockServiceSideConnection x, MockServiceSideConnection y)
-        {
-            return x.Endpoint.Endpoint == y.Endpoint.Endpoint && x.Endpoint.EndpointType == y.Endpoint.EndpointType;
-        }
+namespace Microsoft.Azure.SignalR.IntegrationTests.Infrastructure;
 
-        public int GetHashCode([DisallowNull] MockServiceSideConnection obj) => obj.Endpoint.GetHashCode();
+internal class MockServiceSideConnectionEndpointComparer : IEqualityComparer<MockServiceSideConnection>
+{
+    public bool Equals(MockServiceSideConnection x, MockServiceSideConnection y)
+    {
+        return x.Endpoint.Endpoint == y.Endpoint.Endpoint && x.Endpoint.EndpointType == y.Endpoint.EndpointType;
     }
+
+    public int GetHashCode([DisallowNull] MockServiceSideConnection obj) => obj.Endpoint.GetHashCode();
 }

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnectionFactory.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestConnectionFactory.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Azure.SignalR.Tests;
 
 internal class TestConnectionFactory : IConnectionFactory
 {
-    private readonly Func<TestConnection, Task>? _connectCallback;
-
     public IList<TestConnection> Connections = new List<TestConnection>();
 
+    private readonly Func<TestConnection, Task>? _connectCallback;
+
     public List<DateTime> Times { get; } = new List<DateTime>();
+
+    public HandshakeRequestMessage? HandshakeRequest { get; set; }
 
     public TestConnectionFactory()
     {
@@ -30,8 +32,6 @@ internal class TestConnectionFactory : IConnectionFactory
     {
         _connectCallback = connectCallback;
     }
-
-    public HandshakeRequestMessage? HandshakeRequest { get; set; }
 
     public async Task<ConnectionContext> ConnectAsync(HubServiceEndpoint endpoint,
                                                       TransferFormat transferFormat,
@@ -68,11 +68,6 @@ internal class TestConnectionFactory : IConnectionFactory
         return Task.CompletedTask;
     }
 
-    private async Task HandshakeAsync(TestConnection connection)
-    {
-        await DoHandshakeAsync(connection);
-    }
-
     /// <summary>
     /// Allow sub-class to override the handshake behavior
     /// </summary>
@@ -88,5 +83,10 @@ internal class TestConnectionFactory : IConnectionFactory
     protected virtual Task AfterConnectedAsync(TestConnection connection)
     {
         return Task.CompletedTask;
+    }
+
+    private async Task HandshakeAsync(TestConnection connection)
+    {
+        await DoHandshakeAsync(connection);
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/NegotiateHandlerFacts.cs
@@ -28,746 +28,751 @@ using Moq;
 
 using Xunit;
 
-namespace Microsoft.Azure.SignalR.Tests
+namespace Microsoft.Azure.SignalR.Tests;
+
+public class NegotiateHandlerFacts
 {
-    public class NegotiateHandlerFacts
+    private const string CustomClaimType = "custom.claim";
+
+    private const string CustomUserId = "customUserId";
+
+    private const string DefaultUserId = "nameId";
+
+    private const string DefaultConnectionString = "Endpoint=https://localhost;AccessKey=fake_key;ClientEndpoint=http://redirect";
+
+    private const string ConnectionString2 = "Endpoint=http://localhost2;AccessKey=fake_key;";
+
+    private const string ConnectionString3 = "Endpoint=http://localhost3;AccessKey=fake_key;";
+
+    private const string ConnectionString4 = "Endpoint=http://localhost4;AccessKey=fake_key;";
+
+    private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
+
+    public static IEnumerable<object[]> GetHttpContxtWithoutSuccessfulAuthExp()
     {
-        private const string CustomClaimType = "custom.claim";
-        private const string CustomUserId = "customUserId";
-        private const string DefaultUserId = "nameId";
-        private const string DefaultConnectionString = "Endpoint=https://localhost;AccessKey=fake_key;ClientEndpoint=http://redirect";
-        private const string ConnectionString2 = "Endpoint=http://localhost2;AccessKey=fake_key;";
-        private const string ConnectionString3 = "Endpoint=http://localhost3;AccessKey=fake_key;";
-        private const string ConnectionString4 = "Endpoint=http://localhost4;AccessKey=fake_key;";
+        yield return new object[] { new DefaultHttpContext() };
 
-        private static readonly JwtSecurityTokenHandler JwtSecurityTokenHandler = new();
+        var authSucceededWithoutExp = new DefaultHttpContext();
+        authSucceededWithoutExp.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), "schema"))));
+        yield return new object[] { authSucceededWithoutExp };
 
-        [Theory]
-        [InlineData(typeof(CustomUserIdProvider), CustomUserId)]
-        [InlineData(typeof(NullUserIdProvider), null)]
-        [InlineData(typeof(DefaultUserIdProvider), DefaultUserId)]
-        public async Task GenerateNegotiateResponseWithUserId(Type type, string expectedUserId)
-        {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection()
-                .AddSignalR(o => o.EnableDetailedErrors = false)
-                .AddAzureSignalR(
-                o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.AccessTokenLifetime = TimeSpan.FromDays(1);
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton(typeof(IUserIdProvider), type)
-                .BuildServiceProvider();
+        var authFailedWithExp = new DefaultHttpContext();
+        authFailedWithExp.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Fail("fail", new() { ExpiresUtc = DateTimeOffset.UtcNow })));
+        yield return new object[] { authFailedWithExp };
 
-            var httpContext = new DefaultHttpContext
+        var authNoResult = new DefaultHttpContext();
+        authNoResult.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.NoResult()));
+        yield return new object[] { authNoResult };
+    }
+
+    [Theory]
+    [InlineData(typeof(CustomUserIdProvider), CustomUserId)]
+    [InlineData(typeof(NullUserIdProvider), null)]
+    [InlineData(typeof(DefaultUserIdProvider), DefaultUserId)]
+    public async Task GenerateNegotiateResponseWithUserId(Type type, string expectedUserId)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection()
+            .AddSignalR(o => o.EnableDetailedErrors = false)
+            .AddAzureSignalR(
+            o =>
             {
-                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
-                {
-                    new Claim(CustomClaimType, CustomUserId),
-                    new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
-                    new Claim("custom", "custom"),
-                }))
-            };
+                o.ConnectionString = DefaultConnectionString;
+                o.AccessTokenLifetime = TimeSpan.FromDays(1);
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton(typeof(IUserIdProvider), type)
+            .BuildServiceProvider();
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            Assert.StartsWith("http://redirect/client/?hub=hub", negotiateResponse.Url);
-            Assert.NotNull(negotiateResponse.AccessToken);
-            Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
-
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Equal(expectedUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
-            Assert.Equal("custom", token.Claims.FirstOrDefault(x => x.Type == "custom")?.Value);
-            Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
-            Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName));
-            Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode));
-            Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors));
-        }
-
-        [Fact]
-        public async Task GenerateNegotiateResponseWithDiagnosticClient()
+        var httpContext = new DefaultHttpContext
         {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection()
-                .AddSignalR(o => o.EnableDetailedErrors = false)
-                .AddAzureSignalR(
-                o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.AccessTokenLifetime = TimeSpan.FromDays(1);
-                    o.DiagnosticClientFilter = ctx => { return ctx.Request.Query["diag"].FirstOrDefault() != default; };
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.QueryString = new QueryString("?diag");
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            Assert.NotNull(negotiateResponse.AccessToken);
-
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            var tc = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.DiagnosticClient);
-            Assert.NotNull(tc);
-            Assert.Equal("true", tc.Value);
-        }
-
-        [Fact]
-        public async Task GenerateNegotiateResponseWithUserIdAndServerSticky()
-        {
-            var name = nameof(GenerateNegotiateResponseWithUserIdAndServerSticky);
-            var serverNameProvider = new TestServerNameProvider(name);
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection()
-                .AddSignalR(o => o.EnableDetailedErrors = true)
-                .AddAzureSignalR(
-                o =>
-                {
-                    o.ServerStickyMode = ServerStickyMode.Required;
-                    o.ConnectionString = DefaultConnectionString;
-                    o.AccessTokenLifetime = TimeSpan.FromDays(1);
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton(typeof(IUserIdProvider), typeof(DefaultUserIdProvider))
-                .AddSingleton(typeof(IServerNameProvider), serverNameProvider)
-                .BuildServiceProvider();
-
-            var httpContext = new DefaultHttpContext
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
-                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
-                {
-                    new Claim(CustomClaimType, CustomUserId),
-                    new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
-                    new Claim("custom", "custom"),
-                }))
-            };
+                new Claim(CustomClaimType, CustomUserId),
+                new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
+                new Claim("custom", "custom"),
+            }))
+        };
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var negotiateResponse = await handler.Process(httpContext);
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var negotiateResponse = await handler.Process(httpContext);
 
-            Assert.NotNull(negotiateResponse);
-            Assert.NotNull(negotiateResponse.Url);
-            Assert.NotNull(negotiateResponse.AccessToken);
-            Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
+        Assert.NotNull(negotiateResponse);
+        Assert.StartsWith("http://redirect/client/?hub=hub", negotiateResponse.Url);
+        Assert.NotNull(negotiateResponse.AccessToken);
+        Assert.Null(negotiateResponse.ConnectionId);
+        Assert.Empty(negotiateResponse.AvailableTransports);
 
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Equal(DefaultUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
-            Assert.Equal("custom", token.Claims.FirstOrDefault(x => x.Type == "custom")?.Value);
-            Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.Equal(expectedUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
+        Assert.Equal("custom", token.Claims.FirstOrDefault(x => x.Type == "custom")?.Value);
+        Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
+        Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName));
+        Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode));
+        Assert.Null(token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors));
+    }
 
-            var serverName = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName)?.Value;
-            Assert.Equal(name, serverName);
-            var mode = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode)?.Value;
-            Assert.Equal("Required", mode);
-            Assert.Equal("True", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors)?.Value);
-        }
-
-        [Theory]
-        [InlineData("/user/path/negotiate", "", "", "asrs.op=%2Fuser%2Fpath&asrs_request_id=")]
-        [InlineData("/user/path/negotiate/", "", "a", "asrs.op=%2Fuser%2Fpath&asrs_request_id=a")]
-        [InlineData("", "?customKey=customeValue", "?a=c", "customKey=customeValue&asrs_request_id=%3Fa%3Dc")]
-        [InlineData("/user/path/negotiate", "?customKey=customeValue", "&", "asrs.op=%2Fuser%2Fpath&customKey=customeValue&asrs_request_id=%26")]
-        public async Task GenerateNegotiateResponseWithPathAndQuery(string path, string queryString, string id, string expectedQueryString)
-        {
-            var requestIdProvider = new TestRequestIdProvider(id);
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
-                .BuildServiceProvider();
-
-            var requestFeature = new HttpRequestFeature
+    [Fact]
+    public async Task GenerateNegotiateResponseWithDiagnosticClient()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection()
+            .AddSignalR(o => o.EnableDetailedErrors = false)
+            .AddAzureSignalR(
+            o =>
             {
-                Path = path,
-                QueryString = queryString
-            };
-            var features = new FeatureCollection();
-            features.Set<IHttpRequestFeature>(requestFeature);
-            var httpContext = new DefaultHttpContext(features);
+                o.ConnectionString = DefaultConnectionString;
+                o.AccessTokenLifetime = TimeSpan.FromDays(1);
+                o.DiagnosticClientFilter = ctx => { return ctx.Request.Query["diag"].FirstOrDefault() != default; };
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?diag");
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var negotiateResponse = await handler.Process(httpContext);
 
-            Assert.NotNull(negotiateResponse);
-            Assert.EndsWith($"?hub=chat&{expectedQueryString}", negotiateResponse.Url);
-        }
+        Assert.NotNull(negotiateResponse);
+        Assert.NotNull(negotiateResponse.AccessToken);
 
-        [Theory]
-        [InlineData("", "&", "?hub=chat&asrs_request_id=%26")]
-        [InlineData("appName", "abc", "?hub=appname_chat&asrs_request_id=abc")]
-        public async Task GenerateNegotiateResponseWithAppName(string appName, string id, string expectedResponse)
-        {
-            var requestIdProvider = new TestRequestIdProvider(id);
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.ApplicationName = appName;
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
-                .BuildServiceProvider();
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        var tc = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.DiagnosticClient);
+        Assert.NotNull(tc);
+        Assert.Equal("true", tc.Value);
+    }
 
-            var requestFeature = new HttpRequestFeature
+    [Fact]
+    public async Task GenerateNegotiateResponseWithUserIdAndServerSticky()
+    {
+        var name = nameof(GenerateNegotiateResponseWithUserIdAndServerSticky);
+        var serverNameProvider = new TestServerNameProvider(name);
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection()
+            .AddSignalR(o => o.EnableDetailedErrors = true)
+            .AddAzureSignalR(
+            o =>
             {
-            };
-            var features = new FeatureCollection();
-            features.Set<IHttpRequestFeature>(requestFeature);
-            var httpContext = new DefaultHttpContext(features);
+                o.ServerStickyMode = ServerStickyMode.Required;
+                o.ConnectionString = DefaultConnectionString;
+                o.AccessTokenLifetime = TimeSpan.FromDays(1);
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton(typeof(IUserIdProvider), typeof(DefaultUserIdProvider))
+            .AddSingleton(typeof(IServerNameProvider), serverNameProvider)
+            .BuildServiceProvider();
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            Assert.EndsWith(expectedResponse, negotiateResponse.Url);
-        }
-
-        [Fact]
-        public async Task GenerateNegotiateResponseWithNullTransportTypeProvider()
+        var httpContext = new DefaultHttpContext
         {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
-
-            var httpContext = new DefaultHttpContext();
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.DoesNotContain(token.Claims, c => c.Type == Constants.ClaimType.HttpTransportType);
-        }
-
-        [Fact]
-        public async Task GenerateNegotiateResponseWithTransportTypeProvider()
-        {
-            var authenticatedTransport = HttpTransports.All;
-            var nonAuthenticatedTransport = HttpTransportType.WebSockets;
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.TransportTypeDetector = context => context.User.Identity.AuthenticationType == null ? nonAuthenticatedTransport : authenticatedTransport;
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
-
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-
-            var httpContext = new DefaultHttpContext() { User = new ClaimsPrincipal(new ClaimsIdentity("email")) };
-            var negotiateResponse = await handler.Process(httpContext);
-            Assert.NotNull(negotiateResponse);
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Equal("7", token.Claims.First(c => c.Type == Constants.ClaimType.HttpTransportType).Value);
-
-            httpContext = new DefaultHttpContext() { User = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: null)) };
-            negotiateResponse = await handler.Process(httpContext);
-            Assert.NotNull(negotiateResponse);
-            token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Equal("1", token.Claims.First(c => c.Type == Constants.ClaimType.HttpTransportType).Value);
-        }
-
-        [Theory]
-        [InlineData(typeof(ConnectionIdUserIdProvider), ServiceHubConnectionContext.ConnectionIdUnavailableError)]
-        [InlineData(typeof(ConnectionAbortedTokenUserIdProvider), ServiceHubConnectionContext.ConnectionAbortedUnavailableError)]
-        [InlineData(typeof(ItemsUserIdProvider), ServiceHubConnectionContext.ItemsUnavailableError)]
-        [InlineData(typeof(ProtocolUserIdProvider), ServiceHubConnectionContext.ProtocolUnavailableError)]
-        public async Task CustomUserIdProviderAccessUnavailablePropertyThrowsException(Type type, string errorMessage)
-        {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton(typeof(IUserIdProvider), type)
-                .BuildServiceProvider();
-
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var httpContext = new DefaultHttpContext
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
-                User = new ClaimsPrincipal()
-            };
+                new Claim(CustomClaimType, CustomUserId),
+                new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
+                new Claim("custom", "custom"),
+            }))
+        };
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await handler.Process(httpContext));
-            Assert.Equal(errorMessage, exception.Message);
-        }
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var negotiateResponse = await handler.Process(httpContext);
 
-        [Fact]
-        public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomerRouterAndAppName()
+        Assert.NotNull(negotiateResponse);
+        Assert.NotNull(negotiateResponse.Url);
+        Assert.NotNull(negotiateResponse.AccessToken);
+        Assert.Null(negotiateResponse.ConnectionId);
+        Assert.Empty(negotiateResponse.AvailableTransports);
+
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.Equal(DefaultUserId, token.Claims.FirstOrDefault(x => x.Type == Constants.ClaimType.UserId)?.Value);
+        Assert.Equal("custom", token.Claims.FirstOrDefault(x => x.Type == "custom")?.Value);
+        Assert.Equal(TimeSpan.FromDays(1), token.ValidTo - token.ValidFrom);
+
+        var serverName = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerName)?.Value;
+        Assert.Equal(name, serverName);
+        var mode = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode)?.Value;
+        Assert.Equal("Required", mode);
+        Assert.Equal("True", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors)?.Value);
+    }
+
+    [Theory]
+    [InlineData("/user/path/negotiate", "", "", "asrs.op=%2Fuser%2Fpath&asrs_request_id=")]
+    [InlineData("/user/path/negotiate/", "", "a", "asrs.op=%2Fuser%2Fpath&asrs_request_id=a")]
+    [InlineData("", "?customKey=customeValue", "?a=c", "customKey=customeValue&asrs_request_id=%3Fa%3Dc")]
+    [InlineData("/user/path/negotiate", "?customKey=customeValue", "&", "asrs.op=%2Fuser%2Fpath&customKey=customeValue&asrs_request_id=%26")]
+    public async Task GenerateNegotiateResponseWithPathAndQuery(string path, string queryString, string id, string expectedQueryString)
+    {
+        var requestIdProvider = new TestRequestIdProvider(id);
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
+            .BuildServiceProvider();
+
+        var requestFeature = new HttpRequestFeature
         {
-            var requestIdProvider = new TestRequestIdProvider("a");
-            var config = new ConfigurationBuilder().Build();
-            var router = new TestCustomRouter();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.ApplicationName = "testprefix";
-                    o.Endpoints = new ServiceEndpoint[]
-                    {
-                        new(ConnectionString2),
-                        new(ConnectionString3, name: "chosen"),
-                        new(ConnectionString4),
-                    };
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IEndpointRouter>(router)
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
-                .BuildServiceProvider();
+            Path = path,
+            QueryString = queryString
+        };
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(requestFeature);
+        var httpContext = new DefaultHttpContext(features);
 
-            var requestFeature = new HttpRequestFeature
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+
+        Assert.NotNull(negotiateResponse);
+        Assert.EndsWith($"?hub=chat&{expectedQueryString}", negotiateResponse.Url);
+    }
+
+    [Theory]
+    [InlineData("", "&", "?hub=chat&asrs_request_id=%26")]
+    [InlineData("appName", "abc", "?hub=appname_chat&asrs_request_id=abc")]
+    public async Task GenerateNegotiateResponseWithAppName(string appName, string id, string expectedResponse)
+    {
+        var requestIdProvider = new TestRequestIdProvider(id);
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o =>
             {
-                Path = "/user/path/negotiate/",
-                QueryString = "?endpoint=chosen"
-            };
+                o.ConnectionString = DefaultConnectionString;
+                o.ApplicationName = appName;
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
+            .BuildServiceProvider();
 
-            var features = new FeatureCollection();
-            features.Set<IHttpRequestFeature>(requestFeature);
-            var httpContext = new DefaultHttpContext(features);
-
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            Assert.Equal($"http://localhost3/client/?hub=testprefix_chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
-        }
-
-        [Fact]
-        public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomRouter()
+        var requestFeature = new HttpRequestFeature
         {
-            var requestIdProvider = new TestRequestIdProvider("a");
-            var config = new ConfigurationBuilder().Build();
-            var router = new TestCustomRouter();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(
-                o => o.Endpoints = new ServiceEndpoint[]
+        };
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(requestFeature);
+        var httpContext = new DefaultHttpContext(features);
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+
+        Assert.NotNull(negotiateResponse);
+        Assert.EndsWith(expectedResponse, negotiateResponse.Url);
+    }
+
+    [Fact]
+    public async Task GenerateNegotiateResponseWithNullTransportTypeProvider()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext();
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+
+        Assert.NotNull(negotiateResponse);
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.DoesNotContain(token.Claims, c => c.Type == Constants.ClaimType.HttpTransportType);
+    }
+
+    [Fact]
+    public async Task GenerateNegotiateResponseWithTransportTypeProvider()
+    {
+        var authenticatedTransport = HttpTransports.All;
+        var nonAuthenticatedTransport = HttpTransportType.WebSockets;
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o =>
+            {
+                o.ConnectionString = DefaultConnectionString;
+                o.TransportTypeDetector = context => context.User.Identity.AuthenticationType == null ? nonAuthenticatedTransport : authenticatedTransport;
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+
+        var httpContext = new DefaultHttpContext() { User = new ClaimsPrincipal(new ClaimsIdentity("email")) };
+        var negotiateResponse = await handler.Process(httpContext);
+        Assert.NotNull(negotiateResponse);
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.Equal("7", token.Claims.First(c => c.Type == Constants.ClaimType.HttpTransportType).Value);
+
+        httpContext = new DefaultHttpContext() { User = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: null)) };
+        negotiateResponse = await handler.Process(httpContext);
+        Assert.NotNull(negotiateResponse);
+        token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.Equal("1", token.Claims.First(c => c.Type == Constants.ClaimType.HttpTransportType).Value);
+    }
+
+    [Theory]
+    [InlineData(typeof(ConnectionIdUserIdProvider), ServiceHubConnectionContext.ConnectionIdUnavailableError)]
+    [InlineData(typeof(ConnectionAbortedTokenUserIdProvider), ServiceHubConnectionContext.ConnectionAbortedUnavailableError)]
+    [InlineData(typeof(ItemsUserIdProvider), ServiceHubConnectionContext.ItemsUnavailableError)]
+    [InlineData(typeof(ProtocolUserIdProvider), ServiceHubConnectionContext.ProtocolUnavailableError)]
+    public async Task CustomUserIdProviderAccessUnavailablePropertyThrowsException(Type type, string errorMessage)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o => o.ConnectionString = DefaultConnectionString)
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton(typeof(IUserIdProvider), type)
+            .BuildServiceProvider();
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal()
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await handler.Process(httpContext));
+        Assert.Equal(errorMessage, exception.Message);
+    }
+
+    [Fact]
+    public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomerRouterAndAppName()
+    {
+        var requestIdProvider = new TestRequestIdProvider("a");
+        var config = new ConfigurationBuilder().Build();
+        var router = new TestCustomRouter();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o =>
+            {
+                o.ApplicationName = "testprefix";
+                o.Endpoints = new ServiceEndpoint[]
                 {
                     new(ConnectionString2),
                     new(ConnectionString3, name: "chosen"),
                     new(ConnectionString4),
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IEndpointRouter>(router)
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
-                .BuildServiceProvider();
+                };
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IEndpointRouter>(router)
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
+            .BuildServiceProvider();
 
-            var requestFeature = new HttpRequestFeature
-            {
-                Path = "/user/path/negotiate/",
-                QueryString = "?endpoint=chosen"
-            };
-            var features = new FeatureCollection();
-            features.Set<IHttpRequestFeature>(requestFeature);
-            var httpContext = new DefaultHttpContext(features);
-
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-
-            Assert.NotNull(negotiateResponse);
-            Assert.Equal($"http://localhost3/client/?hub=chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
-
-            // With no query string should return 400
-            requestFeature = new HttpRequestFeature
-            {
-                Path = "/user/path/negotiate/",
-            };
-
-            var responseFeature = new HttpResponseFeature();
-            var responseBodyFeature = new StreamResponseBodyFeature(responseFeature.Body);
-            features.Set<IHttpRequestFeature>(requestFeature);
-            features.Set<IHttpResponseFeature>(responseFeature);
-            features.Set<IHttpResponseBodyFeature>(responseBodyFeature);
-            httpContext = new DefaultHttpContext(features);
-
-            handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            negotiateResponse = await handler.Process(httpContext);
-
-            Assert.Null(negotiateResponse);
-
-            Assert.Equal(400, responseFeature.StatusCode);
-
-            // With no query string should return 400
-            requestFeature = new HttpRequestFeature
-            {
-                Path = "/user/path/negotiate/",
-                QueryString = "?endpoint=notexists"
-            };
-
-            responseFeature = new HttpResponseFeature();
-            responseBodyFeature = new StreamResponseBodyFeature(responseFeature.Body);
-            features.Set<IHttpRequestFeature>(requestFeature);
-            features.Set<IHttpResponseFeature>(responseFeature);
-            features.Set<IHttpResponseBodyFeature>(responseBodyFeature);
-            httpContext = new DefaultHttpContext(features);
-
-            handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => handler.Process(httpContext));
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestNegotiateHandlerRespectClientRequestCulture(bool isBlazor)
+        var requestFeature = new HttpRequestFeature
         {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection()
-                .AddSignalR(o => o.EnableDetailedErrors = false)
-                .AddAzureSignalR(
-                o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.AccessTokenLifetime = TimeSpan.FromDays(1);
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+            Path = "/user/path/negotiate/",
+            QueryString = "?endpoint=chosen"
+        };
 
-            var features = new FeatureCollection();
-            var requestFeature = new HttpRequestFeature
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(requestFeature);
+        var httpContext = new DefaultHttpContext(features);
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+
+        Assert.NotNull(negotiateResponse);
+        Assert.Equal($"http://localhost3/client/?hub=testprefix_chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
+    }
+
+    [Fact]
+    public async Task TestNegotiateHandlerWithMultipleEndpointsAndCustomRouter()
+    {
+        var requestIdProvider = new TestRequestIdProvider("a");
+        var config = new ConfigurationBuilder().Build();
+        var router = new TestCustomRouter();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(
+            o => o.Endpoints = new ServiceEndpoint[]
             {
-                Path = "/user/path/negotiate/",
-                QueryString = "?endpoint=chosen"
-            };
-            features.Set<IHttpRequestFeature>(requestFeature);
-            var httpCultureFeature = new RequestCultureFeature(
-                new RequestCulture("ar-SA", "en-US"),
-                new AcceptLanguageHeaderRequestCultureProvider()
-            );
-            features.Set<IRequestCultureFeature>(httpCultureFeature);
+                new(ConnectionString2),
+                new(ConnectionString3, name: "chosen"),
+                new(ConnectionString4),
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IEndpointRouter>(router)
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<IConnectionRequestIdProvider>(requestIdProvider)
+            .BuildServiceProvider();
 
-            var httpContext = new DefaultHttpContext(features);
-
-            if (isBlazor)
-            {
-                var blazorDetector = serviceProvider.GetRequiredService<IBlazorDetector>();
-                blazorDetector.TrySetBlazor(nameof(Hub), true);
-            }
-
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var negotiateResponse = await handler.Process(httpContext);
-            var requestId = HttpUtility
-                                .ParseQueryString(negotiateResponse.Url)
-                                .Get(Constants.QueryParameter.ConnectionRequestId);
-
-            var cultureFeatureManager = serviceProvider.GetRequiredService<ICultureFeatureManager>();
-            cultureFeatureManager.TryRemoveCultureFeature(requestId, out var actualCultureFeature);
-
-            var expectedCultureFeature = isBlazor ? httpCultureFeature : null;
-            Assert.Equal(expectedCultureFeature, actualCultureFeature);
-        }
-
-        [Theory]
-        [InlineData(-10)]
-        [InlineData(0)]
-        [InlineData(500)]
-        public void TestInvalidDisconnectTimeoutThrowsAfterBuild(int maxPollInterval)
+        var requestFeature = new HttpRequestFeature
         {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.MaxPollIntervalInSeconds = maxPollInterval;
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+            Path = "/user/path/negotiate/",
+            QueryString = "?endpoint=chosen"
+        };
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(requestFeature);
+        var httpContext = new DefaultHttpContext(features);
 
-            Assert.Throws<AzureSignalRInvalidServiceOptionsException>(serviceProvider.GetRequiredService<NegotiateHandler<Hub>>);
-        }
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
 
-        [Theory]
-        [InlineData(1)]
-        [InlineData(15)]
-        [InlineData(300)]
-        public async Task TestNegotiateHandlerResponseContainsValidMaxPollInterval(int maxPollInterval)
+        Assert.NotNull(negotiateResponse);
+        Assert.Equal($"http://localhost3/client/?hub=chat&asrs.op=%2Fuser%2Fpath&endpoint=chosen&asrs_request_id=a", negotiateResponse.Url);
+
+        // With no query string should return 400
+        requestFeature = new HttpRequestFeature
         {
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection().AddSignalR()
-                .AddAzureSignalR(o =>
-                {
-                    o.ConnectionString = DefaultConnectionString;
-                    o.MaxPollIntervalInSeconds = maxPollInterval;
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .BuildServiceProvider();
+            Path = "/user/path/negotiate/",
+        };
 
-            var requestFeature = new HttpRequestFeature
+        var responseFeature = new HttpResponseFeature();
+        var responseBodyFeature = new StreamResponseBodyFeature(responseFeature.Body);
+        features.Set<IHttpRequestFeature>(requestFeature);
+        features.Set<IHttpResponseFeature>(responseFeature);
+        features.Set<IHttpResponseBodyFeature>(responseBodyFeature);
+        httpContext = new DefaultHttpContext(features);
+
+        handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        negotiateResponse = await handler.Process(httpContext);
+
+        Assert.Null(negotiateResponse);
+
+        Assert.Equal(400, responseFeature.StatusCode);
+
+        // With no query string should return 400
+        requestFeature = new HttpRequestFeature
+        {
+            Path = "/user/path/negotiate/",
+            QueryString = "?endpoint=notexists"
+        };
+
+        responseFeature = new HttpResponseFeature();
+        responseBodyFeature = new StreamResponseBodyFeature(responseFeature.Body);
+        features.Set<IHttpRequestFeature>(requestFeature);
+        features.Set<IHttpResponseFeature>(responseFeature);
+        features.Set<IHttpResponseBodyFeature>(responseBodyFeature);
+        httpContext = new DefaultHttpContext(features);
+
+        handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => handler.Process(httpContext));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TestNegotiateHandlerRespectClientRequestCulture(bool isBlazor)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection()
+            .AddSignalR(o => o.EnableDetailedErrors = false)
+            .AddAzureSignalR(
+            o =>
             {
-                Path = "/user/path/negotiate/",
-                QueryString = "?endpoint=chosen"
-            };
-            var responseFeature = new HttpResponseFeature();
-            var features = new FeatureCollection();
-            features.Set<IHttpRequestFeature>(requestFeature);
-            features.Set<IHttpResponseFeature>(responseFeature);
-            var httpContext = new DefaultHttpContext(features);
+                o.ConnectionString = DefaultConnectionString;
+                o.AccessTokenLifetime = TimeSpan.FromDays(1);
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
-            var response = await handler.Process(httpContext);
+        var features = new FeatureCollection();
+        var requestFeature = new HttpRequestFeature
+        {
+            Path = "/user/path/negotiate/",
+            QueryString = "?endpoint=chosen"
+        };
+        features.Set<IHttpRequestFeature>(requestFeature);
+        var httpCultureFeature = new RequestCultureFeature(
+            new RequestCulture("ar-SA", "en-US"),
+            new AcceptLanguageHeaderRequestCultureProvider()
+        );
+        features.Set<IRequestCultureFeature>(httpCultureFeature);
 
-            Assert.Equal(200, responseFeature.StatusCode);
+        var httpContext = new DefaultHttpContext(features);
 
-            var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(response.AccessToken);
-
-            Assert.Contains(tokens.Claims, x => x.Type == Constants.ClaimType.MaxPollInterval && x.Value == maxPollInterval.ToString(CultureInfo.InvariantCulture));
+        if (isBlazor)
+        {
+            var blazorDetector = serviceProvider.GetRequiredService<IBlazorDetector>();
+            blazorDetector.TrySetBlazor(nameof(Hub), true);
         }
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var negotiateResponse = await handler.Process(httpContext);
+        var requestId = HttpUtility
+                            .ParseQueryString(negotiateResponse.Url)
+                            .Get(Constants.QueryParameter.ConnectionRequestId);
+
+        var cultureFeatureManager = serviceProvider.GetRequiredService<ICultureFeatureManager>();
+        cultureFeatureManager.TryRemoveCultureFeature(requestId, out var actualCultureFeature);
+
+        var expectedCultureFeature = isBlazor ? httpCultureFeature : null;
+        Assert.Equal(expectedCultureFeature, actualCultureFeature);
+    }
+
+    [Theory]
+    [InlineData(-10)]
+    [InlineData(0)]
+    [InlineData(500)]
+    public void TestInvalidDisconnectTimeoutThrowsAfterBuild(int maxPollInterval)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o =>
+            {
+                o.ConnectionString = DefaultConnectionString;
+                o.MaxPollIntervalInSeconds = maxPollInterval;
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        Assert.Throws<AzureSignalRInvalidServiceOptionsException>(serviceProvider.GetRequiredService<NegotiateHandler<Hub>>);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(300)]
+    public async Task TestNegotiateHandlerResponseContainsValidMaxPollInterval(int maxPollInterval)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection().AddSignalR()
+            .AddAzureSignalR(o =>
+            {
+                o.ConnectionString = DefaultConnectionString;
+                o.MaxPollIntervalInSeconds = maxPollInterval;
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .BuildServiceProvider();
+
+        var requestFeature = new HttpRequestFeature
+        {
+            Path = "/user/path/negotiate/",
+            QueryString = "?endpoint=chosen"
+        };
+        var responseFeature = new HttpResponseFeature();
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(requestFeature);
+        features.Set<IHttpResponseFeature>(responseFeature);
+        var httpContext = new DefaultHttpContext(features);
+
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Hub>>();
+        var response = await handler.Process(httpContext);
+
+        Assert.Equal(200, responseFeature.StatusCode);
+
+        var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(response.AccessToken);
+
+        Assert.Contains(tokens.Claims, x => x.Type == Constants.ClaimType.MaxPollInterval && x.Value == maxPollInterval.ToString(CultureInfo.InvariantCulture));
+    }
 
 #if NET6_0_OR_GREATER
-        [Fact]
-        public async Task TestNegotiateHandlerReturnCloseOnAuthExpClaims()
-        {
-            using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(true);
-            var httpContext = new DefaultHttpContext();
-            var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
-            httpContext.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), new AuthenticationProperties { ExpiresUtc = expireUtc }, "schema"))));
-            var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-            var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
-            Assert.Contains(tokens.Claims, c => c.Type == "asrs.s.coae" && c.Value == "true");
-            Assert.Contains(tokens.Claims, c => c.Type == "asrs.s.aeo" && c.Value == "0");
-            await app.StopAsync();
-        }
 
-        [Fact]
-        public async Task TestNegotiateHandlerNotReturnCloseOnAuthExpClaimsWhenOptionIsFalse()
-        {
-            using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(false);
-            var httpContext = new DefaultHttpContext();
-            var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
-            httpContext.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), new AuthenticationProperties { ExpiresUtc = expireUtc }, "schema"))));
-            var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-            var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
+    [Fact]
+    public async Task TestNegotiateHandlerReturnCloseOnAuthExpClaims()
+    {
+        using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(true);
+        var httpContext = new DefaultHttpContext();
+        var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
+        httpContext.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), new AuthenticationProperties { ExpiresUtc = expireUtc }, "schema"))));
+        var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+        var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        Assert.Contains(tokens.Claims, c => c.Type == "asrs.s.coae" && c.Value == "true");
+        Assert.Contains(tokens.Claims, c => c.Type == "asrs.s.aeo" && c.Value == "0");
+        await app.StopAsync();
+    }
 
-            Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.coae");
-            Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.aeo");
-            await app.StopAsync();
+    [Fact]
+    public async Task TestNegotiateHandlerNotReturnCloseOnAuthExpClaimsWhenOptionIsFalse()
+    {
+        using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(false);
+        var httpContext = new DefaultHttpContext();
+        var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
+        httpContext.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), new AuthenticationProperties { ExpiresUtc = expireUtc }, "schema"))));
+        var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+        var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
 
-        }
+        Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.coae");
+        Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.aeo");
+        await app.StopAsync();
+    }
 
-        [Theory]
-        [MemberData(nameof(GetHttpContxtWithoutSuccessfulAuthExp))]
-        public async Task TestNegotiateHandlerNotReturnCloseOnAuthExpClaimsWithoutAuthExp(HttpContext httpContext)
-        {
-            using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(true);
-            var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
-            var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
-            var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
+    [Theory]
+    [MemberData(nameof(GetHttpContxtWithoutSuccessfulAuthExp))]
+    public async Task TestNegotiateHandlerNotReturnCloseOnAuthExpClaimsWithoutAuthExp(HttpContext httpContext)
+    {
+        using var app = await CreateSignalRServerAppWithCloseOnAuthExpAsync(true);
+        var expireUtc = DateTimeOffset.FromUnixTimeSeconds(0);
+        var handler = app.Services.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
+        var tokens = JwtTokenHelper.JwtHandler.ReadJwtToken(negotiateResponse.AccessToken);
 
-            Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.coae");
-            Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.aeo");
-            await app.StopAsync();
+        Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.coae");
+        Assert.DoesNotContain(tokens.Claims, c => c.Type == "asrs.s.aeo");
+        await app.StopAsync();
+    }
 
-        }
-
-        public static IEnumerable<object[]> GetHttpContxtWithoutSuccessfulAuthExp()
-        {
-            yield return new object[] { new DefaultHttpContext() };
-
-            var authSucceededWithoutExp = new DefaultHttpContext();
-            authSucceededWithoutExp.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), "schema"))));
-            yield return new object[] { authSucceededWithoutExp };
-
-            var authFailedWithExp = new DefaultHttpContext();
-            authFailedWithExp.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.Fail("fail", new() { ExpiresUtc = DateTimeOffset.UtcNow })));
-            yield return new object[] { authFailedWithExp };
-
-            var authNoResult = new DefaultHttpContext();
-            authNoResult.Features.Set(Mock.Of<IAuthenticateResultFeature>(f => f.AuthenticateResult == AuthenticateResult.NoResult()));
-            yield return new object[] { authNoResult };
-        }
 #endif
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestNegotiateHandlerServerStickyRespectBlazor(bool isBlazor)
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TestNegotiateHandlerServerStickyRespectBlazor(bool isBlazor)
+    {
+        var hubName = typeof(Chat).Name;
+        var blazorDetector = new DefaultBlazorDetector();
+        var config = new ConfigurationBuilder().Build();
+        var serviceProvider = new ServiceCollection()
+            .AddSignalR(o => o.EnableDetailedErrors = true)
+            .AddAzureSignalR(
+            o =>
+            {
+                o.ServerStickyMode = ServerStickyMode.Preferred;
+                o.ConnectionString = DefaultConnectionString;
+            })
+            .Services
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton(typeof(IUserIdProvider), typeof(DefaultUserIdProvider))
+            .AddSingleton(typeof(IBlazorDetector), blazorDetector)
+            .BuildServiceProvider();
+
+        blazorDetector.TrySetBlazor(hubName, isBlazor);
+        var httpContext = new DefaultHttpContext
         {
-            var hubName = typeof(Chat).Name;
-            var blazorDetector = new DefaultBlazorDetector();
-            var config = new ConfigurationBuilder().Build();
-            var serviceProvider = new ServiceCollection()
-                .AddSignalR(o => o.EnableDetailedErrors = true)
-                .AddAzureSignalR(
-                o =>
-                {
-                    o.ServerStickyMode = ServerStickyMode.Preferred;
-                    o.ConnectionString = DefaultConnectionString;
-                })
-                .Services
-                .AddLogging()
-                .AddSingleton<IConfiguration>(config)
-                .AddSingleton(typeof(IUserIdProvider), typeof(DefaultUserIdProvider))
-                .AddSingleton(typeof(IBlazorDetector), blazorDetector)
-                .BuildServiceProvider();
-
-            blazorDetector.TrySetBlazor(hubName, isBlazor);
-            var httpContext = new DefaultHttpContext
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
-                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
-                {
-                    new Claim(CustomClaimType, CustomUserId),
-                    new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
-                    new Claim("custom", "custom"),
-                }))
-            };
+                new Claim(CustomClaimType, CustomUserId),
+                new Claim(ClaimTypes.NameIdentifier, DefaultUserId),
+                new Claim("custom", "custom"),
+            }))
+        };
 
-            var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
-            var negotiateResponse = await handler.Process(httpContext);
+        var handler = serviceProvider.GetRequiredService<NegotiateHandler<Chat>>();
+        var negotiateResponse = await handler.Process(httpContext);
 
-            Assert.NotNull(negotiateResponse);
-            Assert.NotNull(negotiateResponse.Url);
-            Assert.NotNull(negotiateResponse.AccessToken);
-            Assert.Null(negotiateResponse.ConnectionId);
-            Assert.Empty(negotiateResponse.AvailableTransports);
+        Assert.NotNull(negotiateResponse);
+        Assert.NotNull(negotiateResponse.Url);
+        Assert.NotNull(negotiateResponse.AccessToken);
+        Assert.Null(negotiateResponse.ConnectionId);
+        Assert.Empty(negotiateResponse.AvailableTransports);
 
-            var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
+        var token = JwtSecurityTokenHandler.ReadJwtToken(negotiateResponse.AccessToken);
 
-            var mode = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode)?.Value;
-            if (isBlazor)
-            {
-                Assert.Equal("Required", mode);
-            }
-            else
-            {
-                Assert.Equal("Preferred", mode);
-            }
-            Assert.Equal("True", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors)?.Value);
+        var mode = token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.ServerStickyMode)?.Value;
+        if (isBlazor)
+        {
+            Assert.Equal("Required", mode);
+        }
+        else
+        {
+            Assert.Equal("Preferred", mode);
+        }
+        Assert.Equal("True", token.Claims.FirstOrDefault(s => s.Type == Constants.ClaimType.EnableDetailedErrors)?.Value);
+    }
+
+    private static async Task<WebApplication> CreateSignalRServerAppWithCloseOnAuthExpAsync(bool closeOnAuthExp)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddSignalR().AddAzureSignalR("Endpoint=http://localhost;Port=8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;");
+        builder.Services.AddSingleton(sp => Mock.Of<IEndpointRouter>(r => r.GetNegotiateEndpoint(It.IsAny<HttpContext>(), It.IsAny<IEnumerable<ServiceEndpoint>>()) == sp.GetService<IServiceEndpointManager>().Endpoints.First().Value));
+        builder.Services.AddSingleton<IServiceConnectionFactory>(new TestServiceConnectionFactory());
+        var app = builder.Build();
+        app.MapHub<Chat>("/chat", o => o.CloseOnAuthenticationExpiration = closeOnAuthExp);
+        await app.StartAsync();
+        return app;
+    }
+
+    private sealed class TestServerNameProvider : IServerNameProvider
+    {
+        private readonly string _serverName;
+
+        public TestServerNameProvider(string serverName)
+        {
+            _serverName = serverName;
         }
 
-        private sealed class TestServerNameProvider : IServerNameProvider
+        public string GetName()
         {
-            private readonly string _serverName;
-
-            public TestServerNameProvider(string serverName)
-            {
-                _serverName = serverName;
-            }
-
-            public string GetName()
-            {
-                return _serverName;
-            }
+            return _serverName;
         }
+    }
 
-        private sealed class TestCustomRouter : EndpointRouterDecorator
+    private sealed class TestCustomRouter : EndpointRouterDecorator
+    {
+        public override ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)
         {
-            public override ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)
+            var endpointName = context.Request.Query["endpoint"];
+            if (endpointName.Count == 0)
             {
-                var endpointName = context.Request.Query["endpoint"];
-                if (endpointName.Count == 0)
-                {
-                    context.Response.StatusCode = 400;
-                    var response = Encoding.UTF8.GetBytes("Invalid request");
-                    // In latest DefaultHttpContext, response body is set to null
-                    context.Response.Body = new MemoryStream();
-                    context.Response.Body.Write(response, 0, response.Length);
-                    return null;
-                }
-
-                return endpoints.First(s => s.Name == endpointName && s.Online);
-            }
-        }
-
-        private sealed class CustomUserIdProvider : IUserIdProvider
-        {
-            public string GetUserId(HubConnectionContext connection)
-            {
-                return connection.GetHttpContext()?.User?.Claims?.First(c => c.Type == CustomClaimType)?.Value;
-            }
-        }
-
-        private sealed class NullUserIdProvider : IUserIdProvider
-        {
-            public string GetUserId(HubConnectionContext connection)
-            {
+                context.Response.StatusCode = 400;
+                var response = Encoding.UTF8.GetBytes("Invalid request");
+                // In latest DefaultHttpContext, response body is set to null
+                context.Response.Body = new MemoryStream();
+                context.Response.Body.Write(response, 0, response.Length);
                 return null;
             }
-        }
 
-        private sealed class ConnectionIdUserIdProvider : IUserIdProvider
-        {
-            public string GetUserId(HubConnectionContext connection)
-            {
-                return connection.ConnectionId;
-            }
+            return endpoints.First(s => s.Name == endpointName && s.Online);
         }
+    }
 
-        private sealed class ConnectionAbortedTokenUserIdProvider : IUserIdProvider
+    private sealed class CustomUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
         {
-            public string GetUserId(HubConnectionContext connection)
-            {
-                return connection.ConnectionAborted.IsCancellationRequested.ToString();
-            }
+            return connection.GetHttpContext()?.User?.Claims?.First(c => c.Type == CustomClaimType)?.Value;
         }
+    }
 
-        private sealed class ItemsUserIdProvider : IUserIdProvider
+    private sealed class NullUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
         {
-            public string GetUserId(HubConnectionContext connection)
-            {
-                return connection.Items.ToString();
-            }
+            return null;
         }
+    }
 
-        private sealed class ProtocolUserIdProvider : IUserIdProvider
+    private sealed class ConnectionIdUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
         {
-            public string GetUserId(HubConnectionContext connection)
-            {
-                return connection.Protocol.Name;
-            }
+            return connection.ConnectionId;
         }
+    }
 
-        private sealed class Chat : Hub
+    private sealed class ConnectionAbortedTokenUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
         {
+            return connection.ConnectionAborted.IsCancellationRequested.ToString();
         }
+    }
 
-        private static async Task<WebApplication> CreateSignalRServerAppWithCloseOnAuthExpAsync(bool closeOnAuthExp)
+    private sealed class ItemsUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
         {
-            var builder = WebApplication.CreateBuilder();
-            builder.Services.AddSignalR().AddAzureSignalR("Endpoint=http://localhost;Port=8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;");
-            builder.Services.AddSingleton(sp => Mock.Of<IEndpointRouter>(r => r.GetNegotiateEndpoint(It.IsAny<HttpContext>(), It.IsAny<IEnumerable<ServiceEndpoint>>()) == sp.GetService<IServiceEndpointManager>().Endpoints.First().Value));
-            builder.Services.AddSingleton<IServiceConnectionFactory>(new TestServiceConnectionFactory());
-            var app = builder.Build();
-            app.MapHub<Chat>("/chat", o => o.CloseOnAuthenticationExpiration = closeOnAuthExp);
-            await app.StartAsync();
-            return app;
+            return connection.Items.ToString();
         }
+    }
+
+    private sealed class ProtocolUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
+        {
+            return connection.Protocol.Name;
+        }
+    }
+
+    private sealed class Chat : Hub
+    {
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/RunSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RunSignalRTests.cs
@@ -198,8 +198,6 @@ public class RunSignalRTests : VerifiableLoggedTest
 
     private sealed class ControlledServiceConnectionContext : ConnectionContext
     {
-        private static ServiceProtocol ServiceProtocol { get; } = new();
-
         public override IDuplexPipe Transport { get; set; }
 
         public IDuplexPipe Application { get; set; }
@@ -209,6 +207,8 @@ public class RunSignalRTests : VerifiableLoggedTest
         public override IFeatureCollection Features { get; } = new FeatureCollection();
 
         public override IDictionary<object, object?> Items { get; set; } = new Dictionary<object, object?>();
+
+        private static ServiceProtocol ServiceProtocol { get; } = new();
 
         public ControlledServiceConnectionContext()
         {

--- a/test/Microsoft.Azure.SignalR.Tests/TestConnectionContext.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/TestConnectionContext.cs
@@ -8,10 +8,20 @@ using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 
-namespace Microsoft.Azure.SignalR.Tests.Common;
+namespace Microsoft.Azure.SignalR.Tests;
 
 internal sealed class TestConnectionContext : ConnectionContext
 {
+    public override string ConnectionId { get; set; }
+
+    public override IFeatureCollection Features { get; }
+
+    public override IDictionary<object, object> Items { get; set; }
+
+    public override IDuplexPipe Transport { get; set; }
+
+    public IDuplexPipe Application { get; set; }
+
     public TestConnectionContext()
     {
         Features = new FeatureCollection();
@@ -24,14 +34,4 @@ internal sealed class TestConnectionContext : ConnectionContext
         Transport = pair.Transport;
         Application = pair.Application;
     }
-
-    public override string ConnectionId { get; set; }
-
-    public override IFeatureCollection Features { get; }
-
-    public override IDictionary<object, object> Items { get; set; }
-
-    public override IDuplexPipe Transport { get; set; }
-
-    public IDuplexPipe Application { get; set; }
 }


### PR DESCRIPTION
This pull request includes changes to `Microsoft.Azure.SignalR.AspNet.Tests` to improve code readability and modernize the syntax. The most important changes include the refactoring of class constructors, updating array initializations to use modern C# syntax, and minor namespace adjustments.

### Refactoring and Modernization:

* [`test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs`](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL37-R55): Refactored `RunAzureSignalRTests` class constructor to use the new syntax and moved the `JwtSecurityTokenHandler` initialization. Updated array initializations to use the modern C# syntax. [[1]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL37-R55) [[2]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL240-R249) [[3]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL276-R285) [[4]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL310-R319) [[5]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL341-R350) [[6]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL372-R381) [[7]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL406-R415) [[8]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL469-R478) [[9]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL632-R639) [[10]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL706-R717) [[11]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaR873) [[12]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL886-R907) [[13]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL938) [[14]](diffhunk://#diff-d78010eac6d87d10464baefc4c0830e517f0a80f2625aa70e45b2b2130e7e2aaL967-L968)

### Namespace Adjustments:

* [`test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionContext.cs`](diffhunk://#diff-10c3515486b6ab2156e0cc9baf48c0e7850a8cd3fc79627c9eca6660f54eb776L11-R26): Changed the namespace from `Microsoft.Azure.SignalR.Tests.Common` to `Microsoft.Azure.SignalR.AspNet.Tests` and reordered property initializations. [[1]](diffhunk://#diff-10c3515486b6ab2156e0cc9baf48c0e7850a8cd3fc79627c9eca6660f54eb776L11-R26) [[2]](diffhunk://#diff-10c3515486b6ab2156e0cc9baf48c0e7850a8cd3fc79627c9eca6660f54eb776L29-L37)

* [`test/Microsoft.Azure.SignalR.AspNet.Tests/TestConnectionFactory.cs`](diffhunk://#diff-40cb7b17d0e7cf43efc991964e46c275c791c7b41816d67886acd0e1077d14b8R9): Updated the namespace to `Microsoft.Azure.SignalR.AspNet.Tests`.

### Minor Adjustments:

* [`test/Microsoft.Azure.SignalR.Common.Tests/ServiceConnections/MultiEndpointMessageWriterTests.cs`](diffhunk://#diff-93356fcc71f44eeecec157ed5947f2d4fe72e57ed523e378244ab47b1d08e47fR16): Added a newline for better readability.

* [`test/Microsoft.Azure.SignalR.IntegrationTests/Infrastructure/HotReloadIntegrationTestStartup.cs`](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162R8-R24): Adjusted the namespace and refactored `HotReloadIntegrationTestStartup` class constructor and methods to use modern C# syntax. [[1]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162R8-R24) [[2]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162R41-R51) [[3]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162L73-R70) [[4]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162L96-R93) [[5]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162R109-R111) [[6]](diffhunk://#diff-72f3565dcc5785a5a1fd300eecdc874d2c73465a658586cbb940ac936b80b162L126)