### PR TITLE
remove DisposeAsync in RestHubLifetimeManager

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -348,10 +348,6 @@ internal class RestHubLifetimeManager<THub> : HubLifetimeManager<THub>, IService
         await _restClient.SendWithRetryAsync(api, HttpMethod.Post, cancellationToken: cancellationToken);
     }
 
-#pragma warning disable CA1822
-    public Task DisposeAsync() => Task.CompletedTask;
-#pragma warning restore CA1822
-
     private static bool FilterExpectedResponse(HttpResponseMessage response, string expectedErrorCode) =>
         response.IsSuccessStatusCode
         || (response.StatusCode == HttpStatusCode.NotFound && response.Headers.TryGetValues(Headers.MicrosoftErrorCode, out var errorCodes) && errorCodes.First().Equals(expectedErrorCode, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
This pull request includes a small change to the `RestHubLifetimeManager.cs` file. The change removes the `DisposeAsync` method, which was previously disabled with a pragma directive.

Codebase simplification:

* [`src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs`](diffhunk://#diff-11de7506a2e3e980cb4dc1a7ce2b6d4e0cefe856329021ebfb647cbf94771da8L351-L354): Removed the `DisposeAsync` method and the associated pragma directives that were suppressing warnings for this method.