### PR TITLE
Add a new service protocol `RefreshAuthMessage`

### DIFF
--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -402,6 +402,13 @@ namespace Microsoft.Azure.SignalR.Protocol
         public PingMessage() { }
         public string?[] Messages { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
+    public partial class RefreshTokenMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
+    {
+        public RefreshTokenMessage() { }
+        public RefreshTokenMessage(string connectionIdOrToken, string newToken) { }
+        public string? ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string? NewToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {
         public ServiceCompletionMessage(string invocationId, string connectionId, string callerServerId, ulong? tracingId = default(ulong?)) : base (default(string)) { }
@@ -494,6 +501,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int MultiUserDataMessageType = 9;
         public const int OpenConnectionMessageType = 4;
         public const int PingMessageType = 3;
+        public const int RefreshTokenMessageType = 41;
         public const int ServiceErrorMessageType = 15;
         public const int ServiceEventMessageType = 22;
         public const int ServiceMappingMessageType = 37;

--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -404,10 +404,10 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
     public partial class RefreshTokenMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
     {
-        public RefreshTokenMessage() { }
-        public RefreshTokenMessage(string connectionIdOrToken, string newToken) { }
-        public string? ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public string? NewToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public RefreshTokenMessage(string connectionIdOrToken, string authToken, System.DateTimeOffset expireTime) { }
+        public string AuthToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.DateTimeOffset ExpireTime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {

--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -402,12 +402,12 @@ namespace Microsoft.Azure.SignalR.Protocol
         public PingMessage() { }
         public string?[] Messages { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
-    public partial class RefreshTokenMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
+    public partial class RefreshAuthMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage, Microsoft.Azure.SignalR.Protocol.IAckableMessage
     {
-        public RefreshTokenMessage(string connectionIdOrToken, string authToken, System.DateTimeOffset expireTime) { }
-        public string AuthToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, int ackId) { }
+        public int AckId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.Security.Claims.Claim[] Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public System.DateTimeOffset ExpireTime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {
@@ -501,7 +501,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int MultiUserDataMessageType = 9;
         public const int OpenConnectionMessageType = 4;
         public const int PingMessageType = 3;
-        public const int RefreshTokenMessageType = 41;
+        public const int RefreshAuthMessageType = 41;
         public const int ServiceErrorMessageType = 15;
         public const int ServiceEventMessageType = 22;
         public const int ServiceMappingMessageType = 37;

--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -404,10 +404,11 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
     public partial class RefreshAuthMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage, Microsoft.Azure.SignalR.Protocol.IAckableMessage
     {
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, int ackId) { }
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[]? claims, System.DateTimeOffset expireTime, int ackId) { }
         public int AckId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public System.Security.Claims.Claim[] Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.Security.Claims.Claim[]? Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.DateTimeOffset ExpireTime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId
     {

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -647,11 +647,12 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 ### RefreshToken Message
 `RefreshToken` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, NewToken, ExtensionMembers]
+[41, ConnectionIdOrToken, AuthToken, ExpireTime, ExtensionMembers]
 ```
 - 41 - Message Type, indicating this is a `RefreshToken` message.
-- ConnectionIdOrToken - A `String` indicating the connection ID or token.
-- NewToken - A `String` indicating the new refresh token.
+- ConnectionIdOrToken - A `String` indicating the connection ID or the original token.
+- AuthToken - A `String` indicating the new auth token.
+- ExpireTime - An `Int64` indicating the expire time of the new auth token, in UTC ticks.
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 
 #### Example: TODO

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -647,11 +647,12 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 ### RefreshAuth Message
 `RefreshAuth` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, Claims, AckId, ExtensionMembers]
+[41, ConnectionIdOrToken, Claims, ExpireTime, AckId, ExtensionMembers]
 ```
 - 41 - Message Type, indicating this is a `RefreshAuth` message.
 - ConnectionIdOrToken - A `String` indicating the connection ID or the original connection token of the live client connection whose authentication state is being refreshed.
-- Claims - A MessagePack Map of `String` to `String` indicating the refreshed user claims. The `exp` claim is the new authentication expiration deadline for the connection.
+- Claims - A MessagePack Map of `String` to `String` indicating the refreshed user claims.
+- ExpireTime - An `Int64` indicating the new authentication expiration deadline, in UTC ticks.
 - AckId - An `Int32` encoding Id number to identify the corresponding ack message.
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -647,12 +647,12 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 ### RefreshAuth Message
 `RefreshAuth` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, Claims, ExpireTime, AckId, ExtensionMembers]
+[41, ConnectionIdOrToken, Claims?, ExpireTime, AckId, ExtensionMembers]
 ```
 - 41 - Message Type, indicating this is a `RefreshAuth` message.
 - ConnectionIdOrToken - A `String` indicating the connection ID or the original connection token of the live client connection whose authentication state is being refreshed.
-- Claims - A MessagePack Map of `String` to `String` indicating the refreshed user claims.
-- ExpireTime - An `Int64` indicating the new authentication expiration deadline, in UTC ticks.
+- Claims - An optional MessagePack Map of `String` to `String` indicating the refreshed user claims.
+- ExpireTime - A MessagePack Timestamp indicating the new authentication expiration deadline in UTC.
 - AckId - An `Int32` encoding Id number to identify the corresponding ack message.
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -643,3 +643,15 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 - ContinuationToken - A `String` indicating the continuation token of query.
 
 #### Example: TODO
+
+### RefreshToken Message
+`RefreshToken` messages have the following structure:
+```
+[41, ConnectionIdOrToken, NewToken, ExtensionMembers]
+```
+- 41 - Message Type, indicating this is a `RefreshToken` message.
+- ConnectionIdOrToken - A `String` indicating the connection ID or token.
+- NewToken - A `String` indicating the new refresh token.
+- ExtensionMembers - A MessagePack Map indicates the extensible members.
+
+#### Example: TODO

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -112,7 +112,7 @@ EMPTY | EMPTY | Both | Keep server connection alive ping
 `offline` | `fin:0` | Server -> Service | Request to drop clients for non-migratable server connections
 `offline` | `fin:1` | Server -> Service | Request to migrate client connections
 `offline` | `finack` | Service -> Server | Response of received `offline` request
-`servers` | EMPTY | Server -> Service | Request to get all server ids connect to the service 
+`servers` | EMPTY | Server -> Service | Request to get all server ids connect to the service
 `servers` | `<timestamp>:<server1>;<server2>` | Service -> Server | Response of `servers` ping of all server ids
 `echo` | `<identify>` | Service <-> Server | Identify the latency of server connection, available from SDK 1.21.6.
 
@@ -139,7 +139,7 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 	- 1, ShutdownOnly, a client connection can be migrated only if the matched server was shutdown gracefully.
 	- 2, Any, a client connection can be migrated even if the matched server connection was dropped accidentally. (may cause data loss)
 - ExtensibleMembers (Optional) - A MessagePack Map indicates the extensible members.
-- AllowStatefulReconnects (Optional) - A `Boolean` indicates the app server allows stateful reconnects or not. 
+- AllowStatefulReconnects (Optional) - A `Boolean` indicates the app server allows stateful reconnects or not.
 
 #### Example: TODO
 
@@ -644,15 +644,15 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 
 #### Example: TODO
 
-### RefreshToken Message
-`RefreshToken` messages have the following structure:
+### RefreshAuth Message
+`RefreshAuth` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, AuthToken, ExpireTime, ExtensionMembers]
+[41, ConnectionIdOrToken, Claims, AckId, ExtensionMembers]
 ```
-- 41 - Message Type, indicating this is a `RefreshToken` message.
-- ConnectionIdOrToken - A `String` indicating the connection ID or the original token.
-- AuthToken - A `String` indicating the new auth token.
-- ExpireTime - An `Int64` indicating the expire time of the new auth token, in UTC ticks.
+- 41 - Message Type, indicating this is a `RefreshAuth` message.
+- ConnectionIdOrToken - A `String` indicating the connection ID or the original connection token of the live client connection whose authentication state is being refreshed.
+- Claims - A MessagePack Map of `String` to `String` indicating the refreshed user claims. The `exp` claim is the new authentication expiration deadline for the connection.
+- AckId - An `Int32` encoding Id number to identify the corresponding ack message.
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 
 #### Example: TODO

--- a/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
@@ -112,18 +112,6 @@ internal static class MessagePackUtils
         }
     }
 
-    internal static long ReadInt64(ref MessagePackReader reader, string field)
-    {
-        try
-        {
-            return reader.ReadInt64();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException($"Reading '{field}' as Int64 failed.", ex);
-        }
-    }
-
     internal static string? ReadString(ref MessagePackReader reader, string field)
     {
         try

--- a/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/MessagePackUtils.cs
@@ -112,6 +112,18 @@ internal static class MessagePackUtils
         }
     }
 
+    internal static long ReadInt64(ref MessagePackReader reader, string field)
+    {
+        try
+        {
+            return reader.ReadInt64();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException($"Reading '{field}' as Int64 failed.", ex);
+        }
+    }
+
     internal static string? ReadString(ref MessagePackReader reader, string field)
     {
         try

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -327,29 +327,29 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Gets or sets the connection id or the original token.
         /// </summary>
-        public string? ConnectionIdOrToken { get; set; }
+        public string ConnectionIdOrToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the new refresh token.
+        /// Gets or sets the new auth token.
         /// </summary>
-        public string? NewToken { get; set; }
+        public string AuthToken { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// Gets or sets the expire time of the new auth token in UTC.
         /// </summary>
-        public RefreshTokenMessage()
-        {
-        }
+        public DateTimeOffset ExpireTime { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
         /// </summary>
         /// <param name="connectionIdOrToken">The connection id or the original token.</param>
-        /// <param name="newToken">The new refresh token.</param>
-        public RefreshTokenMessage(string connectionIdOrToken, string newToken)
+        /// <param name="authToken">The new auth token.</param>
+        /// <param name="expireTime">The expire time of the new auth token in UTC.</param>
+        public RefreshTokenMessage(string connectionIdOrToken, string authToken, DateTimeOffset expireTime)
         {
-            ConnectionIdOrToken = connectionIdOrToken;
-            NewToken = newToken;
+            ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
+            AuthToken = authToken ?? throw new ArgumentNullException(nameof(authToken));
+            ExpireTime = expireTime.ToUniversalTime();
         }
     }
 

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.SignalR.Protocol
     public class RefreshAuthMessage : ExtensibleServiceMessage, IAckableMessage
     {
         /// <summary>
-        /// Gets or sets the connection id or the original connection token that identifies the live client connection whose authentication state is being refreshed.
+        /// Gets or sets the connection id or the connection token that identifies the live client connection whose authentication state is being refreshed.
         /// </summary>
         public string ConnectionIdOrToken { get; set; }
 
@@ -335,6 +335,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         public System.Security.Claims.Claim[] Claims { get; set; }
 
         /// <summary>
+        /// Gets or sets the time at which the refreshed authentication state expires in UTC.
+        /// </summary>
+        public DateTimeOffset? ExpireTime { get; set; }
+
+        /// <summary>
         /// Gets or sets the protocol correlation id used to acknowledge this refresh operation.
         /// </summary>
         public int AckId { get; set; }
@@ -342,13 +347,15 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshAuthMessage"/> class.
         /// </summary>
-        /// <param name="connectionIdOrToken">The connection id or the original connection token.</param>
-        /// <param name="claims">The refreshed user claims.</param>
+        /// <param name="connectionIdOrToken">The connection id or the connection token that identifies the live client connection.</param>
+        /// <param name="claims">The refreshed user claims for the connection.</param>
+        /// <param name="expireTime">The time at which the refreshed authentication state expires in UTC.</param>
         /// <param name="ackId">The protocol correlation id used to acknowledge this refresh operation.</param>
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, int ackId)
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, DateTimeOffset? expireTime, int ackId)
         {
             ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
             Claims = claims ?? throw new ArgumentNullException(nameof(claims));
+            ExpireTime = expireTime;
             AckId = ackId;
         }
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Gets or sets the time at which the refreshed authentication state expires in UTC.
         /// </summary>
-        public DateTimeOffset? ExpireTime { get; set; }
+        public DateTimeOffset ExpireTime { get; set; }
 
         /// <summary>
         /// Gets or sets the protocol correlation id used to acknowledge this refresh operation.
@@ -351,11 +351,11 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="claims">The refreshed user claims for the connection.</param>
         /// <param name="expireTime">The time at which the refreshed authentication state expires in UTC.</param>
         /// <param name="ackId">The protocol correlation id used to acknowledge this refresh operation.</param>
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, DateTimeOffset? expireTime, int ackId)
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, DateTimeOffset expireTime, int ackId)
         {
             ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
             Claims = claims ?? throw new ArgumentNullException(nameof(claims));
-            ExpireTime = expireTime;
+            ExpireTime = expireTime.ToUniversalTime();
             AckId = ackId;
         }
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Gets or sets the refreshed user claims for the connection.
         /// </summary>
-        public System.Security.Claims.Claim[] Claims { get; set; }
+        public System.Security.Claims.Claim[]? Claims { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the refreshed authentication state expires in UTC.
@@ -351,10 +351,10 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <param name="claims">The refreshed user claims for the connection.</param>
         /// <param name="expireTime">The time at which the refreshed authentication state expires in UTC.</param>
         /// <param name="ackId">The protocol correlation id used to acknowledge this refresh operation.</param>
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, DateTimeOffset expireTime, int ackId)
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[]? claims, DateTimeOffset expireTime, int ackId)
         {
             ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
-            Claims = claims ?? throw new ArgumentNullException(nameof(claims));
+            Claims = claims;
             ExpireTime = expireTime.ToUniversalTime();
             AckId = ackId;
         }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -320,36 +320,36 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
-    /// A refresh token message.
+    /// A message to refresh the authentication state of an existing client connection without forcing the client to reconnect.
     /// </summary>
-    public class RefreshTokenMessage : ExtensibleServiceMessage
+    public class RefreshAuthMessage : ExtensibleServiceMessage, IAckableMessage
     {
         /// <summary>
-        /// Gets or sets the connection id or the original token.
+        /// Gets or sets the connection id or the original connection token that identifies the live client connection whose authentication state is being refreshed.
         /// </summary>
         public string ConnectionIdOrToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the new auth token.
+        /// Gets or sets the refreshed user claims for the connection.
         /// </summary>
-        public string AuthToken { get; set; }
+        public System.Security.Claims.Claim[] Claims { get; set; }
 
         /// <summary>
-        /// Gets or sets the expire time of the new auth token in UTC.
+        /// Gets or sets the protocol correlation id used to acknowledge this refresh operation.
         /// </summary>
-        public DateTimeOffset ExpireTime { get; set; }
+        public int AckId { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// Initializes a new instance of the <see cref="RefreshAuthMessage"/> class.
         /// </summary>
-        /// <param name="connectionIdOrToken">The connection id or the original token.</param>
-        /// <param name="authToken">The new auth token.</param>
-        /// <param name="expireTime">The expire time of the new auth token in UTC.</param>
-        public RefreshTokenMessage(string connectionIdOrToken, string authToken, DateTimeOffset expireTime)
+        /// <param name="connectionIdOrToken">The connection id or the original connection token.</param>
+        /// <param name="claims">The refreshed user claims.</param>
+        /// <param name="ackId">The protocol correlation id used to acknowledge this refresh operation.</param>
+        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[] claims, int ackId)
         {
             ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
-            AuthToken = authToken ?? throw new ArgumentNullException(nameof(authToken));
-            ExpireTime = expireTime.ToUniversalTime();
+            Claims = claims ?? throw new ArgumentNullException(nameof(claims));
+            AckId = ackId;
         }
     }
 
@@ -636,7 +636,7 @@ namespace Microsoft.Azure.SignalR.Protocol
 
         /// <summary>
         /// A token to indiate the start point of results.
-        /// This parameter is provided by the service in the response of a previous request when there are additional results to be fetched. 
+        /// This parameter is provided by the service in the response of a previous request when there are additional results to be fetched.
         /// Clients should include the continuationToken in the next request to receive the subsequent page of data. If this parameter is omitted, the server will return the first page of results.
         /// </summary>
         public string? ContinuationToken { get; set; }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -320,6 +320,40 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
+    /// A refresh token message.
+    /// </summary>
+    public class RefreshTokenMessage : ExtensibleServiceMessage
+    {
+        /// <summary>
+        /// Gets or sets the connection id or the original token.
+        /// </summary>
+        public string? ConnectionIdOrToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new refresh token.
+        /// </summary>
+        public string? NewToken { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// </summary>
+        public RefreshTokenMessage()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenMessage"/> class.
+        /// </summary>
+        /// <param name="connectionIdOrToken">The connection id or the original token.</param>
+        /// <param name="newToken">The new refresh token.</param>
+        public RefreshTokenMessage(string connectionIdOrToken, string newToken)
+        {
+            ConnectionIdOrToken = connectionIdOrToken;
+            NewToken = newToken;
+        }
+    }
+
+    /// <summary>
     /// A handshake request message.
     /// </summary>
     public class HandshakeRequestMessage : ExtensibleServiceMessage

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -765,20 +765,23 @@ public class ServiceProtocol : IServiceProtocol
 
     private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
     {
-        writer.WriteArrayHeader(4);
+        writer.WriteArrayHeader(5);
         writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
         writer.Write(message.ConnectionIdOrToken);
-        writer.Write(message.NewToken);
+        writer.Write(message.AuthToken);
+        writer.Write(message.ExpireTime.UtcTicks);
         message.WriteExtensionMembers(ref writer);
     }
 
     private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
     {
-        var message = new RefreshTokenMessage()
-        {
-            ConnectionIdOrToken = ReadString(ref reader, "connectionIdOrToken"),
-            NewToken = ReadString(ref reader, "newToken"),
-        };
+        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
+        var authToken = ReadStringNotNull(ref reader, "authToken");
+        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var message = new RefreshTokenMessage(
+            connectionIdOrToken,
+            authToken,
+            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -807,7 +807,7 @@ public class ServiceProtocol : IServiceProtocol
         {
             writer.WriteMapHeader(0);
         }
-        writer.Write(message.ExpireTime.UtcTicks);
+        writer.Write(message.ExpireTime.UtcDateTime);
         writer.Write(message.AckId);
         message.WriteExtensionMembers(ref writer);
     }
@@ -1452,12 +1452,12 @@ public class ServiceProtocol : IServiceProtocol
     {
         var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
         var claims = ReadClaims(ref reader);
-        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var expireTime = reader.ReadDateTime();
         var ackId = ReadInt32(ref reader, "ackId");
         var message = new RefreshAuthMessage(
             connectionIdOrToken,
             claims,
-            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero),
+            new DateTimeOffset(expireTime, TimeSpan.Zero),
             ackId);
         message.ReadExtensionMembers(ref reader);
         return message;

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -763,29 +763,6 @@ public class ServiceProtocol : IServiceProtocol
         message.WriteExtensionMembers(ref writer);
     }
 
-    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
-    {
-        writer.WriteArrayHeader(5);
-        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
-        writer.Write(message.ConnectionIdOrToken);
-        writer.Write(message.AuthToken);
-        writer.Write(message.ExpireTime.UtcTicks);
-        message.WriteExtensionMembers(ref writer);
-    }
-
-    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
-    {
-        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
-        var authToken = ReadStringNotNull(ref reader, "authToken");
-        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
-        var message = new RefreshTokenMessage(
-            connectionIdOrToken,
-            authToken,
-            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
-        message.ReadExtensionMembers(ref reader);
-        return message;
-    }
-
     private static void WriteGroupMemberQueryMessage(ref MessagePackWriter writer, GroupMemberQueryMessage message)
     {
         writer.WriteArrayHeader(7);
@@ -810,6 +787,16 @@ public class ServiceProtocol : IServiceProtocol
         {
             writer.WriteNil();
         }
+    }
+
+    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
+    {
+        writer.WriteArrayHeader(5);
+        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
+        writer.Write(message.ConnectionIdOrToken);
+        writer.Write(message.AuthToken);
+        writer.Write(message.ExpireTime.UtcTicks);
+        message.WriteExtensionMembers(ref writer);
     }
 
     private static void WriteStringArray(ref MessagePackWriter writer, IReadOnlyList<string>? array)
@@ -1447,4 +1434,18 @@ public class ServiceProtocol : IServiceProtocol
         }
         return result;
     }
+
+    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
+        var authToken = ReadStringNotNull(ref reader, "authToken");
+        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var message = new RefreshTokenMessage(
+            connectionIdOrToken,
+            authToken,
+            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
+        message.ReadExtensionMembers(ref reader);
+        return message;
+    }
+
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -157,6 +157,8 @@ public class ServiceProtocol : IServiceProtocol
                 return CreateConnectionFlowControlMessage(ref reader, arrayLength);
             case ServiceProtocolConstants.GroupMemberQueryMessageType:
                 return CreateGroupMemberQueryMessage(ref reader, arrayLength);
+            case ServiceProtocolConstants.RefreshTokenMessageType:
+                return CreateRefreshTokenMessage(ref reader, arrayLength);
             default:
                 // Future protocol changes can add message types, old clients can ignore them
                 return null;
@@ -342,6 +344,9 @@ public class ServiceProtocol : IServiceProtocol
                 break;
             case GroupMemberQueryMessage groupMemberQueryMessage:
                 WriteGroupMemberQueryMessage(ref writer, groupMemberQueryMessage);
+                break;
+            case RefreshTokenMessage refreshTokenMessage:
+                WriteRefreshTokenMessage(ref writer, refreshTokenMessage);
                 break;
             default:
                 throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
@@ -756,6 +761,26 @@ public class ServiceProtocol : IServiceProtocol
         writer.WriteInt32((int)message.ConnectionType);
         writer.WriteInt32((int)message.Operation);
         message.WriteExtensionMembers(ref writer);
+    }
+
+    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
+        writer.Write(message.ConnectionIdOrToken);
+        writer.Write(message.NewToken);
+        message.WriteExtensionMembers(ref writer);
+    }
+
+    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var message = new RefreshTokenMessage()
+        {
+            ConnectionIdOrToken = ReadString(ref reader, "connectionIdOrToken"),
+            NewToken = ReadString(ref reader, "newToken"),
+        };
+        message.ReadExtensionMembers(ref reader);
+        return message;
     }
 
     private static void WriteGroupMemberQueryMessage(ref MessagePackWriter writer, GroupMemberQueryMessage message)

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -1452,13 +1452,13 @@ public class ServiceProtocol : IServiceProtocol
     {
         var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
         var claims = ReadClaims(ref reader);
-        var ackId = ReadInt32(ref reader, "ackId");
         var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var ackId = ReadInt32(ref reader, "ackId");
         var message = new RefreshAuthMessage(
             connectionIdOrToken,
             claims,
-            ackId,
-           new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
+            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero),
+            ackId);
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -791,7 +791,7 @@ public class ServiceProtocol : IServiceProtocol
 
     private static void WriteRefreshAuthMessage(ref MessagePackWriter writer, RefreshAuthMessage message)
     {
-        writer.WriteArrayHeader(5);
+        writer.WriteArrayHeader(6);
         writer.Write(ServiceProtocolConstants.RefreshAuthMessageType);
         writer.Write(message.ConnectionIdOrToken);
         if (message.Claims?.Length > 0)
@@ -807,6 +807,7 @@ public class ServiceProtocol : IServiceProtocol
         {
             writer.WriteMapHeader(0);
         }
+        writer.Write(message.ExpireTime.UtcTicks);
         writer.Write(message.AckId);
         message.WriteExtensionMembers(ref writer);
     }
@@ -1452,7 +1453,12 @@ public class ServiceProtocol : IServiceProtocol
         var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
         var claims = ReadClaims(ref reader);
         var ackId = ReadInt32(ref reader, "ackId");
-        var message = new RefreshAuthMessage(connectionIdOrToken, claims, ackId);
+        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
+        var message = new RefreshAuthMessage(
+            connectionIdOrToken,
+            claims,
+            ackId,
+           new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -157,8 +157,8 @@ public class ServiceProtocol : IServiceProtocol
                 return CreateConnectionFlowControlMessage(ref reader, arrayLength);
             case ServiceProtocolConstants.GroupMemberQueryMessageType:
                 return CreateGroupMemberQueryMessage(ref reader, arrayLength);
-            case ServiceProtocolConstants.RefreshTokenMessageType:
-                return CreateRefreshTokenMessage(ref reader, arrayLength);
+            case ServiceProtocolConstants.RefreshAuthMessageType:
+                return CreateRefreshAuthMessage(ref reader, arrayLength);
             default:
                 // Future protocol changes can add message types, old clients can ignore them
                 return null;
@@ -345,8 +345,8 @@ public class ServiceProtocol : IServiceProtocol
             case GroupMemberQueryMessage groupMemberQueryMessage:
                 WriteGroupMemberQueryMessage(ref writer, groupMemberQueryMessage);
                 break;
-            case RefreshTokenMessage refreshTokenMessage:
-                WriteRefreshTokenMessage(ref writer, refreshTokenMessage);
+            case RefreshAuthMessage refreshAuthMessage:
+                WriteRefreshAuthMessage(ref writer, refreshAuthMessage);
                 break;
             default:
                 throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
@@ -789,13 +789,25 @@ public class ServiceProtocol : IServiceProtocol
         }
     }
 
-    private static void WriteRefreshTokenMessage(ref MessagePackWriter writer, RefreshTokenMessage message)
+    private static void WriteRefreshAuthMessage(ref MessagePackWriter writer, RefreshAuthMessage message)
     {
         writer.WriteArrayHeader(5);
-        writer.Write(ServiceProtocolConstants.RefreshTokenMessageType);
+        writer.Write(ServiceProtocolConstants.RefreshAuthMessageType);
         writer.Write(message.ConnectionIdOrToken);
-        writer.Write(message.AuthToken);
-        writer.Write(message.ExpireTime.UtcTicks);
+        if (message.Claims?.Length > 0)
+        {
+            writer.WriteMapHeader(message.Claims.Length);
+            foreach (var claim in message.Claims)
+            {
+                writer.Write(claim.Type);
+                writer.Write(claim.Value);
+            }
+        }
+        else
+        {
+            writer.WriteMapHeader(0);
+        }
+        writer.Write(message.AckId);
         message.WriteExtensionMembers(ref writer);
     }
 
@@ -1435,15 +1447,12 @@ public class ServiceProtocol : IServiceProtocol
         return result;
     }
 
-    private static RefreshTokenMessage CreateRefreshTokenMessage(ref MessagePackReader reader, int arrayLength)
+    private static RefreshAuthMessage CreateRefreshAuthMessage(ref MessagePackReader reader, int arrayLength)
     {
         var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
-        var authToken = ReadStringNotNull(ref reader, "authToken");
-        var expireTimeTicks = ReadInt64(ref reader, "expireTime");
-        var message = new RefreshTokenMessage(
-            connectionIdOrToken,
-            authToken,
-            new DateTimeOffset(expireTimeTicks, TimeSpan.Zero));
+        var claims = ReadClaims(ref reader);
+        var ackId = ReadInt32(ref reader, "ackId");
+        var message = new RefreshAuthMessage(connectionIdOrToken, claims, ackId);
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -46,5 +46,5 @@ public static class ServiceProtocolConstants
     public const int ConnectionReconnectMessageType = 38;
     public const int ConnectionFlowControlMessageType = 39;
     public const int GroupMemberQueryMessageType = 40;
-    public const int RefreshTokenMessageType = 41;
+    public const int RefreshAuthMessageType = 41;
 }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -46,4 +46,5 @@ public static class ServiceProtocolConstants
     public const int ConnectionReconnectMessageType = 38;
     public const int ConnectionFlowControlMessageType = 39;
     public const int GroupMemberQueryMessageType = 40;
+    public const int RefreshTokenMessageType = 41;
 }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return ConnectionFlowControlMessageEqual(connectionFlowControlMessage, (ConnectionFlowControlMessage)y);
                 case GroupMemberQueryMessage groupMemberQueryMessage:
                     return GroupMemberQueryMessageEqual(groupMemberQueryMessage, (GroupMemberQueryMessage)y);
-                case RefreshTokenMessage refreshTokenMessage:
-                    return RefreshTokenMessageEqual(refreshTokenMessage, (RefreshTokenMessage)y);
+                case RefreshAuthMessage refreshAuthMessage:
+                    return RefreshAuthMessageEqual(refreshAuthMessage, (RefreshAuthMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -412,11 +412,11 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                    x.TracingId == y.TracingId;
         }
 
-        private static bool RefreshTokenMessageEqual(RefreshTokenMessage x, RefreshTokenMessage y)
+        private static bool RefreshAuthMessageEqual(RefreshAuthMessage x, RefreshAuthMessage y)
         {
             return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
-                StringEqual(x.AuthToken, y.AuthToken) &&
-                x.ExpireTime == y.ExpireTime;
+                x.AckId == y.AckId &&
+                ClaimsEqual(x.Claims, y.Claims);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -106,6 +106,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return ConnectionFlowControlMessageEqual(connectionFlowControlMessage, (ConnectionFlowControlMessage)y);
                 case GroupMemberQueryMessage groupMemberQueryMessage:
                     return GroupMemberQueryMessageEqual(groupMemberQueryMessage, (GroupMemberQueryMessage)y);
+                case RefreshTokenMessage refreshTokenMessage:
+                    return RefreshTokenMessageEqual(refreshTokenMessage, (RefreshTokenMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -408,6 +410,12 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                    x.Top == y.Top &&
                    StringEqual(x.ContinuationToken, y.ContinuationToken) &&
                    x.TracingId == y.TracingId;
+        }
+
+        private static bool RefreshTokenMessageEqual(RefreshTokenMessage x, RefreshTokenMessage y)
+        {
+            return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
+                StringEqual(x.NewToken, y.NewToken);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
             return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
                 x.AckId == y.AckId &&
                 ClaimsEqual(x.Claims, y.Claims) &&
-                x.ExpireTime == y.ExpireTime;
+                x.ExpireTime.UtcDateTime == y.ExpireTime.UtcDateTime;
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -416,7 +416,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         {
             return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
                 x.AckId == y.AckId &&
-                ClaimsEqual(x.Claims, y.Claims);
+                ClaimsEqual(x.Claims, y.Claims) &&
+                x.ExpireTime == y.ExpireTime;
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -415,7 +415,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
         private static bool RefreshTokenMessageEqual(RefreshTokenMessage x, RefreshTokenMessage y)
         {
             return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
-                StringEqual(x.NewToken, y.NewToken);
+                StringEqual(x.AuthToken, y.AuthToken) &&
+                x.ExpireTime == y.ExpireTime;
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -780,6 +780,10 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "GroupMemberQueryMessageWithOptionalFields",
                 message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1, MaxPageSize = 5, Top = 10, ContinuationToken = "token", TracingId = 1234UL },
                 binary: "lyiBAc0E0qVncm91cAEKpXRva2VuBQ=="),
+            new ProtocolTestData(
+                name: "RefreshTokenMessage",
+                message: new RefreshTokenMessage("conn1", "newtoken"),
+                binary: "lCmlY29ubjGobmV3dG9rZW6A"),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -786,7 +786,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 {
                     new System.Security.Claims.Claim("role", "reader"),
                 }, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 1),
-                binary: "limlY29ubjGBpHJvbGWmcmVhZGVyzwjcClyZAMAAAYA="),
+                binary: "limlY29ubjGBpHJvbGWmcmVhZGVy1v9lkgCAAYA="),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -784,10 +784,9 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 name: "RefreshAuthMessage",
                 message: new RefreshAuthMessage("conn1", new[]
                 {
-                    new System.Security.Claims.Claim("sub", "u1"),
-                    new System.Security.Claims.Claim("exp", "1700000000"),
-                }, 1),
-                binary: "lSmlY29ubjGCo3N1YqJ1MaNleHCqMTcwMDAwMDAwMAGA"),
+                    new System.Security.Claims.Claim("role", "reader"),
+                }, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 1),
+                binary: "limlY29ubjGBpHJvbGWmcmVhZGVyzwjcClyZAMAAAYA="),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -781,9 +781,13 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 message: new GroupMemberQueryMessage() { GroupName = "group", AckId = 1, MaxPageSize = 5, Top = 10, ContinuationToken = "token", TracingId = 1234UL },
                 binary: "lyiBAc0E0qVncm91cAEKpXRva2VuBQ=="),
             new ProtocolTestData(
-                name: "RefreshTokenMessage",
-                message: new RefreshTokenMessage("conn1", "newtoken", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
-                binary: "lSmlY29ubjGobmV3dG9rZW7PCNwKXJkAwACA"),
+                name: "RefreshAuthMessage",
+                message: new RefreshAuthMessage("conn1", new[]
+                {
+                    new System.Security.Claims.Claim("sub", "u1"),
+                    new System.Security.Claims.Claim("exp", "1700000000"),
+                }, 1),
+                binary: "lSmlY29ubjGCo3N1YqJ1MaNleHCqMTcwMDAwMDAwMAGA"),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -782,8 +782,8 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 binary: "lyiBAc0E0qVncm91cAEKpXRva2VuBQ=="),
             new ProtocolTestData(
                 name: "RefreshTokenMessage",
-                message: new RefreshTokenMessage("conn1", "newtoken"),
-                binary: "lCmlY29ubjGobmV3dG9rZW6A"),
+                message: new RefreshTokenMessage("conn1", "newtoken", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+                binary: "lSmlY29ubjGobmV3dG9rZW7PCNwKXJkAwACA"),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)

Update from PR #2259

Add `RefreshAuthMessage`, a new service-protocol message the SDK sends to Azure SignalR Service over an existing server connection to refresh a live client connection's authentication state before it expires.

Fields:

- `41`: message type for `RefreshAuthMessage`.
- `ConnectionIdOrToken`: The connection id or the connection token that identifies the live client connection.
- `Claims`: The refreshed user claims for the connection.
- `ExpireTime` : The time at which the refreshed authentication state expires in UTC.
- `AckId`: The protocol correlation id used to acknowledge this refresh operation.
- `ExtensionMembers`: extension map for forward-compatible optional fields.
