### PR TITLE
fix thread safety issue in client connection context.

### DIFF
--- a/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
@@ -83,6 +83,8 @@ internal partial class ClientConnectionContext : ConnectionContext,
 
     private readonly Queue<IMemoryOwner<byte>> _bufferedMessages = new();
 
+    private readonly SemaphoreSlim _bufferedMessageLock = new(1, 1);
+
     private readonly int _closeTimeOutMilliseconds;
 
     private readonly bool _isMigrated;
@@ -436,7 +438,7 @@ internal partial class ClientConnectionContext : ConnectionContext,
 
     internal async Task PerformDisconnectAsync()
     {
-        ClearBufferedMessages();
+        await ClearBufferedMessagesAsync();
 
         // In normal close, service already knows the client is closed, no need to be informed.
         AbortOnClose = false;
@@ -479,19 +481,35 @@ internal partial class ClientConnectionContext : ConnectionContext,
             {
                 var owner = ExactSizeMemoryPool.Shared.Rent((int)connectionDataMessage.Payload.Length);
                 connectionDataMessage.Payload.CopyTo(owner.Memory.Span);
-                // make sure there is no await operation before _bufferingMessages.
-                _bufferedMessages.Enqueue(owner);
+                // make sure there is no await operation before _bufferedMessageLock.WaitAsync.
+                await _bufferedMessageLock.WaitAsync();
+                try
+                {
+                    _bufferedMessages.Enqueue(owner);
+                }
+                finally
+                {
+                    _bufferedMessageLock.Release();
+                }
             }
             else
             {
                 long length = 0;
-                foreach (var owner in _bufferedMessages)
+                await _bufferedMessageLock.WaitAsync();
+                try
                 {
-                    using (owner)
+                    foreach (var owner in _bufferedMessages)
                     {
-                        await WriteToApplicationAsync(new ReadOnlySequence<byte>(owner.Memory));
-                        length += owner.Memory.Length;
+                        using (owner)
+                        {
+                            await WriteToApplicationAsync(new ReadOnlySequence<byte>(owner.Memory));
+                            length += owner.Memory.Length;
+                        }
                     }
+                }
+                finally
+                {
+                    _bufferedMessageLock.Release();
                 }
                 _bufferedMessages.Clear();
 
@@ -507,9 +525,17 @@ internal partial class ClientConnectionContext : ConnectionContext,
         }
     }
 
-    internal void ClearBufferedMessages()
+    internal async Task ClearBufferedMessagesAsync()
     {
-        _bufferedMessages.Clear();
+        await _bufferedMessageLock.WaitAsync();
+        try
+        {
+            _bufferedMessages.Clear();
+        }
+        finally
+        {
+            _bufferedMessageLock.Release();
+        }
     }
 
     private void ProcessQuery(string queryString, out string originalPath)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -398,12 +398,12 @@ internal partial class ServiceConnection : ServiceConnectionBase
         return Task.CompletedTask;
     }
 
-    private Task OnConnectionReconnectAsync(ConnectionReconnectMessage message)
+    private async Task OnConnectionReconnectAsync(ConnectionReconnectMessage message)
     {
-        if (_clientConnectionManager.TryGetClientConnection(message.ConnectionId, out var connection))
+        if (_clientConnectionManager.TryGetClientConnection(message.ConnectionId, out var connection) &&
+            connection is ClientConnectionContext clientConnection)
         {
-            (connection as ClientConnectionContext)?.ClearBufferedMessages();
+            await clientConnection.ClearBufferedMessagesAsync();
         }
-        return Task.CompletedTask;
     }
 }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceConnectionTests.cs
@@ -945,6 +945,86 @@ public class ServiceConnectionTests : VerifiableLoggedTest
         }
     }
 
+    [Fact]
+    public async Task TestPartialMessagesProcessingShouldBeThreadSafe()
+    {
+        var ccm = new TestClientConnectionManager();
+        var ccf = new ClientConnectionFactory(NullLoggerFactory.Instance, closeTimeOutMilliseconds: 500);
+        var protocol = new ServiceProtocol();
+        var hubProtocol = new JsonHubProtocol();
+        TestConnection transportConnection = null;
+        var connectionFactory = new TestConnectionFactory(conn =>
+        {
+            transportConnection = conn;
+            return Task.CompletedTask;
+        });
+        var services = new ServiceCollection();
+
+        var connectionHandler = new TextContentConnectionHandler();
+        services.AddSingleton(connectionHandler);
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<TextContentConnectionHandler>();
+        var handler = builder.Build();
+        var hubProtocolResolver = new DefaultHubProtocolResolver(new[] { hubProtocol }, NullLogger<DefaultHubProtocolResolver>.Instance);
+        var connection = new ServiceConnection(protocol,
+                                               ccm,
+                                               connectionFactory,
+                                               NullLoggerFactory.Instance,
+                                               handler,
+                                               ccf,
+                                               "serverId",
+                                               Guid.NewGuid().ToString("N"),
+                                               null,
+                                               null,
+                                               null,
+                                               new DefaultClientInvocationManager(),
+                                               hubProtocolResolver,
+                                               null);
+
+        var connectionTask = connection.StartAsync();
+
+        // completed handshake
+        await connection.ConnectionInitializedTask.OrTimeout();
+        Assert.Equal(ServiceConnectionStatus.Connected, connection.Status);
+        var clientConnectionId = Guid.NewGuid().ToString();
+
+        var waitClientTask = ccm.WaitForClientConnectionAsync(clientConnectionId);
+        await transportConnection.Application.Output.WriteAsync(
+            protocol.GetMessageBytes(new OpenConnectionMessage(clientConnectionId, Array.Empty<Claim>()) { Protocol = hubProtocol.Name }));
+
+        var clientConnection = await waitClientTask.OrTimeout();
+
+        var enumerator = connectionHandler.EnumerateContent().GetAsyncEnumerator();
+        var moveNextTask = enumerator.MoveNextAsync().AsTask();
+
+        var partialBytes = protocol.GetMessageBytes(new ConnectionDataMessage(clientConnectionId, "a"u8.ToArray()) { IsPartial = true });
+        var reconnectBytes = protocol.GetMessageBytes(new ConnectionReconnectMessage(clientConnectionId));
+        for (int i = 0; i < 10; i++)
+        {
+            for (int j = 0; j < (i + 1) * 10; j++)
+            {
+                await transportConnection.Application.Output.WriteAsync(partialBytes);
+            }
+            await transportConnection.Application.Output.WriteAsync(reconnectBytes);
+        }
+
+        // when next message comes, there is no partial message.
+        await transportConnection.Application.Output.WriteAsync(
+            protocol.GetMessageBytes(new ConnectionDataMessage(clientConnectionId, Encoding.UTF8.GetBytes("{\"type\":1,\"target\":\"method\"}\u001e"))));
+        await moveNextTask;
+        Assert.Equal("{\"type\":1,\"target\":\"method\"}\u001e", enumerator.Current);
+
+        // complete reading to end the connection
+        transportConnection.Application.Output.Complete();
+
+        await clientConnection.LifetimeTask.OrTimeout();
+
+        // 1s for application task to timeout
+        await connectionTask.OrTimeout(1000);
+        Assert.Equal(ServiceConnectionStatus.Disconnected, connection.Status);
+        Assert.Empty(ccm.ClientConnections);
+    }
+
     private static async Task<ClientConnectionContext> CreateClientConnectionAsync(ServiceProtocol protocol,
                                                                                    IHubProtocol hubProtocol,
                                                                                    TestClientConnectionManager ccm,


### PR DESCRIPTION
### Summary
This pull request improves thread safety in the handling of buffered messages for client connections, particularly when processing partial messages and handling reconnection scenarios. The changes introduce asynchronous locking to avoid race conditions, update method signatures to support async operations, and add a new test to ensure thread safety.

**Thread safety improvements for buffered message handling:**

* Added a `SemaphoreSlim` (`_bufferedMessageLock`) to `ClientConnectionContext` to ensure thread-safe access to the `_bufferedMessages` queue.
* Updated methods that manipulate `_bufferedMessages` (`ProcessConnectionDataMessageAsync`, `ClearBufferedMessagesAsync`) to use asynchronous locking with `_bufferedMessageLock`. [[1]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL482-R500) [[2]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cR509-R513) [[3]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL510-R539)
* Changed `ClearBufferedMessages` to `ClearBufferedMessagesAsync` and updated call sites to await the new async method, ensuring proper synchronization during disconnect and reconnect operations. [[1]](diffhunk://#diff-c64907f1d26490240bd29ed2fd6fa0b97da74e924ee15b7df053a38424309a1cL439-R441) [[2]](diffhunk://#diff-0b12d99f1e49e91ef4c68bf6ace866037efb5c7fdd1d1d1b8911b72adf2f9eb5L401-L407)

**Testing:**

* Added a new test `TestPartialMessagesProcessingShouldBeThreadSafe` to verify that partial message processing is thread-safe under concurrent scenarios.


Fixes #2253
