### PR TITLE
fix bug in ResumeClientConnectionAsync for pause/resume.

### DIFF
--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs
@@ -71,6 +71,16 @@ internal partial class ServiceConnection : ServiceConnectionBase
         return r;
     }
 
+    protected override void AttachClientConnection(IClientConnection connection)
+    {
+        _clientConnections.TryAdd(connection.ConnectionId, (ClientConnectionContext)connection);
+    }
+
+    protected override void DetachClientConnection(IClientConnection connection)
+    {
+        _clientConnections.TryRemove(connection.ConnectionId, out _);
+    }
+
     public override Task CloseClientConnections(CancellationToken token)
     {
         throw new NotSupportedException();

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionBase.cs
@@ -284,6 +284,10 @@ internal abstract partial class ServiceConnectionBase : IServiceConnection
 
     public abstract bool TryRemoveClientConnection(string connectionId, out IClientConnection connection);
 
+    protected virtual void AttachClientConnection(IClientConnection connection) { }
+
+    protected virtual void DetachClientConnection(IClientConnection connection) { }
+
     protected abstract Task<ConnectionContext> CreateConnection(string target = null, CancellationToken cancellationToken = default);
 
     protected abstract Task DisposeConnection(ConnectionContext connection);
@@ -454,14 +458,11 @@ internal abstract partial class ServiceConnectionBase : IServiceConnection
 
         if (clientConnection.ServiceConnection is ServiceConnectionBase serviceConnection)
         {
-            serviceConnection.TryRemoveClientConnection(clientConnection.ConnectionId, out _);
+            serviceConnection.DetachClientConnection(clientConnection);
         }
-        if (TryAddClientConnection(clientConnection))
-        {
-            clientConnection.ServiceConnection = this;
-            return clientConnection.ResumeAsync();
-        }
-        return Task.CompletedTask;
+        clientConnection.ServiceConnection = this;
+        AttachClientConnection(clientConnection);
+        return clientConnection.ResumeAsync();
     }
 
     private Task OnFlowControlMessageAsync(ConnectionFlowControlMessage flowControlMessage)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -104,6 +104,16 @@ internal partial class ServiceConnection : ServiceConnectionBase
         return r;
     }
 
+    protected override void AttachClientConnection(IClientConnection connection)
+    {
+        _connectionIds.TryAdd(connection.ConnectionId, connection.InstanceId);
+    }
+
+    protected override void DetachClientConnection(IClientConnection connection)
+    {
+        _connectionIds.TryRemove(connection.ConnectionId, out _);
+    }
+
     public override async Task CloseClientConnections(CancellationToken token)
     {
         var tasks = new List<Task>();


### PR DESCRIPTION
This pull request introduces new methods for managing client connections in service connection classes, improving encapsulation and consistency in how connections are attached and detached. The changes primarily add `AttachClientConnection` and `DetachClientConnection` methods to the base class and implement them in derived classes, updating related logic to use these methods.

**Client connection management improvements:**

* Added virtual `AttachClientConnection` and `DetachClientConnection` methods to the `ServiceConnectionBase` class, allowing derived classes to override connection attachment and detachment logic.
* Updated the `ResumeClientConnectionAsync` method in `ServiceConnectionBase` to use the new `AttachClientConnection` and `DetachClientConnection` methods instead of directly manipulating connections, improving code clarity and extensibility.

**Derived class implementations:**

* Implemented `AttachClientConnection` and `DetachClientConnection` in `Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnection.cs`, now managing `_clientConnections` using these methods.
* Implemented `AttachClientConnection` and `DetachClientConnection` in `Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs`, now managing `_connectionIds` using these methods.