### PR TITLE
Add .NET 8.x in `release.yml`

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -44,6 +44,7 @@ trigger:
   branches:
     include:
       - dev
+      - shiyingchen/fix-release-2
   paths:
     include:
       - src
@@ -95,6 +96,11 @@ extends:
                     echo $(VersionSuffix)
                     echo $(MSBuildProperties)
                   displayName: Print VersionSuffix and MSBuildProperties
+              - task: UseDotNet@2
+                displayName: Add 8.x
+                inputs:
+                  version: 8.x
+                  performMultiLevelLookup: true
               - task: UseDotNet@2
                 displayName: Add 10.x
                 inputs:

--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -44,7 +44,6 @@ trigger:
   branches:
     include:
       - dev
-      - shiyingchen/fix-release-2
   paths:
     include:
       - src


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)

Add .NET 8.0 runtime back to `release.yml`, since it is necessary for running tests
