### PR TITLE
Add hub name to constructor

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubInstanceFactories/ServiceHubLifetimeManagerFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.SignalR.Management
                         var container = _serviceProvider.GetRequiredService<IServiceConnectionContainer>();
                         var connectionManager = new ServiceConnectionManager<THub>();
                         connectionManager.SetServiceConnection(container);
-                        return ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<THub>>(_serviceProvider, connectionManager);
+                        return ActivatorUtilities.CreateInstance<WebSocketsHubLifetimeManager<THub>>(_serviceProvider, connectionManager, hubName);
                     }
                 case ServiceTransportType.Transient:
                     {

--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -26,13 +26,13 @@ internal class WebSocketsHubLifetimeManager<THub> : ServiceLifetimeManagerBase<T
 
     public WebSocketsHubLifetimeManager(IServiceConnectionManager<THub> serviceConnectionManager, IHubProtocolResolver protocolResolver,
         IOptions<HubOptions> globalHubOptions, IOptions<HubOptions<THub>> hubOptions, ILoggerFactory loggerFactory, IOptions<ServiceManagerOptions> serviceManagerOptions,
-        IClientInvocationManager clientInvocationManager, IServerNameProvider serverNameProvider) :
+        IClientInvocationManager clientInvocationManager, IServerNameProvider serverNameProvider, string hubName) :
         base(serviceConnectionManager, protocolResolver, globalHubOptions, hubOptions, loggerFactory?.CreateLogger(nameof(WebSocketsHubLifetimeManager<Hub>)))
     {
         _serviceManagerOptions = serviceManagerOptions ?? throw new ArgumentNullException(nameof(serviceManagerOptions));
         _clientInvocationManager = clientInvocationManager;
         _callerId = serverNameProvider.GetName();
-        _hub = typeof(THub).Name;
+        _hub = hubName;
     }
 
     public Task RemoveFromAllGroupsAsync(string connectionId, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Azure.SignalR.Management.Tests/WebsocketsHubLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/WebsocketsHubLifetimeManagerFacts.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         private readonly Mock<IOptions<ServiceManagerOptions>> _serviceManagerOptionsMock;
         private readonly Mock<IClientInvocationManager> _clientInvocationManagerMock;
         private readonly Mock<IServerNameProvider> _serverNameProviderMock;
+        private readonly string _hubName = "TestHub";
 
         public WebsocketsHubLifetimeManagerFacts()
         {
@@ -54,7 +55,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 _loggerFactoryMock.Object,
                 _serviceManagerOptionsMock.Object,
                 _clientInvocationManagerMock.Object,
-                _serverNameProviderMock.Object
+                _serverNameProviderMock.Object,
+                _hubName
             );
 
             // Assert
@@ -75,7 +77,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 _loggerFactoryMock.Object,
                 _serviceManagerOptionsMock.Object,
                 _clientInvocationManagerMock.Object,
-                _serverNameProviderMock.Object
+                _serverNameProviderMock.Object,
+                _hubName
             );
 
             var connectionId = "test-connection-id";
@@ -111,7 +114,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 _loggerFactoryMock.Object,
                 _serviceManagerOptionsMock.Object,
                 _clientInvocationManagerMock.Object,
-                _serverNameProviderMock.Object
+                _serverNameProviderMock.Object,
+                _hubName
             );
 
             string invalidConnectionId = null!;
@@ -135,7 +139,8 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 _loggerFactoryMock.Object,
                 _serviceManagerOptionsMock.Object,
                 _clientInvocationManagerMock.Object,
-                _serverNameProviderMock.Object
+                _serverNameProviderMock.Object,
+                _hubName
             );
 
             var connectionId = "test-connection-id";


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
- Inject hub name during lifetime manager creation since THub name may not matches the actual hub name
