### PR TITLE
Fix a potential bug of service protocol

### DIFF
--- a/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
@@ -211,18 +211,6 @@ internal static class MessagePackUtils
         }
     }
 
-    internal static ReadOnlySequence<byte>? ReadByteSequence(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadBytes();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading binary sequence for '{field}' failed.", ex);
-        }
-    }
-
     internal static long ReadMapLength(ref MessagePackReader reader, string field)
     {
         try

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -1316,7 +1316,7 @@ public class ServiceProtocol : IServiceProtocol
         }
         if (arrayLength >= 6)
         {
-            result.Payload = ReadByteSequence(ref reader, "payload");
+            result.Payload = new ReadOnlySequence<byte>(ReadBytes(ref reader, "payload"));
         }
         return result;
     }


### PR DESCRIPTION
Fix a potential bug of service protocol that the `ReadOnlySequence<byte>` returned from reader may be modified before it's consumed.