### PR TITLE
add refresh token message in service protocol.

### DIFF
--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -402,6 +402,13 @@ namespace Microsoft.Azure.SignalR.Protocol
         public PingMessage() { }
         public string?[] Messages { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
+    public partial class RefreshTokenMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
+    {
+        public RefreshTokenMessage() { }
+        public RefreshTokenMessage(string connectionIdOrToken, string newToken) { }
+        public string? ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string? NewToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {
         public ServiceCompletionMessage(string invocationId, string connectionId, string callerServerId, ulong? tracingId = default(ulong?)) : base (default(string)) { }
@@ -494,6 +501,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int MultiUserDataMessageType = 9;
         public const int OpenConnectionMessageType = 4;
         public const int PingMessageType = 3;
+        public const int RefreshTokenMessageType = 41;
         public const int ServiceErrorMessageType = 15;
         public const int ServiceEventMessageType = 22;
         public const int ServiceMappingMessageType = 37;

--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -404,10 +404,10 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
     public partial class RefreshTokenMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
     {
-        public RefreshTokenMessage() { }
-        public RefreshTokenMessage(string connectionIdOrToken, string newToken) { }
-        public string? ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public string? NewToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public RefreshTokenMessage(string connectionIdOrToken, string authToken, System.DateTimeOffset expireTime) { }
+        public string AuthToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.DateTimeOffset ExpireTime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -647,11 +647,12 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 ### RefreshToken Message
 `RefreshToken` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, NewToken, ExtensionMembers]
+[41, ConnectionIdOrToken, AuthToken, ExpireTime, ExtensionMembers]
 ```
 - 41 - Message Type, indicating this is a `RefreshToken` message.
-- ConnectionIdOrToken - A `String` indicating the connection ID or token.
-- NewToken - A `String` indicating the new refresh token.
+- ConnectionIdOrToken - A `String` indicating the connection ID or the original token.
+- AuthToken - A `String` indicating the new auth token.
+- ExpireTime - An `Int64` indicating the expire time of the new auth token, in UTC ticks.
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 
 #### Example: TODO

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -643,3 +643,15 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 - ContinuationToken - A `String` indicating the continuation token of query.
 
 #### Example: TODO
+
+### RefreshToken Message
+`RefreshToken` messages have the following structure:
+```
+[41, ConnectionIdOrToken, NewToken, ExtensionMembers]
+```
+- 41 - Message Type, indicating this is a `RefreshToken` message.
+- ConnectionIdOrToken - A `String` indicating the connection ID or token.
+- NewToken - A `String` indicating the new refresh token.
+- ExtensionMembers - A MessagePack Map indicates the extensible members.
+
+#### Example: TODO

--- a/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
@@ -112,6 +112,18 @@ internal static class MessagePackUtils
         }
     }
 
+    internal static long ReadInt64(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadInt64();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as Int64 failed.", ex);
+        }
+    }
+
     internal static string? ReadString(ref MessagePackReader reader, string field)
     {
         try

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -327,29 +327,29 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Gets or sets the connection id or the original token.
         /// </summary>
-        public string? ConnectionIdOrToken { get; set; }
+        public string ConnectionIdOrToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the new refresh token.
+        /// Gets or sets the new auth token.
         /// </summary>
-        public string? NewToken { get; set; }
+        public string AuthToken { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// Gets or sets the expire time of the new auth token in UTC.
         /// </summary>
-        public RefreshTokenMessage()
-        {
-        }
+        public DateTimeOffset ExpireTime { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
         /// </summary>
         /// <param name="connectionIdOrToken">The connection id or the original token.</param>
-        /// <param name="newToken">The new refresh token.</param>
-        public RefreshTokenMessage(string connectionIdOrToken, string newToken)
+        /// <param name="authToken">The new auth token.</param>
+        /// <param name="expireTime">The expire time of the new auth token in UTC.</param>
+        public RefreshTokenMessage(string connectionIdOrToken, string authToken, DateTimeOffset expireTime)
         {
-            ConnectionIdOrToken = connectionIdOrToken;
-            NewToken = newToken;
+            ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
+            AuthToken = authToken ?? throw new ArgumentNullException(nameof(authToken));
+            ExpireTime = expireTime.ToUniversalTime();
         }
     }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -320,6 +320,40 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
+    /// A refresh token message.
+    /// </summary>
+    public class RefreshTokenMessage : ExtensibleServiceMessage
+    {
+        /// <summary>
+        /// Gets or sets the connection id or the original token.
+        /// </summary>
+        public string? ConnectionIdOrToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new refresh token.
+        /// </summary>
+        public string? NewToken { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// </summary>
+        public RefreshTokenMessage()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// </summary>
+        /// <param name="connectionIdOrToken">The connection id or the original token.</param>
+        /// <param name="newToken">The new refresh token.</param>
+        public RefreshTokenMessage(string connectionIdOrToken, string newToken)
+        {
+            ConnectionIdOrToken = connectionIdOrToken;
+            NewToken = newToken;
+        }
+    }
+
+    /// <summary>
     /// A handshake request message.
     /// </summary>
     public class HandshakeRequestMessage : ExtensibleServiceMessage

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -765,20 +765,23 @@ public class ServiceProtocol : IServiceProtocol
 
     private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
     {
-        writer.WriteArrayHeader(4);
+        writer.WriteArrayHeader(5);
         writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
         writer.Write(message.ConnectionIdOrToken);
-        writer.Write(message.NewToken);
+        writer.Write(message.AuthToken);
+        writer.Write(message.ExpireTime.UtcTicks);
         message.WriteExtensionMembers(ref writer);
     }
 
     private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
     {
-        var message = new RefreshTokenMessage()
-        {
-            ConnectionIdOrToken = ReadString(ref reader, "connectionIdOrToken"),
-            NewToken = ReadString(ref reader, "newToken"),
-        };
+        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
+        var authToken = ReadStringNotNull(ref reader, "authToken");
+        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var message = new RefreshTokenMessage(
+            connectionIdOrToken,
+            authToken,
+            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -763,29 +763,6 @@ public class ServiceProtocol : IServiceProtocol
         message.WriteExtensionMembers(ref writer);
     }
 
-    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
-    {
-        writer.WriteArrayHeader(5);
-        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
-        writer.Write(message.ConnectionIdOrToken);
-        writer.Write(message.AuthToken);
-        writer.Write(message.ExpireTime.UtcTicks);
-        message.WriteExtensionMembers(ref writer);
-    }
-
-    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
-    {
-        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
-        var authToken = ReadStringNotNull(ref reader, "authToken");
-        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
-        var message = new RefreshTokenMessage(
-            connectionIdOrToken,
-            authToken,
-            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
-        message.ReadExtensionMembers(ref reader);
-        return message;
-    }
-
     private static void WriteGroupMemberQueryMessage(ref MessagePackWriter writer, GroupMemberQueryMessage message)
     {
         writer.WriteArrayHeader(7);
@@ -810,6 +787,16 @@ public class ServiceProtocol : IServiceProtocol
         {
             writer.WriteNil();
         }
+    }
+
+    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
+    {
+        writer.WriteArrayHeader(5);
+        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
+        writer.Write(message.ConnectionIdOrToken);
+        writer.Write(message.AuthToken);
+        writer.Write(message.ExpireTime.UtcTicks);
+        message.WriteExtensionMembers(ref writer);
     }
 
     private static void WriteStringArray(ref MessagePackWriter writer, IReadOnlyList<string>? array)
@@ -1447,4 +1434,18 @@ public class ServiceProtocol : IServiceProtocol
         }
         return result;
     }
+
+    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
+        var authToken = ReadStringNotNull(ref reader, "authToken");
+        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var message = new RefreshTokenMessage(
+            connectionIdOrToken,
+            authToken,
+            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
+        message.ReadExtensionMembers(ref reader);
+        return message;
+    }
+
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -157,6 +157,8 @@ public class ServiceProtocol : IServiceProtocol
                 return CreateConnectionFlowControlMessage(ref reader, arrayLength);
             case ServiceProtocolConstants.GroupMemberQueryMessageType:
                 return CreateGroupMemberQueryMessage(ref reader, arrayLength);
+            case ServiceProtocolConstants.RefreshTokenMessageType:
+                return CreateRefreshTokenMessage(ref reader, arrayLength);
             default:
                 // Future protocol changes can add message types, old clients can ignore them
                 return null;
@@ -342,6 +344,9 @@ public class ServiceProtocol : IServiceProtocol
                 break;
             case GroupMemberQueryMessage groupMemberQueryMessage:
                 WriteGroupMemberQueryMessage(ref writer, groupMemberQueryMessage);
+                break;
+            case RefreshTokenMessage refreshTokenMessage:
+                WriteRefreshTokenMessage(ref writer, refreshTokenMessage);
                 break;
             default:
                 throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
@@ -756,6 +761,26 @@ public class ServiceProtocol : IServiceProtocol
         writer.WriteInt32((int)message.ConnectionType);
         writer.WriteInt32((int)message.Operation);
         message.WriteExtensionMembers(ref writer);
+    }
+
+    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
+        writer.Write(message.ConnectionIdOrToken);
+        writer.Write(message.NewToken);
+        message.WriteExtensionMembers(ref writer);
+    }
+
+    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var message = new RefreshTokenMessage()
+        {
+            ConnectionIdOrToken = ReadString(ref reader, "connectionIdOrToken"),
+            NewToken = ReadString(ref reader, "newToken"),
+        };
+        message.ReadExtensionMembers(ref reader);
+        return message;
     }
 
     private static void WriteGroupMemberQueryMessage(ref MessagePackWriter writer, GroupMemberQueryMessage message)

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -46,4 +46,5 @@ public static class ServiceProtocolConstants
     public const int ConnectionReconnectMessageType = 38;
     public const int ConnectionFlowControlMessageType = 39;
     public const int GroupMemberQueryMessageType = 40;
+    public const int RefreshTokenMessageType = 41;
 }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -106,6 +106,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return ConnectionFlowControlMessageEqual(connectionFlowControlMessage, (ConnectionFlowControlMessage)y);
                 case GroupMemberQueryMessage groupMemberQueryMessage:
                     return GroupMemberQueryMessageEqual(groupMemberQueryMessage, (GroupMemberQueryMessage)y);
+                case RefreshTokenMessage refreshTokenMessage:
+                    return RefreshTokenMessageEqual(refreshTokenMessage, (RefreshTokenMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -408,6 +410,12 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                    x.Top == y.Top &&
                    StringEqual(x.ContinuationToken, y.ContinuationToken) &&
                    x.TracingId == y.TracingId;
+        }
+
+        private static bool RefreshTokenMessageEqual(RefreshTokenMessage x, RefreshTokenMessage y)
+        {
+            return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
+                StringEqual(x.NewToken, y.NewToken);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -415,7 +415,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         private static bool RefreshTokenMessageEqual(RefreshTokenMessage x, RefreshTokenMessage y)
         {
             return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
-                StringEqual(x.NewToken, y.NewToken);
+                StringEqual(x.AuthToken, y.AuthToken) &&
+                x.ExpireTime == y.ExpireTime;
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -780,6 +780,10 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "GroupMemberQueryMessageWithOptionalFields",
                 message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1, MaxPageSize = 5, Top = 10, ContinuationToken = "token", TracingId = 1234UL },
                 binary: "lyiBAc0E0qVncm91cAEKpXRva2VuBQ=="),
+            new ProtocolTestData(
+                name: "RefreshTokenMessage",
+                message: new RefreshTokenMessage("conn1", "newtoken"),
+                binary: "lCmlY29ubjGobmV3dG9rZW6A"),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -782,8 +782,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 binary: "lyiBAc0E0qVncm91cAEKpXRva2VuBQ=="),
             new ProtocolTestData(
                 name: "RefreshTokenMessage",
-                message: new RefreshTokenMessage("conn1", "newtoken"),
-                binary: "lCmlY29ubjGobmV3dG9rZW6A"),
+                message: new RefreshTokenMessage("conn1", "newtoken", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+                binary: "lSmlY29ubjGobmV3dG9rZW7PCNwKXJkAwACA"),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)

This pull request introduces support for a new `RefreshTokenMessage` type in the SignalR service protocol. The main changes include the definition of the new message class, updates to the protocol constants, serialization/deserialization logic, protocol documentation, and corresponding test coverage.

**New RefreshTokenMessage support:**

* Added the `RefreshTokenMessage` class to represent messages carrying a new refresh token and connection ID or token. (`src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs`, `api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs`) (F6789d5a, F84cca07)
* Defined the message type constant `RefreshTokenMessageType = 41` in `ServiceProtocolConstants`. (`src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs`, `api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs`) (Fb7bd0c3, F84cca07)

**Protocol logic updates:**

* Implemented serialization and deserialization for `RefreshTokenMessage` in the protocol handling code, enabling reading and writing of this message type. (`src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs`) (F90cc2af)
* Updated the protocol specification documentation to describe the `RefreshToken` message structure and fields. (`specs/ServiceProtocol.md`) (F9db7b07)

**Test coverage:**

* Added equality comparison logic and protocol tests for `RefreshTokenMessage`, including binary serialization tests. (`test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs`, `test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs`) (Fc946edb, Fc39e8c1)

These changes ensure that the protocol and its implementation can handle refresh token operations in a consistent and tested manner.

