### PR TITLE
Don't sign by our pipeline

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -93,13 +93,6 @@ extends:
                     echo $(VersionSuffix)
                     echo $(MSBuildProperties)
                   displayName: Print VersionSuffix and MSBuildProperties
-              - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@3
-                displayName: Install Signing Plugin
-                condition: and(succeeded(), in(variables.SignType, 'real', 'test')) 
-                inputs:
-                  signType: $(SignType)
-                  zipSources: false
-                  feedSource: https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json
               - task: UseDotNet@2
                 displayName: Add 6.x
                 inputs:
@@ -133,7 +126,8 @@ extends:
                     searchPatternPack: src/Microsoft*/*.csproj;!src\Microsoft.Azure.SignalR.Emulator\Microsoft.Azure.SignalR.Emulator.csproj;!src\Microsoft.Azure.SignalR.Serverless.Protocols\Microsoft.Azure.SignalR.Serverless.Protocols.csproj
                     outputDir: artifacts
                     includesymbols: true
-                    buildProperties: $(MSBuildProperties);SymbolPackageFormat=snupkg
+                    includesource: true
+                    buildProperties: $(MSBuildProperties)
                     verbosityPack: Normal
                 - task: CmdLine@2
                   displayName: Clean Local Feed
@@ -152,7 +146,8 @@ extends:
                     searchPatternPack: src/Microsoft.Azure.SignalR.Emulator/Microsoft.Azure.SignalR.Emulator.csproj
                     outputDir: artifacts
                     includesymbols: true
-                    buildProperties: $(MSBuildProperties);SymbolPackageFormat=snupkg
+                    includesource: true
+                    buildProperties: $(MSBuildProperties)
                     verbosityPack: Normal
               - ${{ if or( eq(parameters.isFinalBuild, false),  eq(parameters.releaseServerlessProtocol, true)) }}:
                 - task: DotNetCoreCLI@2
@@ -162,7 +157,8 @@ extends:
                     searchPatternPack: src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
                     outputDir: artifacts
                     includesymbols: true
-                    buildProperties: $(MSBuildProperties);SymbolPackageFormat=snupkg
+                    includesource: true
+                    buildProperties: $(MSBuildProperties)
                     verbosityPack: Normal
               - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
                 displayName: "Manifest Generator "

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,12 +18,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
     <PackageReference Condition="'$(GenerateAPIListing)' == 'true'" Include="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup>
-      <!-- Adding the assemblies to sign -->
-      <FilesToSign Include="$(OutDir)\$(RootNamespace)*.nupkg">
-        <Authenticode>NuGet</Authenticode>
-      </FilesToSign>
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(IsSignalRLibrary)' != '' ">
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionHttpVersion)" />

--- a/src/Microsoft.Azure.SignalR.Emulator/Directory.Build.props
+++ b/src/Microsoft.Azure.SignalR.Emulator/Directory.Build.props
@@ -15,10 +15,4 @@
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
     </ItemGroup>
-    <ItemGroup>
-        <!-- Adding the assemblies to sign -->
-        <FilesToSign Include="$(OutDir)\$(RootNamespace)*.nupkg">
-            <Authenticode>NuGet</Authenticode>
-        </FilesToSign>
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
- Remove signing related code. Currently the signing in our own pipelines is blocked. As the Azure partner pipeline already has signing functionality, we just removed it.

- Switch back to legacy symbol format. ".snupkg" symbol package format is not supported by Azure partner pipeline yet

