### PR TITLE
Fix issue caused by AckHandler disposing

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -457,8 +457,12 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
     {
         if (disposing)
         {
+            // We shouldn't dispose the global one, which may be used by other instances.
+            if (_ackHandler != AckHandler.Singleton)
+            {
             _ackHandler.Dispose();
         }
+    }
     }
 
     protected virtual ServiceConnectionStatus GetStatus()

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
@@ -40,7 +40,7 @@ internal sealed class AckHandler : IDisposable
         id = NextId();
         if (_disposed)
         {
-            return Task.FromResult(AckStatus.Ok);
+            throw new InvalidOperationException($"AckHandler is disposed.");
         }
         var info = (IAckInfo<AckStatus>)_acks.GetOrAdd(id, _ => new SingleStatusAck(ackTimeout ?? _defaultAckTimeout));
         if (info is MultiAckWithStatusInfo)
@@ -56,7 +56,7 @@ internal sealed class AckHandler : IDisposable
         id = NextId();
         if (_disposed)
         {
-            return Task.FromResult(new T());
+            throw new InvalidOperationException($"AckHandler is disposed.");
         }
         var info = (SinglePayloadAck<T>)_acks.GetOrAdd(id, _ => new SinglePayloadAck<T>(ackTimeout ?? _defaultAckTimeout));
         cancellationToken.Register(info.Cancel);
@@ -79,7 +79,7 @@ internal sealed class AckHandler : IDisposable
         id = NextId();
         if (_disposed)
         {
-            return Task.FromResult(AckStatus.Ok);
+            throw new InvalidOperationException($"AckHandler is disposed.");
         }
         var info = (IAckInfo<AckStatus>)_acks.GetOrAdd(id, _ => new MultiAckWithStatusInfo(ackTimeout ?? _defaultAckTimeout));
         if (info is SingleAckInfo<AckStatus>)
@@ -101,7 +101,7 @@ internal sealed class AckHandler : IDisposable
     {
         if (_disposed)
         {
-            return;
+            throw new InvalidOperationException($"AckHandler is disposed.");
         }
 
         if (_acks.TryGetValue(id, out var info))
@@ -121,7 +121,7 @@ internal sealed class AckHandler : IDisposable
     {
         if (_disposed)
         {
-            return;
+            throw new InvalidOperationException($"AckHandler is disposed.");
         }
 
         var utcNow = DateTime.UtcNow;

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -277,7 +277,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             e => new TestServiceConnectionContainer(new List<IServiceConnection> {
             new TestSimpleServiceConnection(),
             new TestSimpleServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         var containerEndpoints = container.GetOnlineEndpoints();
         Assert.Equal(2, containerEndpoints.Count());
@@ -302,7 +302,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             e => new TestServiceConnectionContainer(new List<IServiceConnection> {
             new TestSimpleServiceConnection(),
             new TestSimpleServiceConnection(),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -346,7 +346,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -376,7 +376,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                 new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
                 new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
-            }, e), sem, router, loggerFactory);
+            }, e, new AckHandler()), sem, router, loggerFactory);
 
             // All the connections started
             _ = container.StartAsync();
@@ -403,7 +403,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
             new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -461,7 +461,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -555,7 +555,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
-                    }, e);
+                    }, e, new AckHandler());
                 }
                 return containers[e] = new TestServiceConnectionContainer(new List<IServiceConnection> {
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
@@ -565,7 +565,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
-                    }, e);
+                    }, e, new AckHandler());
             }, sem, router, loggerFactory);
 
             _ = container.StartAsync();
@@ -598,7 +598,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(ServiceConnectionStatus.Disconnected, writeAsyncTcs: writeTcs),
-                }, e);
+                }, e, new AckHandler());
             }
             return containers[e] = new TestServiceConnectionContainer(new List<IServiceConnection> {
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
@@ -608,7 +608,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
                     new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
-                }, e);
+                }, e, new AckHandler());
         }, sem, router, NullLoggerFactory.Instance);
 
         _ = container.StartAsync();
@@ -916,7 +916,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -984,7 +984,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
-        }, e), sem, router, NullLoggerFactory.Instance);
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance);
 
         // All the connections started
         _ = container.StartAsync();
@@ -1099,7 +1099,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
-        }, e), sem, router, NullLoggerFactory.Instance, TimeSpan.FromSeconds(10));
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance, TimeSpan.FromSeconds(10));
 
         var endpoints = sem.GetEndpoints("hub").ToArray();
         Assert.Single(endpoints);
@@ -1477,7 +1477,7 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs),
             new TestSimpleServiceConnection(writeAsyncTcs: writeTcs)
-        }, e), sem, router, NullLoggerFactory.Instance, TimeSpan.FromSeconds(10));
+        }, e, new AckHandler()), sem, router, NullLoggerFactory.Instance, TimeSpan.FromSeconds(10));
 
         var endpoints = sem.GetEndpoints("hub").ToArray();
         Assert.Single(endpoints);


### PR DESCRIPTION
* Don't dispose of the global singleton of `AckHandler`. We use a global singleton of `AckHandler`, which should never be disposed of. 
* Throw `InvalidOperation` when accessing a disposed `AckHandler` instead of returning a positive result.
* Create a separate `AckHandler` in `MultiEndpointServiceConnectionContainerTests`. The tests are based on the condition that each `ServiceConnectionContainerBase` has its own `AckHandler`, and they don't work when we have a global `AckHandler`. The false positive result fixed by the above change made those tests pass falsely.
