### PR TITLE
fix AspNet productInfo

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs
@@ -15,8 +15,10 @@ internal class ConnectionFactory : ConnectionFactoryBase
     {
     }
 
-    protected override void SetCustomHeaders(IDictionary<string, string> headers)
+    protected override void SetInternalUserAgent(IDictionary<string, string> headers)
     {
-        return;
+        // Fix issue: https://github.com/Azure/azure-signalr/issues/198
+        // .NET Framework has restriction about reserved string as the header name like "User-Agent"
+        headers[Constants.AsrsUserAgent] = ProductInfo.GetProductInfo();
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
@@ -72,36 +72,25 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
     internal IDictionary<string, string> GetRequestHeaders()
     {
         var headers = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-        SetCustomHeaders(headers);
-        CheckHeaders(headers, Constants.Headers.AsrsHeaderPrefix);
-        CheckHeaders(headers, Constants.Headers.AsrsInternalHeaderPrefix);
-        SetInternalHeaders(headers);
+        CheckHeadersPrefix(headers, Constants.Headers.AsrsHeaderPrefix, Constants.Headers.AsrsInternalHeaderPrefix);
+        SetInternalUserAgent(headers);
+        SetServerId(headers);
         return headers;
     }
 
-    internal virtual void SetInternalHeaders(IDictionary<string, string> headers)
-    {
-        // Fix issue: https://github.com/Azure/azure-signalr/issues/198
-        // .NET Framework has restriction about reserved string as the header name like "User-Agent"
-        headers[Constants.AsrsUserAgent] = ProductInfo.GetProductInfo();
+    protected abstract void SetInternalUserAgent(IDictionary<string, string> headers);
 
-        if (!string.IsNullOrEmpty(_serverId) && !headers.ContainsKey(Constants.Headers.AsrsServerId))
+    private static void CheckHeadersPrefix(IDictionary<string, string> headers, params string[] forbidPrefixes)
+    {
+        foreach (var (key, prefix) in from key in headers.Keys
+                                      from prefix in forbidPrefixes
+                                      where key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
+                                      select (key, prefix))
         {
-            headers.Add(Constants.Headers.AsrsServerId, _serverId);
+            throw new ArgumentException($"Invalid header {key}, custom header cannot startwith '{prefix}'");
         }
     }
 
-    protected abstract void SetCustomHeaders(IDictionary<string, string> headers);
-
-    private static void CheckHeaders(IDictionary<string, string> headers, string forbidPrefix)
-    {
-        var item = headers.Where(x => x.Key.StartsWith(forbidPrefix, StringComparison.InvariantCultureIgnoreCase));
-        if (item.Any())
-        {
-            var key = item.First().Key;
-            throw new ArgumentException($"Invalid header {key}, custom header cannot startwith '{forbidPrefix}'");
-        }
-    }
     private static Uri GetServiceUrl(IServiceEndpointProvider provider, string hubName, string connectionId, string target)
     {
         var baseUri = new UriBuilder(provider.GetServerEndpoint(hubName));
@@ -124,6 +113,14 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
             baseUri.Query = query;
         }
         return baseUri.Uri;
+    }
+
+    private void SetServerId(IDictionary<string, string> headers)
+    {
+        if (!string.IsNullOrEmpty(_serverId) && !headers.ContainsKey(Constants.Headers.AsrsServerId))
+        {
+            headers.Add(Constants.Headers.AsrsServerId, _serverId);
+        }
     }
 
     private sealed class GracefulLoggerFactory : ILoggerFactory
@@ -150,6 +147,7 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
         {
             _inner.Dispose();
         }
+
         private sealed class GracefulLogger : ILogger
         {
             private readonly ILogger _inner;
@@ -160,10 +158,12 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
             }
 
 #nullable disable
+
             public IDisposable BeginScope<TState>(TState state)
             {
                 return _inner.BeginScope(state);
             }
+
 #nullable enable
 
             public bool IsEnabled(LogLevel logLevel)

--- a/src/Microsoft.Azure.SignalR.Management/ManagementConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ManagementConnectionFactory.cs
@@ -17,18 +17,8 @@ internal class ManagementConnectionFactory(IOptions<ServiceManagerOptions> conte
 {
     private readonly string? _productInfo = context.Value.ProductInfo;
 
-    internal override void SetInternalHeaders(IDictionary<string, string> headers)
+    protected override void SetInternalUserAgent(IDictionary<string, string> headers)
     {
-        base.SetInternalHeaders(headers);
-
-        if (_productInfo != null)
-        {
-            headers[Constants.AsrsUserAgent] = _productInfo;
-        }
-    }
-
-    protected override void SetCustomHeaders(IDictionary<string, string> headers)
-    {
-        return;
+        headers[Constants.AsrsUserAgent] = _productInfo ?? ProductInfo.GetProductInfo();
     }
 }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ConnectionFactory.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ConnectionFactory.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.SignalR;
 
@@ -12,17 +11,15 @@ namespace Microsoft.Azure.SignalR;
 
 internal class ConnectionFactory : ConnectionFactoryBase
 {
-    private readonly IOptions<ServiceOptions> _options;
-
     public ConnectionFactory(IServerNameProvider nameProvider,
-                             IOptions<ServiceOptions> options,
                              ILoggerFactory loggerFactory) : base(nameProvider, loggerFactory)
     {
-        _options = options;
     }
 
-    protected override void SetCustomHeaders(IDictionary<string, string> headers)
+    protected override void SetInternalUserAgent(IDictionary<string, string> headers)
     {
-        _options.Value.CustomHeaderProvider?.Invoke(headers);
+        // Fix issue: https://github.com/Azure/azure-signalr/issues/198
+        // .NET Framework has restriction about reserved string as the header name like "User-Agent"
+        headers[Constants.AsrsUserAgent] = ProductInfo.GetProductInfo();
     }
 }

--- a/src/Microsoft.Azure.SignalR/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR/ServiceOptions.cs
@@ -72,12 +72,6 @@ public class ServiceOptions : IServiceEndpointOptions
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets the func to generate custom headers.
-    /// The headers key should not startwith "asrs-" or "x-asrs", as those are Azure SignalR Service SDK preserved headers and cannot be overwritten.
-    /// </summary>
-    public Action<IDictionary<string, string>>? CustomHeaderProvider { get; set; }
-
-    /// <summary>
     /// Gets or sets the func to set diagnostic client filter from <see cref="HttpContext" />.
     /// The clients will be regarded as diagnostic client only if the function returns true.
     /// </summary>

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/ConnectionFactoryTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/ConnectionFactoryTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
-namespace Microsoft.Azure.SignalR.Tests;
+namespace Microsoft.Azure.SignalR.AspNet.Tests;
 
 #nullable enable
 
@@ -15,12 +15,14 @@ public class ConnectionFactoryTests
     public void TestGetRequestHeaders()
     {
         var nameProvider = new DefaultServerNameProvider();
+
         var loggerFactory = NullLoggerFactory.Instance;
+
         var factory = new ConnectionFactory(nameProvider, loggerFactory);
 
         var headers = factory.GetRequestHeaders();
         Assert.True(headers.TryGetValue(Constants.AsrsUserAgent, out var productInfo));
-        Assert.StartsWith("Microsoft.Azure.SignalR/", productInfo);
+        Assert.StartsWith("Microsoft.Azure.SignalR.AspNet/", productInfo);
 
         Assert.True(headers.TryGetValue(Constants.Headers.AsrsServerId, out var serverId));
         Assert.Equal(nameProvider.GetName(), serverId);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ManagementConnectionFactoryTests.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ManagementConnectionFactoryTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests;
 
 public class ManagementConnectionFactoryTests
 {
-    private const string OptionsAsrsUserAgent = $"Microsoft.Azure.SignalR.Management.123456";
+    private const string OptionsAsrsUserAgent = $"Microsoft.Azure.SignalR.Foo/123456";
 
     [Theory]
     [InlineData(true)]
@@ -39,11 +39,35 @@ public class ManagementConnectionFactoryTests
 
         if (setManagementProductInfo)
         {
-            Assert.StartsWith("Microsoft.Azure.SignalR.Management", productInfo);
+            Assert.StartsWith("Microsoft.Azure.SignalR.Foo/", productInfo);
         }
         else
         {
-            Assert.StartsWith("Microsoft.Azure.SignalR.Common", productInfo);
+            Assert.StartsWith("Microsoft.Azure.SignalR.Management/", productInfo);
         }
+    }
+
+    [Fact]
+    public void TestGetServerIdInRequestHeaders()
+    {
+        var nameProvider1 = new DefaultServerNameProvider();
+        var nameProvider2 = new DefaultServerNameProvider();
+
+        var name1 = nameProvider1.GetName();
+        var name2 = nameProvider2.GetName();
+        Assert.NotEqual(name1, name2);
+
+        static string GetServerId(IServerNameProvider nameProvider)
+        {
+            var options = Options.Create(new ServiceManagerOptions());
+            var connectionFactory = new ManagementConnectionFactory(options, nameProvider, NullLoggerFactory.Instance);
+            var headers = connectionFactory.GetRequestHeaders();
+            Assert.True(headers.TryGetValue(Constants.Headers.AsrsServerId, out var serverId));
+            return serverId;
+        }
+
+        var serverId1 = GetServerId(nameProvider1);
+        var serverId2 = GetServerId(nameProvider2);
+        Assert.NotEqual(serverId1, serverId2);
     }
 }


### PR DESCRIPTION
This pull request focuses on improving the handling of headers in the `ConnectionFactory` classes and updating relevant tests to ensure proper functionality. The key changes include refactoring methods for setting headers, adding a new method for setting the internal user agent, and updating test cases accordingly.

Improvements to header handling:

* [`src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ConnectionFactory.cs`](diffhunk://#diff-91373915111d886ad1b53503ac299a9acdb358665a0e19b48788f75b40984540R18-R24): Added a new method `SetInternalUserAgent` to handle setting the user agent header, addressing an issue with .NET Framework restrictions on reserved strings as header names.
* [`src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs`](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L76-R104): Refactored methods to separate the setting of internal headers and user agent, and renamed methods for clarity. [[1]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6L76-R104) [[2]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6R153) [[3]](diffhunk://#diff-c22ed725ae9e014fb10ba7ce208d4600da9aa77419d229e94eca167ae9b937a6R164-R169)
* [`src/Microsoft.Azure.SignalR.Management/ManagementConnectionFactory.cs`](diffhunk://#diff-9c32f0d221ec5e0629be90e603c6ff2daf4f61a03a6a5eaecf4822fbb03c7efbL20-R27): Updated method overrides to use the new `SetInternalUserAgent` method for setting the user agent header.

Updates to test cases:

* [`test/Microsoft.Azure.SignalR.AspNet.Tests/ConnectionFactoryTests.cs`](diffhunk://#diff-ccc2392df126554b145baede3dc46e22a17883a021cd849c835e31d1a9db3590R1-R30): Added new test cases to validate the correct setting of request headers, including the user agent and server ID.
* [`test/Microsoft.Azure.SignalR.Management.Tests/ManagementConnectionFactoryTests.cs`](diffhunk://#diff-874bc4d4c7c4224c745202142a9f1bbf8d81d11c2c0128148b38dd339a6ff7cbL15-R15): Updated existing test cases to reflect changes in user agent header values. [[1]](diffhunk://#diff-874bc4d4c7c4224c745202142a9f1bbf8d81d11c2c0128148b38dd339a6ff7cbL15-R15) [[2]](diffhunk://#diff-874bc4d4c7c4224c745202142a9f1bbf8d81d11c2c0128148b38dd339a6ff7cbL42-R46)
* [`test/Microsoft.Azure.SignalR.Tests/ConnectionFactoryTests.cs`](diffhunk://#diff-c92460da843b465b662f9bc029d258b9458a272539c4ed6c440c44afb026bc15L40-R40): Modified test cases to ensure proper handling of custom headers and validation of user agent header format. [[1]](diffhunk://#diff-c92460da843b465b662f9bc029d258b9458a272539c4ed6c440c44afb026bc15L40-R40) [[2]](diffhunk://#diff-c92460da843b465b662f9bc029d258b9458a272539c4ed6c440c44afb026bc15L55-R58)