### PR TITLE
Expose an option for the netframework to configure the underlying WebSocket options

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/DispatcherHelper.cs
@@ -132,7 +132,10 @@ internal class DispatcherHelper
         var cf = configuration.Resolver.Resolve<IConnectionFactory>();
         if (cf == null)
         {
-            cf = new ConnectionFactory(serverNameProvider, loggerFactory);
+            cf = new ConnectionFactory(serverNameProvider, loggerFactory)
+            {
+                ConfigureServiceConnectionWebSocketOptions = options.ConfigureServiceConnectionWebSocketOptions
+            };
             configuration.Resolver.Register(typeof(IConnectionFactory), () => cf);
         }
 

--- a/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServiceOptions.cs
@@ -11,6 +11,7 @@ using System.Security.Claims;
 using Microsoft.Owin;
 
 namespace Microsoft.Azure.SignalR.AspNet;
+#nullable enable
 
 /// <summary>
 /// Configurable options when using Azure SignalR Service.
@@ -20,7 +21,7 @@ public class ServiceOptions : IServiceEndpointOptions
     public ServiceOptions()
     {
         var count = ConfigurationManager.ConnectionStrings.Count;
-        string connectionString = null;
+        string? connectionString = null;
         var endpoints = new List<ServiceEndpoint>();
         var connectionStringKeyPrefix = $"{Constants.Keys.ConnectionStringDefaultKey}:";
         for (var i = 0; i < count; i++)
@@ -82,7 +83,7 @@ public class ServiceOptions : IServiceEndpointOptions
     /// <summary>
     /// Gets or sets the proxy used when ServiceEndpoint will attempt to connect to Azure SignalR.
     /// </summary>
-    public IWebProxy Proxy { get; set; }
+    public IWebProxy? Proxy { get; set; }
 
     /// <summary>
     /// Specifies the mode for server sticky, when client is always routed to the server which it first /negotiate with, we call it "server sticky mode".
@@ -96,7 +97,14 @@ public class ServiceOptions : IServiceEndpointOptions
     /// Gets or sets the func to generate claims from <see cref="IOwinContext" />.
     /// The claims will be included in the auto-generated token for clients.
     /// </summary>
-    public Func<IOwinContext, IEnumerable<Claim>> ClaimsProvider { get; set; } = null;
+    public Func<IOwinContext, IEnumerable<Claim>>? ClaimsProvider { get; set; }
+
+    /// <summary>
+    /// Provide the ability to configure the underlying ClientWebSocketOptions for the WebSocketClient used to establish the server connection to the service
+    /// For example, you could specify the inner buffer used for each WebSocketClient by setting:
+    /// <code>options.ConfigureServiceConnectionWebSocketOptions = o => o.SetBuffer(0x1000, 0x1000);</code>
+    /// </summary>
+    public Action<System.Net.WebSockets.ClientWebSocketOptions>? ConfigureServiceConnectionWebSocketOptions { get; set; }
 
     /// <summary>
     /// Gets or sets the initial number of connections per hub from SDK to Azure SignalR Service. Default value is 5.
@@ -114,12 +122,12 @@ public class ServiceOptions : IServiceEndpointOptions
     /// <summary>
     /// Gets or sets the connection string of Azure SignalR Service instance.
     /// </summary>
-    public string ConnectionString { get; set; }
+    public string? ConnectionString { get; set; }
     /// <summary>
     /// Gets or sets the func to set diagnostic client filter from <see cref="IOwinContext" />.
     /// The clients will be regarded as diagnostic client only if the function returns true.
     /// </summary>
-    public Func<IOwinContext, bool> DiagnosticClientFilter { get; set; } = null;
+    public Func<IOwinContext, bool>? DiagnosticClientFilter { get; set; } = null;
 
     /// <summary>
     /// Customize the multiple endpoints used
@@ -145,5 +153,5 @@ public class ServiceOptions : IServiceEndpointOptions
     /// <summary>
     /// Gets applicationName, which will be used as a prefix to apply to each hub name
     /// </summary>
-    internal string ApplicationName { get; set; }
+    internal string ApplicationName { get; set; } = string.Empty;
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ConnectionFactoryBase.cs
@@ -21,6 +21,8 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
 
     private readonly string _serverId;
 
+    public Action<System.Net.WebSockets.ClientWebSocketOptions>? ConfigureServiceConnectionWebSocketOptions { get; init; }
+
     public ConnectionFactoryBase(IServerNameProvider nameProvider,
                                  ILoggerFactory loggerFactory)
     {
@@ -44,6 +46,7 @@ internal abstract class ConnectionFactoryBase : IConnectionFactory
         {
             Headers = GetRequestHeaders(),
             Proxy = provider.Proxy,
+            WebSocketConfiguration = ConfigureServiceConnectionWebSocketOptions,
         };
         var connection = new WebSocketConnectionContext(connectionOptions, _loggerFactory, accessTokenProvider);
 

--- a/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
+++ b/test/Microsoft.Azure.SignalR.AspNet.Tests/RunAzureSignalRTests.cs
@@ -844,12 +844,23 @@ public class RunAzureSignalRTests(ITestOutputHelper output) : VerifiableLoggedTe
         using (var logCollector = StartVerifiableLog(out var loggerFactory, LogLevel.Debug))
         using (new AppSettingsConfigScope(ConnectionString))
         {
+            var logger = loggerFactory.CreateLogger(nameof(TestRunAzureSignalStartsServerConnection));
             var hubConfig = Utility.GetTestHubConfig(loggerFactory);
             var hubName = "hub";
             var testHub = new TestHubManager(hubName);
             hubConfig.Resolver.Register(typeof(IHubManager), () => testHub);
+            var bufferSize = 0x100;
+            var bufferLog = $"Buffer set to {bufferSize}";
             using (WebApp.Start(ServiceUrl, app => app.RunAzureSignalR(AppName, hubConfig,
-                o => o.InitialHubServerConnectionCount = 1
+                o =>
+                {
+                    o.InitialHubServerConnectionCount = 1;
+                    o.ConfigureServiceConnectionWebSocketOptions = i =>
+                    {
+                        i.SetBuffer(bufferSize, bufferSize);
+                        logger.LogInformation(bufferLog);
+                    };
+                }
             )))
             {
                 var options = hubConfig.Resolver.Resolve<IServiceConnectionManager>();
@@ -863,6 +874,7 @@ public class RunAzureSignalRTests(ITestOutputHelper output) : VerifiableLoggedTe
             logCollector.Expects("StartTransport");
             logCollector.Expects("TransportStopping");
             logCollector.Expects("FailedToConnect");
+            logCollector.Expects(i => i.Write.Message == bufferLog);
         }
     }
 


### PR DESCRIPTION
#1928 exposes a performance issue in NetFramework ClientWebSocket connection, exposing the underlying ClientWebSocketOptions configure so that users are able to configure it differently based on their user scenarios.
