### PR TITLE
Add "AzFileCopy" network policy

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -60,6 +60,8 @@ extends:
     sdl:
       eslint:
         enabled: false
+    settings:
+      networkIsolationPolicy: Okay,GitHub,AzureFileCopy
     stages:
       - stage: Stage
         jobs:


### PR DESCRIPTION
Now network isolation policies are enforced in Azure pipelines.
"Okay", "GitHub" policies are inherited. We need a new policy "AzureFileCopy" to copy files to Azure partner release blob. 
