### PR TITLE
fix bug in pause/resume.

### DIFF
--- a/src/Microsoft.Azure.SignalR.Common/Utilities/PauseHandler.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/PauseHandler.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SignalR;
+
+#nullable enable
 
 internal class PauseHandler
 {
@@ -14,9 +16,9 @@ internal class PauseHandler
 
     private volatile int _pauseAcked = 1;
 
-    public bool ShouldReplyAck => Interlocked.CompareExchange(ref _pauseAcked, 1, 0) == 0;
+    public bool ShouldReplyAck() => Interlocked.CompareExchange(ref _pauseAcked, 1, 0) == 0;
 
-    public async Task<bool> WaitAsync(int ms, CancellationToken ctoken) => _pauseSemaphore.Wait(0, ctoken) || await _pauseSemaphore.WaitAsync(ms, ctoken);
+    public Task<bool> TryAcquire(int millisecondsTimeout) => _pauseSemaphore.WaitAsync(millisecondsTimeout);
 
     public void Release() => _pauseSemaphore.Release();
 

--- a/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -261,7 +261,7 @@ internal partial class ClientConnectionContext : ConnectionContext,
 
     public Task PauseAckAsync()
     {
-        if (_pauseHandler.ShouldReplyAck)
+        if (_pauseHandler.ShouldReplyAck())
         {
             Log.OutgoingTaskPauseAck(Logger, ConnectionId);
             var message = new ConnectionFlowControlMessage(ConnectionId, ConnectionFlowControlOperation.PauseAck);
@@ -334,18 +334,26 @@ internal partial class ClientConnectionContext : ConnectionContext,
                     if (HandshakeResponseTask.IsCompleted)
                     {
                         var next = buffer;
-                        while (!buffer.IsEmpty && protocol.TryParseMessage(ref next, FakeInvocationBinder.Instance, out var message))
-                        {
-                            // we still want messages to successfully going out when application completes
-                            if (!await _pauseHandler.WaitAsync(StaticRandom.Next(500, 1500), OutgoingAborted))
-                            {
-                                Log.OutgoingTaskPaused(Logger, ConnectionId);
-                                buffer = buffer.Slice(0);
-                                break;
-                            }
 
-                            try
+                        // we still want messages to successfully going out when application completes
+                        int waitTime = 0;
+                        while (!await _pauseHandler.TryAcquire(1000))
+                        {
+                            Log.OutgoingTaskPaused(Logger, ConnectionId);
+                            if (OutgoingAborted.IsCancellationRequested)
                             {
+                                waitTime++;
+                                if (waitTime > 5)
+                                {
+                                    OutgoingAborted.ThrowIfCancellationRequested();
+                                }
+                            }
+                        }
+                        try
+                        {
+                            while (!buffer.IsEmpty && protocol.TryParseMessage(ref next, FakeInvocationBinder.Instance, out var message))
+                            {
+
                                 var messageType = message switch
                                 {
                                     SignalRProtocol.HubInvocationMessage => DataMessageType.Invocation,
@@ -363,10 +371,10 @@ internal partial class ClientConnectionContext : ConnectionContext,
                                     _ => next,
                                 };
                             }
-                            finally
-                            {
-                                _pauseHandler.Release();
-                            }
+                        }
+                        finally
+                        {
+                            _pauseHandler.Release();
                         }
                     }
                 }

--- a/test/Microsoft.Azure.SignalR.Common.Tests/PauseHandlerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Common.Tests/PauseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
@@ -13,22 +13,23 @@ public class PauseHandlerTests
     public async Task TestPauseAndResume()
     {
         var handler = new PauseHandler();
-        Assert.False(handler.ShouldReplyAck);
+        Assert.False(handler.ShouldReplyAck());
 
         await handler.PauseAsync();
-        Assert.False(await handler.WaitAsync(100, default));
+        Assert.False(await handler.TryAcquire(100));
 
-        Assert.True(handler.ShouldReplyAck);
-        Assert.False(handler.ShouldReplyAck); // ack only once
+        Assert.True(handler.ShouldReplyAck());
+        Assert.False(handler.ShouldReplyAck()); // ack only once
 
         await handler.PauseAsync(); // pause can be called multiple times.
-        Assert.False(await handler.WaitAsync(100, default));
-        Assert.False(handler.ShouldReplyAck); // already acked previously
+        Assert.False(await handler.TryAcquire(100));
+        Assert.False(handler.ShouldReplyAck()); // already acked previously
 
         await handler.ResumeAsync();
-        Assert.True(await handler.WaitAsync(100, default));
-        Assert.False(await handler.WaitAsync(100, default)); // only 1 parallel
+
+        Assert.True(await handler.TryAcquire(100));
+        Assert.False(await handler.TryAcquire(100)); // only 1 parallel
         handler.Release();
-        Assert.True(await handler.WaitAsync(100, default));
+        Assert.True(await handler.TryAcquire(100));
     }
 }


### PR DESCRIPTION
This pull request refactors the `PauseHandler` class and updates its usage throughout the codebase to improve clarity and consistency in pausing and resuming client connections. The main changes include renaming methods for clarity, updating method calls, and revising the logic for handling outgoing messages during pauses.

**PauseHandler API changes:**

* Renamed `ShouldReplyAck` property to a method `ShouldReplyAck()` for clarity and updated all usages accordingly. [[1]](diffhunk://#diff-78516e7ab0e0c2e9f2ee66acce8f83e3d79abc947e72e7e6aeed535aff59f440L17-R21) [[2]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL264-R264) [[3]](diffhunk://#diff-7d634646940b52853f1494dc2a8582de3e07c4ff77491040696c7595014d21a0L16-R33)
* Replaced `WaitAsync` with `TryAcquire`, simplifying the semaphore acquisition logic and updating all related method calls in code and tests. [[1]](diffhunk://#diff-78516e7ab0e0c2e9f2ee66acce8f83e3d79abc947e72e7e6aeed535aff59f440L17-R21) [[2]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL337-R356) [[3]](diffhunk://#diff-7d634646940b52853f1494dc2a8582de3e07c4ff77491040696c7595014d21a0L16-R33)

**Outgoing message processing logic:**

* Refactored the outgoing message loop in `ClientConnectionContext` to use the new `TryAcquire` method, added retry logic with a timeout for pause handling, and improved cancellation handling during message processing.
* Moved the message parsing loop inside the semaphore acquisition block to ensure proper pause handling and resource release. [[1]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL337-R356) [[2]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cR374-L372)

**Testing updates:**

* Updated the `PauseHandlerTests` to use the new method names and logic, ensuring the tests match the refactored API and behavior.
