### PR TITLE
Add new service protocols `GetConnectionClaimsMessage` and `UpdateConnectionClaimsMessage`

### DIFF
--- a/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Protocols.netstandard2.0.cs
@@ -213,6 +213,12 @@ namespace Microsoft.Azure.SignalR.Protocol
     {
         protected ExtensibleServiceMessage() { }
     }
+    public partial class GetConnectionClaimsMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage, Microsoft.Azure.SignalR.Protocol.IAckableMessage
+    {
+        public GetConnectionClaimsMessage(string connectionToken, int ackId) { }
+        public int AckId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string ConnectionToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
     public partial class GroupBroadcastDataMessage : Microsoft.Azure.SignalR.Protocol.MulticastDataMessage, Microsoft.Azure.SignalR.Protocol.IPartitionableMessage
     {
         public GroupBroadcastDataMessage(string groupName, System.Collections.Generic.IDictionary<string, System.ReadOnlyMemory<byte>> payloads, ulong? tracingId = default(ulong?)) : base (default(System.Collections.Generic.IDictionary<string, System.ReadOnlyMemory<byte>>), default(ulong?)) { }
@@ -489,6 +495,7 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int ConnectionFlowControlMessageType = 39;
         public const int ConnectionReconnectMessageType = 38;
         public const int ErrorCompletionMessageType = 36;
+        public const int GetConnectionClaimsMessageType = 42;
         public const int GroupBroadcastDataMessageType = 13;
         public const int GroupMemberQueryMessageType = 40;
         public const int HandshakeRequestType = 1;
@@ -506,11 +513,18 @@ namespace Microsoft.Azure.SignalR.Protocol
         public const int ServiceErrorMessageType = 15;
         public const int ServiceEventMessageType = 22;
         public const int ServiceMappingMessageType = 37;
+        public const int UpdateConnectionClaimsMessageType = 43;
         public const int UserDataMessageType = 8;
         public const int UserJoinGroupMessageType = 16;
         public const int UserJoinGroupWithAckMessageType = 26;
         public const int UserLeaveGroupMessageType = 17;
         public const int UserLeaveGroupWithAckMessageType = 27;
+    }
+    public partial class UpdateConnectionClaimsMessage : Microsoft.Azure.SignalR.Protocol.ExtensibleServiceMessage
+    {
+        public UpdateConnectionClaimsMessage(string connectionId, System.Security.Claims.Claim[]? claims) { }
+        public System.Security.Claims.Claim[]? Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string ConnectionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
     public partial class UserDataMessage : Microsoft.Azure.SignalR.Protocol.MulticastDataMessage, Microsoft.Azure.SignalR.Protocol.IPartitionableMessage
     {

--- a/specs/ServiceProtocol.md
+++ b/specs/ServiceProtocol.md
@@ -657,3 +657,27 @@ MessagePack uses different formats to encode values. Refer to the [MessagePack F
 - ExtensionMembers - A MessagePack Map indicates the extensible members.
 
 #### Example: TODO
+
+### GetConnectionClaims Message
+`GetConnectionClaims` messages have the following structure:
+```
+[42, ConnectionToken, AckId, ExtensionMembers]
+```
+- 42 - Message Type, indicating this is a `GetConnectionClaims` message.
+- ConnectionToken - A `String` indicating the connection token of the live client connection whose current user claims are being fetched.
+- AckId - An `Int32` encoding Id number to identify the corresponding ack message.
+- ExtensionMembers - A MessagePack Map indicates the extensible members.
+
+#### Example: TODO
+
+### UpdateConnectionClaims Message
+`UpdateConnectionClaims` messages have the following structure:
+```
+[43, ConnectionId, Claims, ExtensionMembers]
+```
+- 43 - Message Type, indicating this is an `UpdateConnectionClaims` message.
+- ConnectionId - A `String` indicating the connection id of the live client connection whose user claims are being updated on the owning server.
+- Claims - A MessagePack Map of `String` to `String` indicating the refreshed user claims to apply.
+- ExtensionMembers - A MessagePack Map indicates the extensible members.
+
+#### Example: TODO

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceMessage.cs
@@ -366,6 +366,60 @@ namespace Microsoft.Azure.SignalR.Protocol
     }
 
     /// <summary>
+    /// A read-only message to fetch the current user claims of an existing client connection.
+    /// </summary>
+    public class GetConnectionClaimsMessage : ExtensibleServiceMessage, IAckableMessage
+    {
+        /// <summary>
+        /// Gets or sets the connection token that identifies the live client connection whose claims are being fetched.
+        /// </summary>
+        public string ConnectionToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the protocol correlation id used to acknowledge this read operation.
+        /// </summary>
+        public int AckId { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetConnectionClaimsMessage"/> class.
+        /// </summary>
+        /// <param name="connectionToken">The connection token that identifies the live client connection.</param>
+        /// <param name="ackId">The protocol correlation id used to acknowledge this read operation.</param>
+        public GetConnectionClaimsMessage(string connectionToken, int ackId)
+        {
+            ConnectionToken = connectionToken ?? throw new ArgumentNullException(nameof(connectionToken));
+            AckId = ackId;
+        }
+    }
+
+    /// <summary>
+    /// A server-bound message that pushes refreshed user claims of a client connection to its owning app server.
+    /// </summary>
+    public class UpdateConnectionClaimsMessage : ExtensibleServiceMessage
+    {
+        /// <summary>
+        /// Gets or sets the connection id of the live client connection whose claims are being updated.
+        /// </summary>
+        public string ConnectionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the refreshed user claims to apply on the owning app server.
+        /// </summary>
+        public System.Security.Claims.Claim[]? Claims { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateConnectionClaimsMessage"/> class.
+        /// </summary>
+        /// <param name="connectionId">The connection id of the live client connection.</param>
+        /// <param name="claims">The refreshed user claims to apply on the owning app server.</param>
+        public UpdateConnectionClaimsMessage(string connectionId, System.Security.Claims.Claim[]? claims)
+        {
+            ConnectionId = connectionId ?? throw new ArgumentNullException(nameof(connectionId));
+            Claims = claims;
+        }
+    }
+
+    /// <summary>
     /// A handshake request message.
     /// </summary>
     public class HandshakeRequestMessage : ExtensibleServiceMessage

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocol.cs
@@ -159,6 +159,10 @@ public class ServiceProtocol : IServiceProtocol
                 return CreateGroupMemberQueryMessage(ref reader, arrayLength);
             case ServiceProtocolConstants.RefreshAuthMessageType:
                 return CreateRefreshAuthMessage(ref reader, arrayLength);
+            case ServiceProtocolConstants.GetConnectionClaimsMessageType:
+                return CreateGetConnectionClaimsMessage(ref reader, arrayLength);
+            case ServiceProtocolConstants.UpdateConnectionClaimsMessageType:
+                return CreateUpdateConnectionClaimsMessage(ref reader, arrayLength);
             default:
                 // Future protocol changes can add message types, old clients can ignore them
                 return null;
@@ -347,6 +351,12 @@ public class ServiceProtocol : IServiceProtocol
                 break;
             case RefreshAuthMessage refreshAuthMessage:
                 WriteRefreshAuthMessage(ref writer, refreshAuthMessage);
+                break;
+            case GetConnectionClaimsMessage getConnectionClaimsMessage:
+                WriteGetConnectionClaimsMessage(ref writer, getConnectionClaimsMessage);
+                break;
+            case UpdateConnectionClaimsMessage updateConnectionClaimsMessage:
+                WriteUpdateConnectionClaimsMessage(ref writer, updateConnectionClaimsMessage);
                 break;
             default:
                 throw new InvalidDataException($"Unexpected message type: {message.GetType().Name}");
@@ -809,6 +819,36 @@ public class ServiceProtocol : IServiceProtocol
         }
         writer.Write(message.ExpireTime.UtcDateTime);
         writer.Write(message.AckId);
+        message.WriteExtensionMembers(ref writer);
+    }
+
+    private static void WriteGetConnectionClaimsMessage(ref MessagePackWriter writer, GetConnectionClaimsMessage message)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(ServiceProtocolConstants.GetConnectionClaimsMessageType);
+        writer.Write(message.ConnectionToken);
+        writer.Write(message.AckId);
+        message.WriteExtensionMembers(ref writer);
+    }
+
+    private static void WriteUpdateConnectionClaimsMessage(ref MessagePackWriter writer, UpdateConnectionClaimsMessage message)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(ServiceProtocolConstants.UpdateConnectionClaimsMessageType);
+        writer.Write(message.ConnectionId);
+        if (message.Claims?.Length > 0)
+        {
+            writer.WriteMapHeader(message.Claims.Length);
+            foreach (var claim in message.Claims)
+            {
+                writer.Write(claim.Type);
+                writer.Write(claim.Value);
+            }
+        }
+        else
+        {
+            writer.WriteMapHeader(0);
+        }
         message.WriteExtensionMembers(ref writer);
     }
 
@@ -1459,6 +1499,24 @@ public class ServiceProtocol : IServiceProtocol
             claims,
             new DateTimeOffset(expireTime, TimeSpan.Zero),
             ackId);
+        message.ReadExtensionMembers(ref reader);
+        return message;
+    }
+
+    private static GetConnectionClaimsMessage CreateGetConnectionClaimsMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var connectionToken = ReadStringNotNull(ref reader, "connectionToken");
+        var ackId = ReadInt32(ref reader, "ackId");
+        var message = new GetConnectionClaimsMessage(connectionToken, ackId);
+        message.ReadExtensionMembers(ref reader);
+        return message;
+    }
+
+    private static UpdateConnectionClaimsMessage CreateUpdateConnectionClaimsMessage(ref MessagePackReader reader, int arrayLength)
+    {
+        var connectionId = ReadStringNotNull(ref reader, "connectionId");
+        var claims = ReadClaims(ref reader);
+        var message = new UpdateConnectionClaimsMessage(connectionId, claims);
         message.ReadExtensionMembers(ref reader);
         return message;
     }

--- a/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/ServiceProtocolConstants.cs
@@ -47,4 +47,6 @@ public static class ServiceProtocolConstants
     public const int ConnectionFlowControlMessageType = 39;
     public const int GroupMemberQueryMessageType = 40;
     public const int RefreshAuthMessageType = 41;
+    public const int GetConnectionClaimsMessageType = 42;
+    public const int UpdateConnectionClaimsMessageType = 43;
 }

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceMessageEqualityComparer.cs
@@ -108,6 +108,10 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     return GroupMemberQueryMessageEqual(groupMemberQueryMessage, (GroupMemberQueryMessage)y);
                 case RefreshAuthMessage refreshAuthMessage:
                     return RefreshAuthMessageEqual(refreshAuthMessage, (RefreshAuthMessage)y);
+                case GetConnectionClaimsMessage getConnectionClaimsMessage:
+                    return GetConnectionClaimsMessageEqual(getConnectionClaimsMessage, (GetConnectionClaimsMessage)y);
+                case UpdateConnectionClaimsMessage updateConnectionClaimsMessage:
+                    return UpdateConnectionClaimsMessageEqual(updateConnectionClaimsMessage, (UpdateConnectionClaimsMessage)y);
                 default:
                     throw new InvalidOperationException($"Unknown message type: {x.GetType().FullName}");
             }
@@ -418,6 +422,18 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                 x.AckId == y.AckId &&
                 ClaimsEqual(x.Claims, y.Claims) &&
                 x.ExpireTime.UtcDateTime == y.ExpireTime.UtcDateTime;
+        }
+
+        private static bool GetConnectionClaimsMessageEqual(GetConnectionClaimsMessage x, GetConnectionClaimsMessage y)
+        {
+            return StringEqual(x.ConnectionToken, y.ConnectionToken) &&
+                x.AckId == y.AckId;
+        }
+
+        private static bool UpdateConnectionClaimsMessageEqual(UpdateConnectionClaimsMessage x, UpdateConnectionClaimsMessage y)
+        {
+            return StringEqual(x.ConnectionId, y.ConnectionId) &&
+                ClaimsEqual(x.Claims, y.Claims);
         }
 
         private static bool StringEqual(string x, string y)

--- a/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Protocols.Tests/ServiceProtocolFacts.cs
@@ -787,6 +787,17 @@ namespace Microsoft.Azure.SignalR.Protocol.Tests
                     new System.Security.Claims.Claim("role", "reader"),
                 }, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 1),
                 binary: "limlY29ubjGBpHJvbGWmcmVhZGVy1v9lkgCAAYA="),
+            new ProtocolTestData(
+                name: "GetConnectionClaimsMessage",
+                message: new GetConnectionClaimsMessage("conn1", 1),
+                binary: "lCqlY29ubjEBgA=="),
+            new ProtocolTestData(
+                name: "UpdateConnectionClaimsMessage",
+                message: new UpdateConnectionClaimsMessage("conn1", new[]
+                {
+                    new System.Security.Claims.Claim("role", "reader"),
+                }),
+                binary: "lCulY29ubjGBpHJvbGWmcmVhZGVygA=="),
         }.ToDictionary(t => t.Name);
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
Adds two new service protocols `GetConnectionClaimsMessage` and `UpdateConnectionClaimsMessage`

`GetConnectionClaimsMessage`: A read-only, ackable request used to fetch a live client connection's current user claims

Fields:
- `42`: Message type.
- `ConnectionToken`: String. Secret connection token of the live client connection whose claims are being read.
- `AckId`: Int32. The protocol correlation id used to acknowledge this get connection claims operation.
- `ExtensionMembers`: Map. The extension map for forward-compatible optional fields.

`UpdateConnectionClaimsMessage`: A server-bound, fire-and-forget push that propagates refreshed claims out to the owning app server.

Fields:
- `43`: Message type.
- `ConnectionId`: String. Public connection id of the live client connection whose user claims are being updated.
- `Claims`: Map. The refreshed user claims for the connection.
- `ExtensionMembers`: Map. The extension map for forward-compatible optional fields.