### PR TITLE
Support distributed tracing in server sdk.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -274,7 +274,7 @@ internal class WebSocketsHubLifetimeManager<THub> : ServiceLifetimeManagerBase<T
         var cancellationTokenInUse = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token;
            
         var invocationId = _clientInvocationManager.Caller.GenerateInvocationId(connectionId);
-        var message = AppendMessageTracingId(new ClientInvocationMessage(invocationId, connectionId, _callerId, SerializeAllProtocols(methodName, args, invocationId)));
+        var message = AppendMessageTracingId(new ClientInvocationMessage(invocationId, connectionId, _callerId, SerializeAllProtocols(methodName, args, null, invocationId)));
         await WriteAsync(message);
         var task = _clientInvocationManager.Caller.AddInvocation<T>(_hub, connectionId, invocationId, cancellationTokenInUse);
 

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManager.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,12 +89,15 @@ namespace Microsoft.Azure.SignalR
 
             if (_clientConnectionManager.TryGetClientConnection(connectionId, out var clientConnection))
             {
-                var message = CreateMessage(connectionId, methodName, args, clientConnection);
+                var activity = CreateActivity(methodName);
+                activity?.Start();
+                var message = CreateMessage(connectionId, methodName, args, clientConnection, activity);
                 var messageWithTracingId = (IMessageWithTracingId)message;
                 try
                 {
                     // Write directly to this connection
                     await clientConnection.ServiceConnection.WriteAsync(message);
+                    activity?.Stop();
 
                     if (messageWithTracingId.TracingId != null)
                     {
@@ -102,11 +106,26 @@ namespace Microsoft.Azure.SignalR
                 }
                 catch (ServiceConnectionNotActiveException)
                 {
-                    // Fallback to send message through other server connections
-                    // Although in current design the server connection drop leads to routed client connection drops
-                    // The message thrown here is misleading to the customer
-                    // Also sending the message back provides the support when later we support client connection migration
-                    await WriteAsync(message);
+                    try
+                    {
+                        // Fallback to send message through other server connections
+                        // Although in current design the server connection drop leads to routed client connection drops
+                        // The message thrown here is misleading to the customer
+                        // Also sending the message back provides the support when later we support client connection migration
+                        await WriteAsync(message);
+                        activity?.Stop();
+                    }
+                    catch (Exception ex)
+                    {
+                        if (activity is not null)
+                        {
+                            activity.SetStatus(ActivityStatusCode.Error);
+                            activity.SetTag("error.type", ex.GetType().FullName);
+                            activity.Stop();
+                        }
+
+                        throw;
+                    }
                 }
             }
             else
@@ -129,18 +148,28 @@ namespace Microsoft.Azure.SignalR
             }
 
             var invocationId = _clientInvocationManager.Caller.GenerateInvocationId(connectionId);
-            var message = AppendMessageTracingId(new ClientInvocationMessage(invocationId, connectionId, _callerId, SerializeAllProtocols(methodName, args, invocationId)));
+            var activity = CreateActivity(methodName);
+            var message = AppendMessageTracingId(new ClientInvocationMessage(invocationId, connectionId, _callerId, SerializeAllProtocols(methodName, args, activity, invocationId)));
             await WriteAsync(message);
             var task = _clientInvocationManager.Caller.AddInvocation<T>(_hub, connectionId, invocationId, cancellationToken);
 
             // Exception handling follows https://source.dot.net/#Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs,349
             try
             {
-                return await task;
+                activity?.Start();
+                var result = await task;
+                activity?.Stop();
+                return result;
             }
-            catch
+            catch (Exception ex)
             {
                 _clientInvocationManager.Caller.RemoveInvocation(invocationId);
+                if (activity is not null)
+                {
+                    activity.SetStatus(ActivityStatusCode.Error);
+                    activity.SetTag("error.type", ex.GetType().FullName);
+                    activity.Stop();
+                }
                 throw;
             }
         }
@@ -186,7 +215,7 @@ namespace Microsoft.Azure.SignalR
         }
 #endif
 
-        private MultiConnectionDataMessage CreateMessage(string connectionId, string methodName, object[] args, IClientConnection clientConnection)
+        private MultiConnectionDataMessage CreateMessage(string connectionId, string methodName, object[] args, IClientConnection clientConnection, Activity activity)
         {
             IDictionary<string, ReadOnlyMemory<byte>> payloads;
             if (clientConnection.HubProtocol != null)
@@ -198,7 +227,7 @@ namespace Microsoft.Azure.SignalR
             }
             else
             {
-                payloads = SerializeAllProtocols(methodName, args);
+                payloads = SerializeAllProtocols(methodName, args, activity);
             }
 
             // don't use ConnectionDataMessage here, since handshake message is also wrapped into ConnectionDataMessage.

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Internals;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,18 +18,25 @@ namespace Microsoft.Azure.SignalR;
 
 internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<THub> where THub : Hub
 {
+    internal const string ActivityName = "Microsoft.Azure.SignalR.Server.InvocationOut";
+
     protected const string NullOrEmptyStringErrorMessage = "Argument cannot be null or empty.";
     protected const string TtlOutOfRangeErrorMessage = "Ttl cannot be less than 0.";
     protected readonly IServiceConnectionManager<THub> ServiceConnectionContainer;
+
     protected ILogger Logger { get; set; }
 
     private readonly DefaultHubMessageSerializer _messageSerializer;
+    private readonly ActivitySource _activitySource;
+    private readonly string _serviceName;
 
     public ServiceLifetimeManagerBase(IServiceConnectionManager<THub> serviceConnectionManager, IHubProtocolResolver protocolResolver, IOptions<HubOptions> globalHubOptions, IOptions<HubOptions<THub>> hubOptions, ILogger logger)
     {
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         ServiceConnectionContainer = serviceConnectionManager;
         _messageSerializer = new DefaultHubMessageSerializer(protocolResolver, globalHubOptions.Value.SupportedProtocols, hubOptions.Value.SupportedProtocols);
+        _activitySource = SignalRServerActivitySource.Instance.ActivitySource;
+        _serviceName = typeof(THub).Name;
     }
 
     public override Task OnConnectedAsync(HubConnectionContext connection)
@@ -47,12 +56,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new BroadcastDataMessage(null, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToBroadcastMessage(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds, CancellationToken cancellationToken = default)
@@ -62,12 +73,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new BroadcastDataMessage(excludedIds, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToBroadcastMessage(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendConnectionAsync(string connectionId, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -82,12 +95,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new MultiConnectionDataMessage(new[] { connectionId }, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new MultiConnectionDataMessage(new[] { connectionId }, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToSendMessageToConnections(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -107,12 +122,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             return Task.CompletedTask;
         }
 
-        var message = AppendMessageTracingId(new MultiConnectionDataMessage(connectionIds, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new MultiConnectionDataMessage(connectionIds, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToSendMessageToConnections(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendGroupAsync(string groupName, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -127,12 +144,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new GroupBroadcastDataMessage(groupName, null, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new GroupBroadcastDataMessage(groupName, null, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToBroadcastMessageToGroup(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -152,14 +171,16 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             return Task.CompletedTask;
         }
 
-        var message = AppendMessageTracingId(new MultiGroupBroadcastDataMessage(groupNames, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new MultiGroupBroadcastDataMessage(groupNames, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToBroadcastMessageToGroups(Logger, message);
         }
         // Send this message from a random service connection because this message involves of multiple groups.
         // Unless we send message for each group one by one, we can not guarantee the message order for all groups.
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds, CancellationToken cancellationToken = default)
@@ -174,12 +195,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new GroupBroadcastDataMessage(groupName, excludedIds, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new GroupBroadcastDataMessage(groupName, excludedIds, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToBroadcastMessageToGroup(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendUserAsync(string userId, string methodName, object[] args, CancellationToken cancellationToken = default)
@@ -194,12 +217,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(methodName));
         }
 
-        var message = AppendMessageTracingId(new UserDataMessage(userId, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new UserDataMessage(userId, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToSendMessageToUser(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args,
@@ -220,12 +245,14 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             return Task.CompletedTask;
         }
 
-        var message = AppendMessageTracingId(new MultiUserDataMessage(userIds, SerializeAllProtocols(methodName, args)));
+        var activity = CreateActivity(methodName);
+        activity?.Start();
+        var message = AppendMessageTracingId(new MultiUserDataMessage(userIds, SerializeAllProtocols(methodName, args, activity)));
         if (message.TracingId != null)
         {
             MessageLog.StartToSendMessageToUsers(Logger, message);
         }
-        return WriteAsync(message);
+        return WriteAsync(message, activity);
     }
 
     public override Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
@@ -268,6 +295,26 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
         return WriteAckableMessageAsync(message, cancellationToken);
     }
 
+    protected async Task WriteAsync<T>(T message, Activity activity) where T : ServiceMessage, IMessageWithTracingId
+    {
+        if (activity is not null)
+        {
+            try
+            {
+                await WriteAsync(message);
+                activity.Stop();
+            }
+            catch (Exception ex)
+            {
+                activity.SetStatus(ActivityStatusCode.Error);
+                activity.SetTag("error.type", ex.GetType().FullName);
+                activity.Stop();
+
+                throw;
+            }
+        }
+    }
+
     protected Task WriteAsync<T>(T message) where T : ServiceMessage, IMessageWithTracingId =>
         WriteCoreAsync(message, m => ServiceConnectionContainer.WriteAsync(message));
 
@@ -284,7 +331,7 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
         return list == null;
     }
 
-    protected IDictionary<string, ReadOnlyMemory<byte>> SerializeAllProtocols(string method, object[] args, string invocationId = null)
+    protected IDictionary<string, ReadOnlyMemory<byte>> SerializeAllProtocols(string method, object[] args, Activity activity, string invocationId = null)
     {
         InvocationMessage message;
         if (invocationId == null)
@@ -295,6 +342,10 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
         {
             message = new InvocationMessage(invocationId, method, args);
         }
+        if (activity is not null)
+        {
+            InjectHeaders(activity, message);
+        }
         var serializedHubMessages = _messageSerializer.SerializeMessage(message);
         var payloads = new ArrayDictionary<string, ReadOnlyMemory<byte>>(serializedHubMessages.Count);
         foreach (var serializedMessage in serializedHubMessages)
@@ -302,6 +353,43 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
             payloads.Add(serializedMessage.ProtocolName, serializedMessage.Serialized);
         }
         return payloads;
+    }
+
+    protected Activity CreateActivity(string methodName)
+    {
+        var activity = _activitySource.CreateActivity(ActivityName, ActivityKind.Client);
+        if (activity is null && Activity.Current is not null && Logger.IsEnabled(LogLevel.Critical))
+        {
+            activity = new Activity(ActivityName);
+        }
+
+        if (activity is not null)
+        {
+            if (!string.IsNullOrEmpty(_serviceName))
+            {
+                activity.DisplayName = $"{_serviceName}/{methodName}";
+                activity.SetTag("rpc.service", _serviceName);
+            }
+            else
+            {
+                activity.DisplayName = methodName;
+            }
+
+            activity.SetTag("rpc.system", "signalr");
+            activity.SetTag("rpc.method", methodName);
+        }
+
+        return activity;
+    }
+
+    private static void InjectHeaders(Activity activity, HubInvocationMessage invocationMessage)
+    {
+        DistributedContextPropagator.Current.Inject(activity, invocationMessage, static (carrier, key, value) =>
+        {
+            var invocationMessage = (HubInvocationMessage)carrier;
+            invocationMessage.Headers ??= new Dictionary<string, string>();
+            invocationMessage.Headers[key] = value;
+        });
     }
 
     protected IDictionary<string, ReadOnlyMemory<byte>> SerializeAllProtocols(HubMessage message)

--- a/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/ServiceLifetimeManagerBase.cs
@@ -313,6 +313,10 @@ internal abstract class ServiceLifetimeManagerBase<THub> : HubLifetimeManager<TH
                 throw;
             }
         }
+        else
+        {
+            await WriteAsync(message);
+        }
     }
 
     protected Task WriteAsync<T>(T message) where T : ServiceMessage, IMessageWithTracingId =>

--- a/src/Microsoft.Azure.SignalR/Internals/SignalRServerActivitySource.cs
+++ b/src/Microsoft.Azure.SignalR/Internals/SignalRServerActivitySource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Azure.SignalR.Internals;
+
+internal sealed class SignalRServerActivitySource
+{
+    public static readonly SignalRServerActivitySource Instance = new();
+
+    public ActivitySource ActivitySource { get; } = new ActivitySource("Microsoft.Azure.SignalR.Server");
+}

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceLifetimeManagerFacts.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.Azure.SignalR.Internals;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
@@ -263,6 +265,83 @@ public class ServiceLifetimeManagerFacts
         Assert.Null(hubConnectionContext.Features.Get<ServiceUserIdFeature>());
     }
 
+    [Theory]
+    [InlineData("SendAllAsync", typeof(BroadcastDataMessage))]
+    [InlineData("SendAllExceptAsync", typeof(BroadcastDataMessage))]
+    [InlineData("SendConnectionAsync", typeof(MultiConnectionDataMessage))]
+    [InlineData("SendConnectionsAsync", typeof(MultiConnectionDataMessage))]
+    [InlineData("SendGroupAsync", typeof(GroupBroadcastDataMessage))]
+    [InlineData("SendGroupsAsync", typeof(MultiGroupBroadcastDataMessage))]
+    [InlineData("SendGroupExceptAsync", typeof(GroupBroadcastDataMessage))]
+    [InlineData("SendUserAsync", typeof(UserDataMessage))]
+    [InlineData("SendUsersAsync", typeof(MultiUserDataMessage))]
+    public async Task ServiceLifetimeManagerTraceTest(string methodName, Type messageType)
+    {
+        var proxy = new ServiceConnectionProxy();
+        var blazorDetector = new DefaultBlazorDetector();
+
+        var serviceConnectionManager = new ServiceConnectionManager<TestHub>();
+        serviceConnectionManager.SetServiceConnection(proxy.ServiceConnectionContainer);
+        var clientInvocationManager = new DefaultClientInvocationManager();
+
+        var serverSource = SignalRServerActivitySource.Instance.ActivitySource;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var serviceLifetimeManager = new ServiceLifetimeManager<TestHub>(serviceConnectionManager,
+            proxy.ClientConnectionManager, HubProtocolResolver, Logger, Marker, GlobalHubOptions, LocalHubOptions, blazorDetector, new DefaultServerNameProvider(), clientInvocationManager);
+
+        var serverTask = proxy.WaitForServerConnectionAsync(1);
+        _ = proxy.StartAsync();
+        await proxy.WaitForServerConnectionsInited().OrTimeout();
+        await serverTask.OrTimeout();
+
+        var task = proxy.WaitForApplicationMessageAsync(messageType);
+
+        var invokeTask = InvokeMethod(serviceLifetimeManager, methodName);
+
+        var message = await task.OrTimeout();
+
+        if (typeof(IAckableMessage).IsAssignableFrom(messageType))
+        {
+            var ackId = (message as IAckableMessage).AckId;
+            Assert.NotEqual(0, ackId);
+            await proxy.WriteMessageAsync(new AckMessage(ackId, (int)AckStatus.Ok));
+        }
+
+        // Need to return in time, or it indicate a timeout when sending ack-able messages.
+        await invokeTask.OrTimeout();
+
+        VerifyServiceMessage(methodName, message);
+
+        var multicastDataMessage = Assert.IsAssignableFrom<MulticastDataMessage>(message);
+        Assert.Equal(2, multicastDataMessage.Payloads.Count);
+
+        Assert.True(multicastDataMessage.Payloads.ContainsKey("json"));
+        ReadOnlySequence<byte> jsonPayload = new(multicastDataMessage.Payloads["json"]);
+        new SignalRProtocol.JsonHubProtocol().TryParseMessage(ref jsonPayload, new TestHubInvocationBinder(), out var jsonMessage);
+        var jsonInvocationMessage = Assert.IsAssignableFrom<SignalRProtocol.HubInvocationMessage>(jsonMessage);
+        Assert.NotEmpty(jsonInvocationMessage.Headers);
+        Assert.Contains(jsonInvocationMessage.Headers, h => h.Key == "traceparent");
+        Assert.NotEmpty(jsonInvocationMessage.Headers["traceparent"]);
+
+        Assert.True(multicastDataMessage.Payloads.ContainsKey("messagepack"));
+        ReadOnlySequence<byte> messagePackPayload = new(multicastDataMessage.Payloads["messagepack"]);
+        new SignalRProtocol.MessagePackHubProtocol().TryParseMessage(ref messagePackPayload, new TestHubInvocationBinder(), out var messagePackMessage);
+        var messagePackInvocationMessage = Assert.IsAssignableFrom<SignalRProtocol.HubInvocationMessage>(messagePackMessage);
+        Assert.NotEmpty(messagePackInvocationMessage.Headers);
+        Assert.Contains(messagePackInvocationMessage.Headers, h => h.Key == "traceparent");
+        Assert.NotEmpty(messagePackInvocationMessage.Headers["traceparent"]);
+
+        Assert.Equal(jsonInvocationMessage.Headers["traceparent"], messagePackInvocationMessage.Headers["traceparent"]);
+    }
+
     private static async Task InvokeMethod(HubLifetimeManager<TestHub> serviceLifetimeManager, string methodName)
     {
         switch (methodName)
@@ -421,5 +500,14 @@ public class ServiceLifetimeManagerFacts
         {
             throw new NotImplementedException();
         }
+    }
+
+    private sealed class TestHubInvocationBinder : IInvocationBinder
+    {
+        public IReadOnlyList<Type> GetParameterTypes(string methodName) => new[] { typeof(string) };
+
+        public Type GetReturnType(string invocationId) => typeof(void);
+
+        public Type GetStreamItemType(string streamId) => typeof(int);
     }
 }


### PR DESCRIPTION
This pull request introduces activity tracing from app server to SignalR clients. The changes include creating and managing `Activity` instances to trace method calls and their outcomes, enhancing the observability of the service.

### Tracing Enhancements:

* [`ServiceLifetimeManagerBase.cs`](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R21-R39): Introduced `Activity` creation and management for various methods like `SendAllAsync`, `SendAllExceptAsync`, `SendConnectionAsync`, etc., and added a method `CreateActivity` to initialize `Activity` instances. [[1]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R21-R39) [[2]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L50-R66) [[3]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L65-R83) [[4]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L85-R105) [[5]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L110-R132) [[6]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L130-R154) [[7]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L155-R183) [[8]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L177-R205) [[9]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L197-R227) [[10]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L223-R255) [[11]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R298-R317) [[12]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268L287-R334) [[13]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R345-R348) [[14]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R358-R394)

* [`ServiceLifetimeManager.cs`](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L91-R128): Updated methods like `SendConnectionAsync` and `InvokeConnectionAsync` to create and start `Activity` instances, and handle exceptions by setting error status and tags on the `Activity`. [[1]](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L91-R128) [[2]](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L132-R172)

### Method Signature Changes:

* `CreateMessage` method in `ServiceLifetimeManager.cs`: Added an `Activity` parameter to include tracing information in the message creation process. [[1]](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L189-R218) [[2]](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L201-R230)

### Dependency Additions:

* Added `System.Diagnostics` and `Microsoft.Azure.SignalR.Internals` namespaces to support activity tracing. [[1]](diffhunk://#diff-fb7462d3e47387f4a5325285c6d34411b9ae6e9dcd80ff0798d5556cf35d40c8L1-R6) [[2]](diffhunk://#diff-421d2ddd4830ecaab4e6abbccef7751e56cec4eea3e9c0dec81f2a00cc1a1268R6-R12)

These changes aim to enhance the diagnostic capabilities of the Azure SignalR service by incorporating distributed tracing, making it easier to monitor and troubleshoot the service's behavior.