### PR TITLE
Support distributed tracing in server sdk.

### DIFF
--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -136,11 +137,20 @@ namespace Microsoft.Azure.SignalR
             // Exception handling follows https://source.dot.net/#Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs,349
             try
             {
-                return await task;
+                var result = await task;
+                Activity.Current?.Stop();
+                return result;
             }
-            catch
+            catch (Exception ex)
             {
                 _clientInvocationManager.Caller.RemoveInvocation(invocationId);
+                var currentActivity = Activity.Current;
+                if (currentActivity is not null)
+                {
+                    currentActivity.SetStatus(ActivityStatusCode.Error);
+                    currentActivity.SetTag("error.type", ex.GetType().FullName);
+                    currentActivity.Stop();
+                }
                 throw;
             }
         }

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET7_0_OR_GREATER
 using System.Diagnostics;
+#endif
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Internals;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,18 +18,25 @@ namespace Microsoft.Azure.SignalR;
 
 internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<THub> where THub : Hub
 {
+    internal const string ActivityName = "Microsoft.Azure.SignalR.Client.InvocationOut";
+
     protected const string NullOrEmptyStringErrorMessage = "Argument cannot be null or empty.";
     protected const string TtlOutOfRangeErrorMessage = "Ttl cannot be less than 0.";
     protected readonly IServiceConnectionManager<THub> ServiceConnectionContainer;
+
     protected ILogger Logger { get; set; }
 
     private readonly DefaultHubMessageSerializer _messageSerializer;
+    private readonly ActivitySource _activitySource;
+    private readonly string _serviceName;
 
     public ServiceLifetimeManagerBase(IServiceConnectionManager<THub> serviceConnectionManager, IHubProtocolResolver protocolResolver, IOptions<HubOptions> globalHubOptions, IOptions<HubOptions<THub>> hubOptions, ILogger logger)
     {
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         ServiceConnectionContainer = serviceConnectionManager;
         _messageSerializer = new DefaultHubMessageSerializer(protocolResolver, globalHubOptions.Value.SupportedProtocols, hubOptions.Value.SupportedProtocols);
+        _activitySource = SignalRClientActivitySource.Instance.ActivitySource;
+        _serviceName = typeof(THub).Name;
     }
 
     public override Task OnConnectedAsync(HubConnectionContext connection)
@@ -295,6 +304,12 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
         {
             message = new InvocationMessage(invocationId, method, args);
         }
+        var activity = CreateActivity(method);
+        if (activity is not null)
+        {
+            activity.Start();
+            InjectHeaders(activity, message);
+        }
         var serializedHubMessages = _messageSerializer.SerializeMessage(message);
         var payloads = new ArrayDictionary<string, ReadOnlyMemory<byte>>(serializedHubMessages.Count);
         foreach (var serializedMessage in serializedHubMessages)
@@ -302,6 +317,43 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             payloads.Add(serializedMessage.ProtocolName, serializedMessage.Serialized);
         }
         return payloads;
+    }
+
+    private Activity CreateActivity(string methodName)
+    {
+        var activity = _activitySource.CreateActivity(ActivityName, ActivityKind.Client);
+        if (activity is null && Activity.Current is not null && Logger.IsEnabled(LogLevel.Critical))
+        {
+            activity = new Activity(ActivityName);
+        }
+
+        if (activity is not null)
+        {
+            if (!string.IsNullOrEmpty(_serviceName))
+            {
+                activity.DisplayName = $"{_serviceName}/{methodName}";
+                activity.SetTag("rpc.service", _serviceName);
+            }
+            else
+            {
+                activity.DisplayName = methodName;
+            }
+
+            activity.SetTag("rpc.system", "signalr");
+            activity.SetTag("rpc.method", methodName);
+        }
+
+        return activity;
+    }
+
+    private static void InjectHeaders(Activity activity, HubInvocationMessage invocationMessage)
+    {
+        DistributedContextPropagator.Current.Inject(activity, invocationMessage, static (carrier, key, value) =>
+        {
+            var invocationMessage = (HubInvocationMessage)carrier;
+            invocationMessage.Headers ??= new Dictionary<string, string>();
+            invocationMessage.Headers[key] = value;
+        });
     }
 
     protected IDictionary<string, ReadOnlyMemory<byte>> SerializeAllProtocols(HubMessage message)

--- a/src/Microsoft.Azure.SignalR/Internals/SignalRClientActivitySource.cs
+++ b/src/Microsoft.Azure.SignalR/Internals/SignalRClientActivitySource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Azure.SignalR.Internals;
+
+internal sealed class SignalRClientActivitySource
+{
+    public static readonly SignalRClientActivitySource Instance = new();
+
+    public ActivitySource ActivitySource { get; } = new ActivitySource("Microsoft.Azure.SignalR.Client");
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.Azure.SignalR.Internals;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
@@ -263,6 +265,83 @@ public class ServiceLifetimeManagerFacts
         Assert.Null(hubConnectionContext.Features.Get<ServiceUserIdFeature>());
     }
 
+    [Theory]
+    [InlineData("SendAllAsync", typeof(BroadcastDataMessage))]
+    [InlineData("SendAllExceptAsync", typeof(BroadcastDataMessage))]
+    [InlineData("SendConnectionAsync", typeof(MultiConnectionDataMessage))]
+    [InlineData("SendConnectionsAsync", typeof(MultiConnectionDataMessage))]
+    [InlineData("SendGroupAsync", typeof(GroupBroadcastDataMessage))]
+    [InlineData("SendGroupsAsync", typeof(MultiGroupBroadcastDataMessage))]
+    [InlineData("SendGroupExceptAsync", typeof(GroupBroadcastDataMessage))]
+    [InlineData("SendUserAsync", typeof(UserDataMessage))]
+    [InlineData("SendUsersAsync", typeof(MultiUserDataMessage))]
+    public async Task ServiceLifetimeManagerTraceTest(string methodName, Type messageType)
+    {
+        var proxy = new ServiceConnectionProxy();
+        var blazorDetector = new DefaultBlazorDetector();
+
+        var serviceConnectionManager = new ServiceConnectionManager<TestHub>();
+        serviceConnectionManager.SetServiceConnection(proxy.ServiceConnectionContainer);
+        var clientInvocationManager = new DefaultClientInvocationManager();
+
+        var serverSource = SignalRClientActivitySource.Instance.ActivitySource;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
+            proxy.ClientConnectionManager, HubProtocolResolver, Logger, Marker, GlobalHubOptions, LocalHubOptions, blazorDetector, new DefaultServerNameProvider(), clientInvocationManager);
+
+        var serverTask = proxy.WaitForServerConnectionAsync(1);
+        _ = proxy.StartAsync();
+        await proxy.WaitForServerConnectionsInited().OrTimeout();
+        await serverTask.OrTimeout();
+
+        var task = proxy.WaitForApplicationMessageAsync(messageType);
+
+        var invokeTask = InvokeMethod(serviceLifetimeManager, methodName);
+
+        var message = await task.OrTimeout();
+
+        if (typeof(IAckableMessage).IsAssignableFrom(messageType))
+        {
+            var ackId = (message as IAckableMessage).AckId;
+            Assert.NotEqual(0, ackId);
+            await proxy.WriteMessageAsync(new AckMessage(ackId, (int)AckStatus.Ok));
+        }
+
+        // Need to return in time, or it indicate a timeout when sending ack-able messages.
+        await invokeTask.OrTimeout();
+
+        VerifyServiceMessage(methodName, message);
+
+        var multicastDataMessage = Assert.IsAssignableFrom<MulticastDataMessage>(message);
+        Assert.Equal(2, multicastDataMessage.Payloads.Count);
+
+        Assert.True(multicastDataMessage.Payloads.ContainsKey("json"));
+        ReadOnlySequence<byte> jsonPayload = new(multicastDataMessage.Payloads["json"]);
+        new SignalRProtocol.JsonHubProtocol().TryParseMessage(ref jsonPayload, new TestHubInvocationBinder(), out var jsonMessage);
+        var jsonInvocationMessage = Assert.IsAssignableFrom<SignalRProtocol.HubInvocationMessage>(jsonMessage);
+        Assert.NotEmpty(jsonInvocationMessage.Headers);
+        Assert.Contains(jsonInvocationMessage.Headers, h => h.Key == "traceparent");
+        Assert.NotEmpty(jsonInvocationMessage.Headers["traceparent"]);
+
+        Assert.True(multicastDataMessage.Payloads.ContainsKey("messagepack"));
+        ReadOnlySequence<byte> messagePackPayload = new(multicastDataMessage.Payloads["messagepack"]);
+        new SignalRProtocol.MessagePackHubProtocol().TryParseMessage(ref messagePackPayload, new TestHubInvocationBinder(), out var messagePackMessage);
+        var messagePackInvocationMessage = Assert.IsAssignableFrom<SignalRProtocol.HubInvocationMessage>(messagePackMessage);
+        Assert.NotEmpty(messagePackInvocationMessage.Headers);
+        Assert.Contains(messagePackInvocationMessage.Headers, h => h.Key == "traceparent");
+        Assert.NotEmpty(messagePackInvocationMessage.Headers["traceparent"]);
+
+        Assert.Equal(jsonInvocationMessage.Headers["traceparent"], messagePackInvocationMessage.Headers["traceparent"]);
+    }
+
     private static async Task InvokeMethod(HubLifetimeManager<TestHub> serviceLifetimeManager, string methodName)
     {
         switch (methodName)
@@ -421,5 +500,14 @@ public class ServiceLifetimeManagerFacts
         {
             throw new NotImplementedException();
         }
+    }
+
+    private sealed class TestHubInvocationBinder : IInvocationBinder
+    {
+        public IReadOnlyList<Type> GetParameterTypes(string methodName) => new[] { typeof(string) };
+
+        public Type GetReturnType(string invocationId) => typeof(void);
+
+        public Type GetStreamItemType(string streamId) => typeof(int);
     }
 }


### PR DESCRIPTION
This pull request introduces changes to improve activity tracking and error handling within the SignalR service. The changes include adding activity creation and propagation, as well as enhancing error handling by setting activity status and tags.

Improvements to activity tracking:

* [`src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs`](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L139-R153): Stopped the current activity after task completion and set activity status and tags in case of an exception.
* [`src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs`](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R21-R39): Added `ActivitySource` and `_serviceName` fields, created and started activities for method invocations, and injected headers for distributed tracing. [[1]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R21-R39) [[2]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R307-R312) [[3]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R322-R358)

Enhancements to error handling:

* [`src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs`](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L139-R153): Enhanced exception handling by setting activity status and tags before stopping the activity.

New utility class:

* [`src/Microsoft.Azure.SignalR/Internals/SignalRClientActivitySource.cs`](diffhunk://#diff-baf88e8baec689355300840f5d3b60b1da9ae9d4a97e248829858fb48bc87252R1-R13): Introduced a new class to provide a singleton instance of `ActivitySource` for SignalR client activities.