### PR TITLE
Fix the filename is too long in submodule

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -81,6 +81,8 @@ extends:
                   packageParentPath: artifacts
                   publishFeedCredentials: azure-signalr-dev
             steps:
+              - script: git config --global core.longpaths true
+                displayName: Enable git long paths
               - checkout: self
                 clean: true
                 submodules: true


### PR DESCRIPTION
Fix the git checkout issue caused by filename too long in submodule