### PR TITLE
Fix the long filename path issue in auto injected SDLSources stage

### DIFF
--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -61,7 +61,7 @@ extends:
       eslint:
         enabled: 
       git:
-        lfs: true
+        longpaths: true
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     stages:

--- a/.azure/pipelines/release.yml
+++ b/.azure/pipelines/release.yml
@@ -59,7 +59,9 @@ extends:
       - MigrationTooling-mseng-VSJava-8484-Tool
     sdl:
       eslint:
-        enabled: false
+        enabled: 
+      git:
+        lfs: true
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     stages:


### PR DESCRIPTION
Enable the longpaths flag in 1es template can resolve the issue