### PR TITLE
Let SDK decide the language version

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
+++ b/src/Microsoft.Azure.SignalR.AspNet/Microsoft.Azure.SignalR.AspNet.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Description>.NET Framework SDK for Azure ASP.NET SignalR.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>11</LangVersion>
     <RootNamespace>Microsoft.Azure.SignalR.AspNet</RootNamespace>
     <TargetFramework>net462</TargetFramework>
     <!-- jQuery is not used in this library, upgrading jQuery to 3.x might potentially break users using 1.x, so ignore this warning -->

--- a/src/Microsoft.Azure.SignalR.Common/Microsoft.Azure.SignalR.Common.csproj
+++ b/src/Microsoft.Azure.SignalR.Common/Microsoft.Azure.SignalR.Common.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
+++ b/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
@@ -3,7 +3,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>.NET Standard SDK for Azure SignalR.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>11</LangVersion>
     <RootNamespace>Microsoft.Azure.SignalR</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
It's better to let SDK decide which language version to use based on target frameworks, unless we need a specific language version that differs from the one automatically selected.
> In Visual Studio, the option to change the language version through the UI is disabled because the default version is aligned with the project's target framework (TFM). This default configuration ensures compatibility between language features and runtime support.

> For example, changing the target TFM (for example, from .NET 6 to .NET 9) updates the language version accordingly, from C# 10 to C# 13. This approach prevents issues with runtime compatibility and minimizes unexpected build errors due to unsupported language features.

> If you need a specific language version that differs from the one automatically selected, refer to the methods in this article to override the default settings directly in the project file.

Reference: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version