### PR TITLE
Upgrade MessagePack to 3.1.7

### DIFF
--- a/.github/workflows/apichecks.yml
+++ b/.github/workflows/apichecks.yml
@@ -27,6 +27,9 @@ jobs:
             - '**.csproj'
             - '**.targets'
             - '*.sln'
+      - name: Enable git long paths
+        if: steps.filter.outputs.src == 'true'
+        run: git config --global core.longpaths true
       - name: Update SubModules
         if: steps.filter.outputs.src == 'true'
         run: git submodule update --init --recursive

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,9 @@ jobs:
           - '**.targets'
           - '*.sh'
           - '*.sln'
+    - name: Enable git long paths
+      run: git config --global core.longpaths true
+      if: steps.filter.outputs.src == 'true'
     - name: Update SubModules
       run: git submodule update --init --recursive
       if: steps.filter.outputs.src == 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/submodules/MessagePack-CSharp"]
 	path = src/submodules/MessagePack-CSharp
 	url = https://github.com/neuecc/MessagePack-CSharp
-	branch = v2.1.115
+	branch = v3.1.7

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -59,7 +59,7 @@
     
     <!-- Vulnerability fix-->
     <jQueryPackageVersion>3.7.1</jQueryPackageVersion>
-    <MessagePackPackageVersion>2.5.192</MessagePackPackageVersion>
+    <MessagePackPackageVersion>3.1.7</MessagePackPackageVersion>
     <SystemNetHttpPackageVersion>4.3.4</SystemNetHttpPackageVersion>
     <SystemTextRegularExpressionsPackageVersion>4.3.1</SystemTextRegularExpressionsPackageVersion>
   </PropertyGroup>

--- a/src/Common/DoesNotReturnIfAttribute.cs
+++ b/src/Common/DoesNotReturnIfAttribute.cs
@@ -1,4 +1,5 @@
-// Licensed under the MIT License.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Polyfill for System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute, which is
 // referenced by the vendored MessagePack source but is not available on netstandard2.0.

--- a/src/Common/DoesNotReturnIfAttribute.cs
+++ b/src/Common/DoesNotReturnIfAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed under the MIT License.
+
+// Polyfill for System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute, which is
+// referenced by the vendored MessagePack source but is not available on netstandard2.0.
+#if !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP3_0_OR_GREATER && !NET5_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) => this.ParameterValue = parameterValue;
+
+        public bool ParameterValue { get; }
+    }
+}
+#endif

--- a/src/Microsoft.Azure.SignalR.Protocols/Microsoft.Azure.SignalR.Protocols.csproj
+++ b/src/Microsoft.Azure.SignalR.Protocols/Microsoft.Azure.SignalR.Protocols.csproj
@@ -23,27 +23,31 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;SPAN_BUILTIN;MESSAGEPACK_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <MessagePackRoot>$(RepositoryRoot)src\submodules\MessagePack-CSharp\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\</MessagePackRoot>
+    <MessagePackRoot>$(RepositoryRoot)src\submodules\MessagePack-CSharp\src\MessagePack\</MessagePackRoot>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- MessagePack -->
     <Compile Include="$(MessagePackRoot)MessagePackReader.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackReader.Integers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Readers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Readers.Integers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackWriter.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Writers.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)SequenceReader.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)SequenceReaderExtensions.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)MessagePackSerializationException.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)MessagePackCode.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)T4\MessagePackReader.Integers.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackWriter.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)ExtensionHeader.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)Nil.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)ExtensionResult.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)SequenceReaderExtensions.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)Internal\DateTimeConstants.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)StringEncoding.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)BufferWriter.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)SequencePool.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)Utilities.cs" LinkBase="MessagePack" />
     <Compile Include="..\Common\SequenceOfT.cs" LinkBase="MessagePack" />
+    <Compile Include="..\Common\DoesNotReturnIfAttribute.cs" Link="Internal\DoesNotReturnIfAttribute.cs" />
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
+++ b/src/Microsoft.Azure.SignalR.Serverless.Protocols/Microsoft.Azure.SignalR.Serverless.Protocols.csproj
@@ -15,21 +15,24 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;SPAN_BUILTIN;MESSAGEPACK_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <MessagePackRoot>$(RepositoryRoot)src\submodules\MessagePack-CSharp\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\</MessagePackRoot>
+    <MessagePackRoot>$(RepositoryRoot)src\submodules\MessagePack-CSharp\src\MessagePack\</MessagePackRoot>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- MessagePack -->
     <Compile Include="$(MessagePackRoot)MessagePackReader.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackReader.Integers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Readers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Readers.Integers.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackWriter.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)MessagePackPrimitives.Writers.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)SequenceReader.cs" LinkBase="MessagePack" />
+    <Compile Include="$(MessagePackRoot)SequenceReaderExtensions.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)MessagePackSerializationException.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)MessagePackCode.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)T4\MessagePackReader.Integers.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackWriter.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)ExtensionHeader.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)Nil.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)ExtensionResult.cs" LinkBase="MessagePack" />
-    <Compile Include="$(MessagePackRoot)SequenceReaderExtensions.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)Internal\DateTimeConstants.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)StringEncoding.cs" LinkBase="MessagePack" />
     <Compile Include="$(MessagePackRoot)BufferWriter.cs" LinkBase="MessagePack" />
@@ -37,6 +40,7 @@
     <Compile Include="$(MessagePackRoot)Utilities.cs" LinkBase="MessagePack" />
     <Compile Include="..\Common\MemoryBufferWriter.cs" Link="Internal\MemoryBufferWriter.cs" />
     <Compile Include="..\Common\SequenceOfT.cs" LinkBase="MessagePack" />
+    <Compile Include="..\Common\DoesNotReturnIfAttribute.cs" Link="Internal\DoesNotReturnIfAttribute.cs" />
   </ItemGroup>
   
 </Project>

--- a/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Management/ServiceHubContextE2EFacts.cs
@@ -1703,7 +1703,7 @@ public class ServiceHubContextE2EFacts : VerifiableLoggedTest
         }
     }
 
-    private sealed class TestEnumFormatter : IMessagePackFormatter<TestEnum>
+    internal sealed class TestEnumFormatter : IMessagePackFormatter<TestEnum>
     {
         public void Serialize(ref MessagePackWriter writer, TestEnum value, MessagePackSerializerOptions options)
         {
@@ -1722,7 +1722,7 @@ public class ServiceHubContextE2EFacts : VerifiableLoggedTest
         }
     }
 
-    private sealed class TestInvocationResultFormatter : IMessagePackFormatter<TestInvocationResult>
+    internal sealed class TestInvocationResultFormatter : IMessagePackFormatter<TestInvocationResult>
     {
         public void Serialize(ref MessagePackWriter writer, TestInvocationResult value, MessagePackSerializerOptions options)
         {
@@ -1791,7 +1791,7 @@ public class ServiceHubContextE2EFacts : VerifiableLoggedTest
         }
     }
 
-    private sealed class TestInvocationInputFormatter : IMessagePackFormatter<TestInvocationInput>
+    internal sealed class TestInvocationInputFormatter : IMessagePackFormatter<TestInvocationInput>
     {
         public void Serialize(ref MessagePackWriter writer, TestInvocationInput value, MessagePackSerializerOptions options)
         {


### PR DESCRIPTION
﻿## Summary
Upgrades **MessagePack to 3.1.7** to address security concerns, covering **both** places it is referenced:
1. The NuGet package (used by test/sample projects).
2. The vendored source compiled from the `MessagePack-CSharp` git submodule into the Protocols libraries.

## Changes
- `build/dependencies.props`: `MessagePackPackageVersion` `2.5.192` → `3.1.7`.
- Submodule `src/submodules/MessagePack-CSharp`: bumped to tag `v3.1.7` (`d3d435b9` → `1b53ae8b`); `.gitmodules` branch updated to `v3.1.7`.
- `Microsoft.Azure.SignalR.Protocols` & `Microsoft.Azure.SignalR.Serverless.Protocols` csproj: v3 relocated the core source from `MessagePack.UnityClient/Assets/Scripts/MessagePack/` to `src/MessagePack/`. Updated `MessagePackRoot` and the vendored `Compile Include` list (added the new `MessagePackPrimitives.*` and `MessagePackReader.Integers.cs` files).
- `src/Common/DoesNotReturnIfAttribute.cs`: minimal `internal` polyfill. v3 relies on PolySharp for `DoesNotReturnIfAttribute`, which netstandard2.0 lacks and the vendored projects do not use. Guarded so it cannot conflict under `TreatWarningsAsErrors`.
- `ServiceHubContextE2EFacts.cs`: three custom `IMessagePackFormatter` test classes changed `private` → `internal` to satisfy v3's now-default `MsgPack010` analyzer.

## Breaking-change assessment (v2 → v3)
- **Wire format unchanged.** `ServiceProtocolFacts` asserts against hardcoded golden base64 byte strings; all 229 protocol tests pass, proving v3 emits byte-for-byte identical output → full client/service interop preserved.
- **Low-level API compatible.** Production `src/` code uses only the vendored `MessagePackReader`/`MessagePackWriter` (no high-level serializer/resolver/formatter), so v3's "AOT source-gen on by default" has no effect. The only high-level usage is one E2E test that registers formatters explicitly via `CompositeResolver.Create(...)`.
- **Analyzer.** The only breaking change that touched us was `MsgPack010` (fixed). Full solution builds with 0 warnings / 0 errors under `TreatWarningsAsErrors`.

## Verification
- `dotnet build AzureSignalR.sln`: 0 warnings, 0 errors.
- `Protocols.Tests`: 229 passed · `Serverless.Protocols.Tests`: 18 passed · `Management` serialization tests: 2 passed.
