### PR TITLE
Update SignalR MessagePack package version to 8.0.28 for CVE patch

### DIFF
--- a/build/dependencies.private.props
+++ b/build/dependencies.private.props
@@ -3,7 +3,8 @@
     <!--For tests and samples: always try the latest version-->
     <SystemIdentityModelTokensJwtPackageVersion>8.0.1</SystemIdentityModelTokensJwtPackageVersion>
     <MicrosoftAspNetCoreHttpConnectionsClientPackageVersion>8.0.8</MicrosoftAspNetCoreHttpConnectionsClientPackageVersion>
-    <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>8.0.8</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
+    <!-- 8.0.28 patches CVE-2026-45591 (GHSA-f8h2-vmm9-qhj6): MessagePack hub protocol DoS -->
+    <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>8.0.28</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
     <MicrosoftAspNetCoreSignalRProtocolsJsonPackageVersion>8.0.7</MicrosoftAspNetCoreSignalRProtocolsJsonPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>8.0.0</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>17.11.0</MicrosoftNETTestSdkPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -55,8 +55,8 @@
 
     <!--Emulator, self-contained, always try the latest version -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.22272.1</SystemCommandLinePackageVersion>
-    <EmulatorMicrosoftPackageVersion>8.0.11</EmulatorMicrosoftPackageVersion>
-    
+    <EmulatorMicrosoftPackageVersion>8.0.28</EmulatorMicrosoftPackageVersion>
+
     <!-- Vulnerability fix-->
     <jQueryPackageVersion>3.7.1</jQueryPackageVersion>
     <MessagePackPackageVersion>3.1.7</MessagePackPackageVersion>

--- a/samples/ChatSample.Cli/ChatSample.Cli.csproj
+++ b/samples/ChatSample.Cli/ChatSample.Cli.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRCommonNet8PackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRCommonNet8PackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.SignalR.E2ETests/Microsoft.Azure.SignalR.E2ETests.csproj
+++ b/test/Microsoft.Azure.SignalR.E2ETests/Microsoft.Azure.SignalR.E2ETests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="$(MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
Package Microsoft.AspNetCore.SignalR.Protocols.MessagePack 8.0.8 / 8.0.11 has a known high severity vulnerability, GHSA-f8h2-vmm9-qhj6