### PR TITLE
Rename `ConnectionIdOrToken` to `ConnectionToken` for `RefreshAuthMessage`

### DIFF
--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -404,10 +404,10 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
     public partial class RefreshAuthMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage, Microsoft.Azure.SignalR.Protocol.IAckableMessage
     {
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[]? claims, System.DateTimeOffset expireTime, int ackId) { }
+        public RefreshAuthMessage(string connectionToken, System.Security.Claims.Claim[]? claims, System.DateTimeOffset expireTime, int ackId) { }
         public int AckId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public System.Security.Claims.Claim[]? Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public string ConnectionIdOrToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string ConnectionToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public System.DateTimeOffset ExpireTime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public abstract partial class ServiceCompletionMessage : Microsoft.Azure.SignalR.Protocol.ConnectionMessage, Microsoft.Azure.SignalR.Protocol.IMessageWithTracingId

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -647,10 +647,10 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 ### RefreshAuth Message
 `RefreshAuth` messages have the following structure:
 ```
-[41, ConnectionIdOrToken, Claims?, ExpireTime, AckId, ExtensionMembers]
+[41, ConnectionToken, Claims?, ExpireTime, AckId, ExtensionMembers]
 ```
 - 41 - Message Type, indicating this is a `RefreshAuth` message.
-- ConnectionIdOrToken - A `String` indicating the connection ID or the original connection token of the live client connection whose authentication state is being refreshed.
+- ConnectionToken - A `String` indicating the connection token of the live client connection whose authentication state is being refreshed.
 - Claims - An optional MessagePack Map of `String` to `String` indicating the refreshed user claims.
 - ExpireTime - A MessagePack Timestamp indicating the new authentication expiration deadline in UTC.
 - AckId - An `Int32` encoding Id number to identify the corresponding ack message.

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -330,9 +330,9 @@ namespace Microsoft.Azure.SignalR.Protocol
     public class RefreshAuthMessage : ExtensibleServiceMessage, IAckableMessage
     {
         /// <summary>
-        /// Gets or sets the connection id or the connection token that identifies the live client connection whose authentication state is being refreshed.
+        /// Gets or sets the connection token that identifies the live client connection whose authentication state is being refreshed.
         /// </summary>
-        public string ConnectionIdOrToken { get; set; }
+        public string ConnectionToken { get; set; }
 
         /// <summary>
         /// Gets or sets the refreshed user claims for the connection.
@@ -352,13 +352,13 @@ namespace Microsoft.Azure.SignalR.Protocol
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshAuthMessage"/> class.
         /// </summary>
-        /// <param name="connectionIdOrToken">The connection id or the connection token that identifies the live client connection.</param>
+        /// <param name="connectionToken">The connection token that identifies the live client connection.</param>
         /// <param name="claims">The refreshed user claims for the connection.</param>
         /// <param name="expireTime">The time at which the refreshed authentication state expires in UTC.</param>
         /// <param name="ackId">The protocol correlation id used to acknowledge this refresh operation.</param>
-        public RefreshAuthMessage(string connectionIdOrToken, System.Security.Claims.Claim[]? claims, DateTimeOffset expireTime, int ackId)
+        public RefreshAuthMessage(string connectionToken, System.Security.Claims.Claim[]? claims, DateTimeOffset expireTime, int ackId)
         {
-            ConnectionIdOrToken = connectionIdOrToken ?? throw new ArgumentNullException(nameof(connectionIdOrToken));
+            ConnectionToken = connectionToken ?? throw new ArgumentNullException(nameof(connectionToken));
             Claims = claims;
             ExpireTime = expireTime.ToUniversalTime();
             AckId = ackId;

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -793,7 +793,7 @@ public class ServiceProtocol : IServiceProtocol
     {
         writer.WriteArrayHeader(6);
         writer.Write(ServiceProtocolConstants.RefreshAuthMessageType);
-        writer.Write(message.ConnectionIdOrToken);
+        writer.Write(message.ConnectionToken);
         if (message.Claims?.Length > 0)
         {
             writer.WriteMapHeader(message.Claims.Length);
@@ -1450,12 +1450,12 @@ public class ServiceProtocol : IServiceProtocol
 
     private static RefreshAuthMessage CreateRefreshAuthMessage(ref MessagePackReader reader, int arrayLength)
     {
-        var connectionIdOrToken = ReadStringNotNull(ref reader, "connectionIdOrToken");
+        var connectionToken = ReadStringNotNull(ref reader, "connectionToken");
         var claims = ReadClaims(ref reader);
         var expireTime = reader.ReadDateTime();
         var ackId = ReadInt32(ref reader, "ackId");
         var message = new RefreshAuthMessage(
-            connectionIdOrToken,
+            connectionToken,
             claims,
             new DateTimeOffset(expireTime, TimeSpan.Zero),
             ackId);

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
 
         private static bool RefreshAuthMessageEqual(RefreshAuthMessage x, RefreshAuthMessage y)
         {
-            return StringEqual(x.ConnectionIdOrToken, y.ConnectionIdOrToken) &&
+            return StringEqual(x.ConnectionToken, y.ConnectionToken) &&
                 x.AckId == y.AckId &&
                 ClaimsEqual(x.Claims, y.Claims) &&
                 x.ExpireTime.UtcDateTime == y.ExpireTime.UtcDateTime;


### PR DESCRIPTION
A follow-up PR related to #2261