### PR TITLE
Support Authentication Refresh for Azure SignalR (Default mode)

### DIFF
--- a/.github/workflows/apichecks.yml
+++ b/.github/workflows/apichecks.yml
@@ -34,9 +34,15 @@ jobs:
         if: steps.filter.outputs.src == 'true'
         run: git submodule update --init --recursive
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'  # Adjust as needed
+          dotnet-version: '8.0.x'
+      # Remove it when .NET 11 is GA.
+      - name: Setup .NET 11 daily SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'daily'
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -37,9 +37,15 @@ jobs:
       if: steps.filter.outputs.src == 'true'
       run: git submodule update --init --recursive
     - name: Setup dotnet ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+    #  Remove it when .NET 11 is GA.
+    - name: Setup .NET 11 daily SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '11.0.x'
+        dotnet-quality: 'daily'
     - name: Display dotnet version
       run: dotnet --version
     - name: Build with dotnet

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,9 +37,15 @@ jobs:
       run: git submodule update --init --recursive
       if: steps.filter.outputs.src == 'true'
     - name: Setup dotnet ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+    #  Remove it when .NET 11 is GA.
+    - name: Setup .NET 11 daily SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '11.0.x'
+        dotnet-quality: 'daily'
     - name: Display dotnet version
       run: dotnet --version
     - name: Build with dotnet

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,9 +40,15 @@ jobs:
       run: git submodule update --init --recursive
       if: steps.filter.outputs.src == 'true'
     - name: Setup dotnet ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+    # Remove it when .NET 11 is GA.
+    - name: Setup .NET 11 daily SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '11.0.x'
+        dotnet-quality: 'daily'
     - name: Display dotnet version
       run: dotnet --version
     - name: Build with dotnet

--- a/api/Microsoft.Azure.SignalR.net11.0.cs
+++ b/api/Microsoft.Azure.SignalR.net11.0.cs
@@ -1,0 +1,99 @@
+namespace Microsoft.AspNetCore.Builder
+{
+    public static partial class AzureSignalRApplicationBuilderExtensions
+    {
+        [System.ObsoleteAttribute("IApplicationBuilder.UseAzureSignalR is obsoleted, please use IApplicationBuilder.UseEndpoints() instead.")]
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseAzureSignalR(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, System.Action<Microsoft.Azure.SignalR.ServiceRouteBuilder> configure) { throw null; }
+    }
+}
+namespace Microsoft.Azure.SignalR
+{
+    public partial class EndpointRouterDecorator : Microsoft.Azure.SignalR.IEndpointRouter, Microsoft.Azure.SignalR.IMessageRouter
+    {
+        public EndpointRouterDecorator(Microsoft.Azure.SignalR.IEndpointRouter router = null) { }
+        public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetEndpointsForBroadcast(System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetEndpointsForConnection(string connectionId, System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetEndpointsForGroup(string groupName, System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetEndpointsForUser(string userId, System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
+        public virtual Microsoft.Azure.SignalR.ServiceEndpoint GetNegotiateEndpoint(Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
+    }
+    public partial class GracefulShutdownOptions
+    {
+        public GracefulShutdownOptions() { }
+        public Microsoft.Azure.SignalR.GracefulShutdownMode Mode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.TimeSpan Timeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public void Add<THub>(System.Action action) { }
+        public void Add<THub>(System.Action<Microsoft.AspNetCore.SignalR.IHubContext<THub>> action) where THub : Microsoft.AspNetCore.SignalR.Hub { }
+        public void Add<THub>(System.Func<Microsoft.AspNetCore.SignalR.IHubContext<THub>, System.Threading.Tasks.Task> func) where THub : Microsoft.AspNetCore.SignalR.Hub { }
+        public void Add<THub>(System.Func<System.Threading.Tasks.Task> func) { }
+    }
+    public partial interface IConnectionMigrationFeature
+    {
+        string MigrateFrom { get; }
+        string MigrateTo { get; }
+    }
+    public partial interface IConnectionStatFeature
+    {
+        System.DateTime LastMessageReceivedAtUtc { get; }
+        long ReceivedBytes { get; }
+        System.DateTime StartedAtUtc { get; }
+    }
+    public partial interface IEndpointRouter : Microsoft.Azure.SignalR.IMessageRouter
+    {
+        Microsoft.Azure.SignalR.ServiceEndpoint GetNegotiateEndpoint(Microsoft.AspNetCore.Http.HttpContext context, System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints);
+    }
+    [System.Runtime.CompilerServices.NullableAttribute((byte)0)]
+    [System.Runtime.CompilerServices.NullableContextAttribute((byte)2)]
+    public partial class ServiceOptions
+    {
+        public ServiceOptions() { }
+        public Microsoft.Azure.SignalR.AccessTokenAlgorithm AccessTokenAlgorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.TimeSpan AccessTokenLifetime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public bool? AllowStatefulReconnects { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string? ApplicationName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1, (byte)1, (byte)1})]
+        public System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>>? ClaimsProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("Please use InitialHubServerConnectionCount instead.")]
+        public int ConnectionCount { get { throw null; } set { } }
+        public string? ConnectionString { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        public System.Func<Microsoft.AspNetCore.Http.HttpContext, bool>? DiagnosticClientFilter { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        public Microsoft.Azure.SignalR.ServiceEndpoint[]? Endpoints { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.Runtime.CompilerServices.NullableAttribute((byte)1)]
+        public Microsoft.Azure.SignalR.GracefulShutdownOptions GracefulShutdown { [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Runtime.CompilerServices.NullableContextAttribute((byte)1)] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute, System.Runtime.CompilerServices.NullableContextAttribute((byte)1)] set { } }
+        public int InitialHubServerConnectionCount { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public int? MaxHubServerConnectionCount { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public int? MaxPollIntervalInSeconds { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.Net.IWebProxy? Proxy { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public Microsoft.Azure.SignalR.ServerStickyMode ServerStickyMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.TimeSpan ServiceScaleTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[]{ (byte)2, (byte)1})]
+        public System.Func<Microsoft.AspNetCore.Http.HttpContext, Microsoft.AspNetCore.Http.Connections.HttpTransportType>? TransportTypeDetector { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
+    public partial class ServiceRouteBuilder
+    {
+        public ServiceRouteBuilder(Microsoft.AspNetCore.Routing.RouteBuilder routes) { }
+        public void MapHub<THub>(Microsoft.AspNetCore.Http.PathString path) where THub : Microsoft.AspNetCore.SignalR.Hub { }
+        public void MapHub<THub>(string path) where THub : Microsoft.AspNetCore.SignalR.Hub { }
+    }
+}
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class AzureSignalRDependencyInjectionExtensions
+    {
+        public static Microsoft.AspNetCore.SignalR.ISignalRServerBuilder AddAzureSignalR(this Microsoft.AspNetCore.SignalR.ISignalRServerBuilder builder) { throw null; }
+        public static Microsoft.AspNetCore.SignalR.ISignalRServerBuilder AddAzureSignalR(this Microsoft.AspNetCore.SignalR.ISignalRServerBuilder builder, System.Action<Microsoft.Azure.SignalR.ServiceOptions> configure) { throw null; }
+        public static Microsoft.AspNetCore.SignalR.ISignalRServerBuilder AddAzureSignalR(this Microsoft.AspNetCore.SignalR.ISignalRServerBuilder builder, string connectionString) { throw null; }
+        public static Microsoft.AspNetCore.SignalR.ISignalRServerBuilder AddNamedAzureSignalR(this Microsoft.AspNetCore.SignalR.ISignalRServerBuilder builder, string name) { throw null; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -149,12 +149,12 @@ internal class ServiceConnectionManager : IServiceConnectionManager
     }
 
     // ASP.NET SignalR does not support it.
-    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException();
     }
 
-    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException();
     }

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -148,6 +148,17 @@ internal class ServiceConnectionManager : IServiceConnectionManager
         throw new NotImplementedException();
     }
 
+    // ASP.NET SignalR does not support it.
+    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
     public void Dispose()
     {
         StopAsync().GetAwaiter().GetResult();

--- a/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR.AspNet/ServerConnections/ServiceConnectionManager.cs
@@ -149,7 +149,7 @@ internal class ServiceConnectionManager : IServiceConnectionManager
     }
 
     // ASP.NET SignalR does not support it.
-    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException();
     }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -27,8 +27,8 @@ internal interface IServiceConnectionContainer : IServiceConnectionManager,  IDi
 
     Task StopGetServersPing();
 
-    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint? preferredEndpoint = null, CancellationToken cancellationToken = default);
 
-    Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
+    Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }
 

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -27,7 +27,7 @@ internal interface IServiceConnectionContainer : IServiceConnectionManager,  IDi
 
     Task StopGetServersPing();
 
-    Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
 
     Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Interfaces/IServiceConnectionContainer.cs
@@ -2,9 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.SignalR.Protocol;
+
 namespace Microsoft.Azure.SignalR;
+
+#nullable enable
 
 internal interface IServiceConnectionContainer : IServiceConnectionManager,  IDisposable
 {
@@ -19,4 +26,9 @@ internal interface IServiceConnectionContainer : IServiceConnectionManager,  IDi
     Task StartGetServersPing();
 
     Task StopGetServersPing();
+
+    Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+
+    Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }
+

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/AckStatus.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/AckStatus.cs
@@ -12,4 +12,6 @@ internal enum AckStatus
     Timeout = 3,
 
     InternalServerError = 4,
+
+    Forbidden = 5,
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/GetConnectionClaimsResult.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/GetConnectionClaimsResult.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.Azure.SignalR;
+
+#nullable enable
+
+/// <summary>
+/// The result of reading the claims of a live client connection, including the endpoint that answered
+/// so a subsequent refresh can be pinned to it instead of fanning out again.
+/// </summary>
+internal readonly struct GetConnectionClaimsResult
+{
+    public GetConnectionClaimsResult(AckStatus status, IReadOnlyList<Claim>? claims = null, HubServiceEndpoint? owningEndpoint = null)
+    {
+        Status = status;
+        Claims = claims;
+        OwningEndpoint = owningEndpoint;
+    }
+
+    public AckStatus Status { get; }
+
+    public IReadOnlyList<Claim>? Claims { get; }
+
+    public HubServiceEndpoint? OwningEndpoint { get; }
+
+    public void Deconstruct(out AckStatus status, out IReadOnlyList<Claim>? claims)
+    {
+        status = Status;
+        claims = Claims;
+    }
+
+    public void Deconstruct(out AckStatus status, out IReadOnlyList<Claim>? claims, out HubServiceEndpoint? owningEndpoint)
+    {
+        status = Status;
+        claims = Claims;
+        owningEndpoint = OwningEndpoint;
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -155,6 +156,57 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
     public Task<bool> WriteAckableMessageAsync(ServiceMessage serviceMessage, CancellationToken cancellationToken = default)
     {
         return CreateMessageWriter(serviceMessage).WriteAckableMessageAsync(serviceMessage, cancellationToken);
+    }
+
+    // TODO: multi-endpoint sharding
+    public async Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        var endpoints = GetOnlineEndpoints().ToArray();
+        if (endpoints.Length == 0)
+        {
+            return AckStatus.NotFound;
+        }
+        if (endpoints.Length == 1)
+        {
+            return await endpoints[0].ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken);
+        }
+
+        var statuses = await Task.WhenAll(endpoints.Select(e =>
+            e.ConnectionContainer.RefreshConnectionAuthAsync((RefreshAuthMessage)message.Clone(), cancellationToken)));
+
+        foreach (var status in statuses)
+        {
+            if (status != AckStatus.NotFound)
+            {
+                return status;
+            }
+        }
+        return AckStatus.NotFound;
+    }
+
+    public async Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        var endpoints = GetOnlineEndpoints().ToArray();
+        if (endpoints.Length == 0)
+        {
+            return (AckStatus.NotFound, null);
+        }
+        if (endpoints.Length == 1)
+        {
+            return await endpoints[0].ConnectionContainer.GetConnectionClaimsAsync(message, cancellationToken);
+        }
+
+        var results = await Task.WhenAll(endpoints.Select(e =>
+            e.ConnectionContainer.GetConnectionClaimsAsync((GetConnectionClaimsMessage)message.Clone(), cancellationToken)));
+
+        foreach (var result in results)
+        {
+            if (result.Status != AckStatus.NotFound)
+            {
+                return result;
+            }
+        }
+        return (AckStatus.NotFound, null);
     }
 
     public IAsyncEnumerable<Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, CancellationToken token = default)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -160,23 +160,33 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
 
     // Refresh mutates an existing connection on its owning ServiceEndpoint; it never negotiates a new endpoint or rebalances.
     // Exactly one endpoint should own the connection; multiple owners are treated as an ambiguous-sharding failure rather than picking one.
-    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
         var endpoints = GetOnlineEndpoints().ToArray();
         if (endpoints.Length == 0)
         {
             return new RefreshConnectionAuthResult(AckStatus.NotFound);
         }
+        // When GetConnectionClaims already resolved the owning endpoint, pin the refresh to it and skip the second fan-out.
+        if (preferredEndpoint != null)
+        {
+            var pinned = Array.Find(endpoints, e => ReferenceEquals(e, preferredEndpoint));
+            if (pinned != null)
+            {
+                return await pinned.ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken: cancellationToken);
+            }
+            // The owning endpoint went offline between the read and the refresh; fall back to fanning out.
+        }
         if (endpoints.Length == 1)
         {
-            return await endpoints[0].ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken);
+            return await endpoints[0].ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken: cancellationToken);
         }
 
         var results = await Task.WhenAll(endpoints.Select(async e =>
         {
             try
             {
-                return await e.ConnectionContainer.RefreshConnectionAuthAsync((RefreshAuthMessage)message.Clone(), cancellationToken);
+                return await e.ConnectionContainer.RefreshConnectionAuthAsync((RefreshAuthMessage)message.Clone(), cancellationToken: cancellationToken);
             }
             catch (TimeoutException)
             {
@@ -199,41 +209,44 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         return new RefreshConnectionAuthResult(results.Any(r => r.Status == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound);
     }
 
-    public async Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public async Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         var endpoints = GetOnlineEndpoints().ToArray();
         if (endpoints.Length == 0)
         {
-            return (AckStatus.NotFound, null);
+            return new GetConnectionClaimsResult(AckStatus.NotFound);
         }
         if (endpoints.Length == 1)
         {
-            return await endpoints[0].ConnectionContainer.GetConnectionClaimsAsync(message, cancellationToken);
+            var single = await endpoints[0].ConnectionContainer.GetConnectionClaimsAsync(message, cancellationToken);
+            // Surface the queried endpoint so the caller can pin a follow-up refresh to it.
+            return new GetConnectionClaimsResult(single.Status, single.Claims, endpoints[0]);
         }
 
         var results = await Task.WhenAll(endpoints.Select(async e =>
         {
             try
             {
-                return await e.ConnectionContainer.GetConnectionClaimsAsync((GetConnectionClaimsMessage)message.Clone(), cancellationToken);
+                var r = await e.ConnectionContainer.GetConnectionClaimsAsync((GetConnectionClaimsMessage)message.Clone(), cancellationToken);
+                return (Endpoint: e, r.Status, r.Claims);
             }
             catch (TimeoutException)
             {
-                return (Status: AckStatus.Timeout, Claims: (IReadOnlyList<Claim>)null);
+                return (Endpoint: e, Status: AckStatus.Timeout, Claims: (IReadOnlyList<Claim>)null);
             }
         }));
 
         var resolved = results.Where(r => r.Status != AckStatus.NotFound && r.Status != AckStatus.Timeout).ToArray();
         if (resolved.Length == 1)
         {
-            return resolved[0];
+            return new GetConnectionClaimsResult(resolved[0].Status, resolved[0].Claims, resolved[0].Endpoint);
         }
         if (resolved.Length > 1)
         {
             Log.AmbiguousShardingOwnership(_logger, resolved.Length);
-            return (AckStatus.InternalServerError, null);
+            return new GetConnectionClaimsResult(AckStatus.InternalServerError);
         }
-        return (results.Any(r => r.Status == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound, null);
+        return new GetConnectionClaimsResult(results.Any(r => r.Status == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound);
     }
 
     public IAsyncEnumerable<Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, CancellationToken token = default)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -160,19 +160,19 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
 
     // Refresh mutates an existing connection on its owning ServiceEndpoint; it never negotiates a new endpoint or rebalances.
     // Exactly one endpoint should own the connection; multiple owners are treated as an ambiguous-sharding failure rather than picking one.
-    public async Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         var endpoints = GetOnlineEndpoints().ToArray();
         if (endpoints.Length == 0)
         {
-            return AckStatus.NotFound;
+            return new RefreshConnectionAuthResult(AckStatus.NotFound);
         }
         if (endpoints.Length == 1)
         {
             return await endpoints[0].ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken);
         }
 
-        var statuses = await Task.WhenAll(endpoints.Select(async e =>
+        var results = await Task.WhenAll(endpoints.Select(async e =>
         {
             try
             {
@@ -180,12 +180,12 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
             }
             catch (TimeoutException)
             {
-                return AckStatus.Timeout;
+                return new RefreshConnectionAuthResult(AckStatus.Timeout);
             }
         }));
 
-        // Owners are endpoints that resolved the connection.
-        var resolved = statuses.Where(s => s != AckStatus.NotFound && s != AckStatus.Timeout).ToArray();
+        // Owners are endpoints that resolved the connection. Each carries its own claims + owning endpoint.
+        var resolved = results.Where(r => r.Status != AckStatus.NotFound && r.Status != AckStatus.Timeout).ToArray();
         if (resolved.Length == 1)
         {
             return resolved[0];
@@ -193,10 +193,10 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         if (resolved.Length > 1)
         {
             Log.AmbiguousShardingOwnership(_logger, resolved.Length);
-            return AckStatus.InternalServerError;
+            return new RefreshConnectionAuthResult(AckStatus.InternalServerError);
         }
         // No endpoint owned the connection: surface Timeout if any was inconclusive, otherwise NotFound.
-        return statuses.Any(s => s == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound;
+        return new RefreshConnectionAuthResult(results.Any(r => r.Status == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound);
     }
 
     public async Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/MultiEndpointServiceConnectionContainer.cs
@@ -158,7 +158,8 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         return CreateMessageWriter(serviceMessage).WriteAckableMessageAsync(serviceMessage, cancellationToken);
     }
 
-    // TODO: multi-endpoint sharding
+    // Refresh mutates an existing connection on its owning ServiceEndpoint; it never negotiates a new endpoint or rebalances.
+    // Exactly one endpoint should own the connection; multiple owners are treated as an ambiguous-sharding failure rather than picking one.
     public async Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         var endpoints = GetOnlineEndpoints().ToArray();
@@ -171,17 +172,31 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
             return await endpoints[0].ConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken);
         }
 
-        var statuses = await Task.WhenAll(endpoints.Select(e =>
-            e.ConnectionContainer.RefreshConnectionAuthAsync((RefreshAuthMessage)message.Clone(), cancellationToken)));
-
-        foreach (var status in statuses)
+        var statuses = await Task.WhenAll(endpoints.Select(async e =>
         {
-            if (status != AckStatus.NotFound)
+            try
             {
-                return status;
+                return await e.ConnectionContainer.RefreshConnectionAuthAsync((RefreshAuthMessage)message.Clone(), cancellationToken);
             }
+            catch (TimeoutException)
+            {
+                return AckStatus.Timeout;
+            }
+        }));
+
+        // Owners are endpoints that resolved the connection.
+        var resolved = statuses.Where(s => s != AckStatus.NotFound && s != AckStatus.Timeout).ToArray();
+        if (resolved.Length == 1)
+        {
+            return resolved[0];
         }
-        return AckStatus.NotFound;
+        if (resolved.Length > 1)
+        {
+            Log.AmbiguousShardingOwnership(_logger, resolved.Length);
+            return AckStatus.InternalServerError;
+        }
+        // No endpoint owned the connection: surface Timeout if any was inconclusive, otherwise NotFound.
+        return statuses.Any(s => s == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound;
     }
 
     public async Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
@@ -196,17 +211,29 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
             return await endpoints[0].ConnectionContainer.GetConnectionClaimsAsync(message, cancellationToken);
         }
 
-        var results = await Task.WhenAll(endpoints.Select(e =>
-            e.ConnectionContainer.GetConnectionClaimsAsync((GetConnectionClaimsMessage)message.Clone(), cancellationToken)));
-
-        foreach (var result in results)
+        var results = await Task.WhenAll(endpoints.Select(async e =>
         {
-            if (result.Status != AckStatus.NotFound)
+            try
             {
-                return result;
+                return await e.ConnectionContainer.GetConnectionClaimsAsync((GetConnectionClaimsMessage)message.Clone(), cancellationToken);
             }
+            catch (TimeoutException)
+            {
+                return (Status: AckStatus.Timeout, Claims: (IReadOnlyList<Claim>)null);
+            }
+        }));
+
+        var resolved = results.Where(r => r.Status != AckStatus.NotFound && r.Status != AckStatus.Timeout).ToArray();
+        if (resolved.Length == 1)
+        {
+            return resolved[0];
         }
-        return (AckStatus.NotFound, null);
+        if (resolved.Length > 1)
+        {
+            Log.AmbiguousShardingOwnership(_logger, resolved.Length);
+            return (AckStatus.InternalServerError, null);
+        }
+        return (results.Any(r => r.Status == AckStatus.Timeout) ? AckStatus.Timeout : AckStatus.NotFound, null);
     }
 
     public IAsyncEnumerable<Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, CancellationToken token = default)
@@ -526,6 +553,9 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         private static readonly Action<ILogger, string, Exception> FailedRemovingConnectionForEndpointAction =
             LoggerMessage.Define<string>(LogLevel.Error, new EventId(10, "FailedRemovingConnectionForEndpoint"), "Fail to stop server connections for endpoint {endpoint}.");
 
+        private static readonly Action<ILogger, int, Exception> AmbiguousShardingOwnershipAction =
+            LoggerMessage.Define<int>(LogLevel.Error, new EventId(11, "AmbiguousShardingOwnership"), "Auth refresh resolved to {count} owning endpoints for a single connection; treating as ambiguous sharding and failing the refresh.");
+
         public static void StartingConnection(ILogger logger, string endpoint)
         {
             StartingConnectionAction(logger, endpoint, null);
@@ -559,6 +589,11 @@ internal class MultiEndpointServiceConnectionContainer : IServiceConnectionConta
         public static void FailedRemovingConnectionForEndpoint(ILogger logger, string endpoint, Exception ex)
         {
             FailedRemovingConnectionForEndpointAction(logger, endpoint, ex);
+        }
+
+        public static void AmbiguousShardingOwnership(ILogger logger, int count)
+        {
+            AmbiguousShardingOwnershipAction(logger, count, null);
         }
     }
 }

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/RefreshConnectionAuthResult.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/RefreshConnectionAuthResult.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.Azure.SignalR;
+
+#nullable enable
+
+/// <summary>
+/// The result of refreshing auth on a live client connection.
+/// </summary>
+internal readonly struct RefreshConnectionAuthResult
+{
+    public RefreshConnectionAuthResult(AckStatus status, IReadOnlyList<Claim>? claims = null, HubServiceEndpoint? owningEndpoint = null)
+    {
+        Status = status;
+        Claims = claims;
+        OwningEndpoint = owningEndpoint;
+    }
+
+    public AckStatus Status { get; }
+
+    public IReadOnlyList<Claim>? Claims { get; }
+
+    public HubServiceEndpoint? OwningEndpoint { get; }
+
+    public void Deconstruct(out AckStatus status, out IReadOnlyList<Claim>? claims, out HubServiceEndpoint? owningEndpoint)
+    {
+        status = Status;
+        claims = Claims;
+        owningEndpoint = OwningEndpoint;
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -252,6 +253,29 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         return AckHandler.HandleAckStatus(ackableMessage, status);
     }
 
+#nullable enable
+    public async Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        var task = _ackHandler.CreateSingleAck(out var id, null, cancellationToken);
+        message.AckId = id;
+
+        await WriteMessageAsync(message);
+
+        return await task;
+    }
+
+    public async Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        var task = _ackHandler.CreateSingleAckWithPayload<ConnectionClaimsResponse>(out var id, null, cancellationToken);
+        message.AckId = id;
+
+        await WriteMessageAsync(message);
+
+        var (status, payload) = await task;
+        return (status, payload?.Claims);
+    }
+#nullable restore
+
     public async IAsyncEnumerable<Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, [EnumeratorCancellation] CancellationToken token = default)
     {
         if (string.IsNullOrWhiteSpace(groupName))
@@ -292,7 +316,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
     }
 
     /// <summary>
-    /// <see cref="WriteAckableMessageAsync(ServiceMessage, CancellationToken)"/> only checks <see cref="AckMessage.Status"/> as the response, 
+    /// <see cref="WriteAckableMessageAsync(ServiceMessage, CancellationToken)"/> only checks <see cref="AckMessage.Status"/> as the response,
     /// while this method checks <see cref="AckMessage.Payload"/> and deserialize it to <typeparamref name="T"/>.
     /// </summary>
     /// Made "interval virtual" for testing

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -254,14 +254,15 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
     }
 
 #nullable enable
-    public async Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
-        var task = _ackHandler.CreateSingleAck(out var id, null, cancellationToken);
+        var task = _ackHandler.CreateSingleAckWithPayload<ConnectionClaimsResponse>(out var id, null, cancellationToken);
         message.AckId = id;
 
         await WriteMessageAsync(message);
 
-        return await task;
+        var (status, payload) = await task;
+        return new RefreshConnectionAuthResult(status, payload?.Claims, Endpoint);
     }
 
     public async Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
+++ b/src/Microsoft.Azure.SignalR.Common/ServiceConnections/ServiceConnectionContainerBase.cs
@@ -254,8 +254,9 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
     }
 
 #nullable enable
-    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public async Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint? preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
+        // A single-endpoint container always owns its connections; the preferred endpoint hint is only meaningful for the multi-endpoint router.
         var task = _ackHandler.CreateSingleAckWithPayload<ConnectionClaimsResponse>(out var id, null, cancellationToken);
         message.AckId = id;
 
@@ -265,7 +266,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         return new RefreshConnectionAuthResult(status, payload?.Claims, Endpoint);
     }
 
-    public async Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public async Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         var task = _ackHandler.CreateSingleAckWithPayload<ConnectionClaimsResponse>(out var id, null, cancellationToken);
         message.AckId = id;
@@ -273,7 +274,7 @@ internal abstract class ServiceConnectionContainerBase : IServiceConnectionConta
         await WriteMessageAsync(message);
 
         var (status, payload) = await task;
-        return (status, payload?.Claims);
+        return new GetConnectionClaimsResult(status, payload?.Claims, Endpoint);
     }
 #nullable restore
 

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/AckHandler.cs
@@ -63,6 +63,18 @@ internal sealed class AckHandler : IDisposable
         return info.Task.ContinueWith(task => task.Result, TaskScheduler.Default);
     }
 
+    public Task<(AckStatus Status, T? Payload)> CreateSingleAckWithPayload<T>(out int id, TimeSpan? ackTimeout = default, CancellationToken cancellationToken = default) where T : class, new()
+    {
+        id = NextId();
+        if (_disposed)
+        {
+            throw new InvalidOperationException($"AckHandler is disposed.");
+        }
+        var info = (SingleStatusWithPayloadAck<T>)_acks.GetOrAdd(id, _ => new SingleStatusWithPayloadAck<T>(ackTimeout ?? _defaultAckTimeout));
+        cancellationToken.Register(info.Cancel);
+        return info.Task.ContinueWith(task => task.Result, TaskScheduler.Default);
+    }
+
     public static bool HandleAckStatus(IAckableMessage message, AckStatus status)
     {
         return status switch
@@ -234,6 +246,32 @@ internal sealed class AckHandler : IDisposable
             {
                 return _tcs.TrySetException(e);
             }
+        }
+    }
+
+    private sealed class SingleStatusWithPayloadAck<T> : SingleAckInfo<(AckStatus Status, T? Payload)> where T : class, new()
+    {
+        public SingleStatusWithPayloadAck(TimeSpan timeout) : base(timeout) { }
+
+        public override bool Ack(AckStatus status, ReadOnlySequence<byte>? payload = null)
+        {
+            if (status == AckStatus.Timeout)
+            {
+                return _tcs.TrySetException(new TimeoutException($"Waiting for a {typeof(T).Name} response timed out."));
+            }
+            if (status == AckStatus.Ok && payload != null)
+            {
+                try
+                {
+                    var result = _serviceProtocol.ParseMessagePayload<T>(payload.Value);
+                    return _tcs.TrySetResult((status, result));
+                }
+                catch (Exception e)
+                {
+                    return _tcs.TrySetException(e);
+                }
+            }
+            return _tcs.TrySetResult((status, null));
         }
     }
 

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -125,6 +126,11 @@ namespace Microsoft.Azure.SignalR.Management
             public Task StopGetServersPing() => throw new NotSupportedException();
 
             public Task CloseClientConnections(CancellationToken token) => throw new NotSupportedException();
+
+            // TODO: Serverless refresh support.
+            public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+            public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
             #endregion Not supported method or properties
         }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -128,9 +128,9 @@ namespace Microsoft.Azure.SignalR.Management
             public Task CloseClientConnections(CancellationToken token) => throw new NotSupportedException();
 
             // TODO: Serverless refresh support.
-            public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
-            public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
             #endregion Not supported method or properties
         }

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.SignalR.Management
             public Task CloseClientConnections(CancellationToken token) => throw new NotSupportedException();
 
             // TODO: Serverless refresh support.
-            public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+            public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
             public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 

--- a/src/Microsoft.Azure.SignalR.Protocols/Models/ConnectionClaimsResponse.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/Models/ConnectionClaimsResponse.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+using MessagePack;
+
+namespace Microsoft.Azure.SignalR.Protocol;
+
+#nullable enable
+
+/// <summary>
+/// Wire model for the <see cref="GetConnectionClaimsMessage"/> ack payload.
+/// The payload is either nil (no claims) or a MessagePack map of claim type to claim value.
+/// </summary>
+internal sealed class ConnectionClaimsResponse : IMessagePackSerializable
+{
+    public IReadOnlyList<Claim> Claims { get; set; } = [];
+
+    void IMessagePackSerializable.Serialize(ref MessagePackWriter writer)
+    {
+        if (Claims.Count == 0)
+        {
+            writer.WriteNil();
+            return;
+        }
+
+        writer.WriteMapHeader(Claims.Count);
+        foreach (var claim in Claims)
+        {
+            writer.Write(claim.Type);
+            writer.Write(claim.Value);
+        }
+    }
+
+    void IMessagePackSerializable.Load(ref MessagePackReader reader, string fieldName)
+    {
+        if (reader.TryReadNil())
+        {
+            Claims = [];
+            return;
+        }
+
+        var count = reader.ReadMapHeader();
+        var claims = new List<Claim>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var type = reader.ReadString();
+            var value = reader.ReadString();
+            claims.Add(new Claim(type ?? string.Empty, value ?? string.Empty));
+        }
+        Claims = claims;
+    }
+}

--- a/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.Log.cs
+++ b/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.Log.cs
@@ -42,6 +42,11 @@ internal partial class ClientConnectionContext
         private static readonly Action<ILogger, string, Exception> _outgoingTaskPauseAck =
             LoggerMessage.Define<string>(LogLevel.Information, new EventId(10, "OutgoingTaskPauseAck"), "Acknowlege the pause request for connection {connectionId}.");
 
+#if NET11_0_OR_GREATER
+        private static readonly Action<ILogger, string, Exception> _userRefreshedCallbackFailed =
+            LoggerMessage.Define<string>(LogLevel.Error, new EventId(11, "UserRefreshedCallbackFailed"), "An IConnectionUserRefreshFeature.OnUserRefreshed callback threw an exception for connection {TransportConnectionId}.");
+#endif
+
         public static void WriteMessageToApplication(ILogger<ServiceConnection> logger, long count, string connectionId)
         {
             _writeMessageToApplication(logger, count, connectionId, null);
@@ -91,5 +96,12 @@ internal partial class ClientConnectionContext
         {
             _outgoingTaskPauseAck(logger, connectionId, null);
         }
+
+#if NET11_0_OR_GREATER
+        public static void UserRefreshedCallbackFailed(ILogger logger, string connectionId, Exception exception)
+        {
+            _userRefreshedCallbackFailed(logger, connectionId, exception);
+        }
+#endif
     }
 }

--- a/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
+++ b/src/Microsoft.Azure.SignalR/ClientConnections/ClientConnectionContext.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Azure.SignalR;
 internal partial class ClientConnectionContext : ConnectionContext,
                                           IClientConnection,
                                           IConnectionUserFeature,
+#if NET11_0_OR_GREATER
+                                          IConnectionUserRefreshFeature,
+#endif
                                           IConnectionItemsFeature,
                                           IConnectionIdFeature,
                                           IConnectionTransportFeature,
@@ -127,6 +130,89 @@ internal partial class ClientConnectionContext : ConnectionContext,
     public IDuplexPipe Application { get; set; }
 
     public ClaimsPrincipal User { get; set; }
+
+    /// <summary>
+    /// Applies refreshed user claims pushed from the service to the live client connection.
+    /// </summary>
+    /// <param name="user">The refreshed user principal.</param>
+    public void UpdateUser(ClaimsPrincipal user)
+    {
+        User = user;
+#if NET11_0_OR_GREATER
+        NotifyUserRefreshed(user);
+#endif
+    }
+
+#if NET11_0_OR_GREATER
+    private readonly object _userRefreshedLock = new();
+
+    private List<UserRefreshedRegistration> _userRefreshedCallbacks;
+
+    IDisposable IConnectionUserRefreshFeature.OnUserRefreshed(Action<ClaimsPrincipal, object> callback, object state)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var registration = new UserRefreshedRegistration(this, callback, state);
+        lock (_userRefreshedLock)
+        {
+            (_userRefreshedCallbacks ??= new List<UserRefreshedRegistration>()).Add(registration);
+        }
+        return registration;
+    }
+
+    private void NotifyUserRefreshed(ClaimsPrincipal user)
+    {
+        UserRefreshedRegistration[] callbacks;
+        lock (_userRefreshedLock)
+        {
+            if (_userRefreshedCallbacks == null || _userRefreshedCallbacks.Count == 0)
+            {
+                return;
+            }
+            callbacks = _userRefreshedCallbacks.ToArray();
+        }
+
+        foreach (var registration in callbacks)
+        {
+            try
+            {
+                registration.Invoke(user);
+            }
+            catch (Exception ex)
+            {
+                Log.UserRefreshedCallbackFailed(Logger, ConnectionId, ex);
+            }
+        }
+    }
+
+    private void RemoveUserRefreshedRegistration(UserRefreshedRegistration registration)
+    {
+        lock (_userRefreshedLock)
+        {
+            _userRefreshedCallbacks?.Remove(registration);
+        }
+    }
+
+    private sealed class UserRefreshedRegistration : IDisposable
+    {
+        private readonly ClientConnectionContext _connection;
+
+        private readonly Action<ClaimsPrincipal, object> _callback;
+
+        private readonly object _state;
+
+        public UserRefreshedRegistration(ClientConnectionContext connection, Action<ClaimsPrincipal, object> callback, object state)
+        {
+            _connection = connection;
+            _callback = callback;
+            _state = state;
+        }
+
+        public void Invoke(ClaimsPrincipal user) => _callback(user, _state);
+
+        public void Dispose() => _connection.RemoveUserRefreshedRegistration(this);
+    }
+#endif
 
     public Task LifetimeTask => _connectionEndTcs.Task;
 
@@ -620,6 +706,9 @@ internal partial class ClientConnectionContext : ConnectionContext,
         var features = new FeatureCollection();
         features.Set<IConnectionHeartbeatFeature>(this);
         features.Set<IConnectionUserFeature>(this);
+#if NET11_0_OR_GREATER
+        features.Set<IConnectionUserRefreshFeature>(this);
+#endif
         features.Set<IConnectionItemsFeature>(this);
         features.Set<IConnectionIdFeature>(this);
         features.Set<IConnectionTransportFeature>(this);

--- a/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
+++ b/src/Microsoft.Azure.SignalR/DependencyInjectionExtensions.cs
@@ -108,6 +108,10 @@ public static class AzureSignalRDependencyInjectionExtensions
             .AddSingleton<IHostedService, HeartBeat>()
             .AddSingleton(typeof(NegotiateHandler<>));
 
+#if NET11_0_OR_GREATER
+        builder.Services.AddSingleton(typeof(RefreshHandler<>));
+#endif
+
         // If a custom router is added, do not add the default router
         builder.Services.TryAddSingleton(typeof(IEndpointRouter), typeof(DefaultEndpointRouter));
         builder.Services.TryAddSingleton(typeof(IConnectionRequestIdProvider), typeof(DefaultConnectionRequestIdProvider));
@@ -127,6 +131,9 @@ public static class AzureSignalRDependencyInjectionExtensions
         builder.Services.TryAddSingleton<AzureSignalRHostedService>();
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter, AzureSignalRStartupFilter>());
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, NegotiateMatcherPolicy>());
+#endif
+#if NET11_0_OR_GREATER
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, AuthRefreshMatcherPolicy>());
 #endif
 
         return builder;

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
@@ -145,19 +146,34 @@ internal class NegotiateHandler<THub> where THub : Hub
     }
 
 #if NET11_0_OR_GREATER
-    public async Task<(string AccessToken, int TokenLifetimeSeconds)> GenerateRefreshedAccessTokenAsync(HttpContext context)
+    /// <summary>
+    /// Mints a refreshed client access token from the runtime-returned post-refresh claim set for the connection's owning endpoint.
+    /// </summary>
+    public async Task<(string AccessToken, int TokenLifetimeSeconds)> GenerateRefreshedAccessTokenAsync(
+        HubServiceEndpoint endpoint, IReadOnlyList<Claim> claims, DateTimeOffset newExpiration)
     {
-        var claims = BuildClaims(context);
-
-        var provider = _endpointManager.GetEndpointProvider(_router.GetNegotiateEndpoint(context, _endpointManager.GetEndpoints(_hubName)));
+        var provider = _endpointManager.GetEndpointProvider(endpoint);
         if (provider == null)
         {
             throw new AzureSignalRNotConnectedException();
         }
 
-        var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, claims);
-        var tokenLifetimeSeconds = ComputeTokenLifetimeSeconds(GetAuthenticationExpiresOn(context));
+        var tokenClaims = ApplyRefreshedExpiration(claims, newExpiration);
+        var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, tokenClaims);
+        var tokenLifetimeSeconds = ComputeTokenLifetimeSeconds(newExpiration);
         return (accessToken, tokenLifetimeSeconds);
+    }
+
+    private static IReadOnlyList<Claim> ApplyRefreshedExpiration(IReadOnlyList<Claim> claims, DateTimeOffset newExpiration)
+    {
+        var result = new List<Claim>(claims.Count);
+        foreach (var claim in claims)
+        {
+            result.Add(claim.Type == Constants.ClaimType.AuthExpiresOn
+                ? new Claim(Constants.ClaimType.AuthExpiresOn, newExpiration.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture))
+                : claim);
+        }
+        return result;
     }
 
     private int ComputeTokenLifetimeSeconds(DateTimeOffset? authenticationExpiresOn)

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -47,6 +49,8 @@ internal class NegotiateHandler<THub> where THub : Hub
     private readonly int _customHandshakeTimeout;
 
     private readonly string _hubName;
+
+    private readonly TimeSpan _accessTokenLifetime;
 
     private readonly ILogger<NegotiateHandler<THub>> _logger;
 
@@ -89,6 +93,7 @@ internal class NegotiateHandler<THub> where THub : Hub
         _transportTypeDetector = options.Value.TransportTypeDetector;
         _customHandshakeTimeout = GetCustomHandshakeTimeout(hubOptions.Value.HandshakeTimeout ?? globalHubOptions.Value.HandshakeTimeout);
         _hubName = typeof(THub).Name;
+        _accessTokenLifetime = options.Value.AccessTokenLifetime;
 #if NET6_0_OR_GREATER
         _dispatcherOptions = GetDispatcherOptions(endpointDataSource, typeof(THub));
 #endif
@@ -119,14 +124,93 @@ internal class NegotiateHandler<THub> where THub : Hub
             _cultureFeatureManager.TryAddCultureFeature(clientRequestId, cultureFeature);
         }
 
-        return new NegotiationResponse
+        var response = new NegotiationResponse
         {
             Url = provider.GetClientEndpoint(_hubName, originalPath, queryString),
             AccessToken = await provider.GenerateClientAccessTokenAsync(_hubName, claims),
             // Need to set this even though it's technically protocol violation https://github.com/aspnet/SignalR/issues/2133
             AvailableTransports = new List<AvailableTransport>()
         };
+
+#if NET11_0_OR_GREATER
+        if (_dispatcherOptions.EnableAuthenticationRefresh
+            && context.User?.Identity?.IsAuthenticated == true
+            && !HasWindowsIdentity(context.User))
+        {
+            response.TokenLifetime = TimeSpan.FromSeconds(ComputeTokenLifetimeSeconds(GetAuthenticationExpiresOn(context)));
+        }
+#endif
+
+        return response;
     }
+
+#if NET11_0_OR_GREATER
+    public async Task<(string AccessToken, int TokenLifetimeSeconds)> GenerateRefreshedAccessTokenAsync(HttpContext context)
+    {
+        var claims = BuildClaims(context);
+
+        var provider = _endpointManager.GetEndpointProvider(_router.GetNegotiateEndpoint(context, _endpointManager.GetEndpoints(_hubName)));
+        if (provider == null)
+        {
+            throw new AzureSignalRNotConnectedException();
+        }
+
+        var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, claims);
+        var tokenLifetimeSeconds = ComputeTokenLifetimeSeconds(GetAuthenticationExpiresOn(context));
+        return (accessToken, tokenLifetimeSeconds);
+    }
+
+    private int ComputeTokenLifetimeSeconds(DateTimeOffset? authenticationExpiresOn)
+    {
+        var lifetime = _accessTokenLifetime;
+        if (authenticationExpiresOn.HasValue)
+        {
+            var untilExpire = authenticationExpiresOn.Value - DateTimeOffset.UtcNow;
+            if (untilExpire < lifetime)
+            {
+                lifetime = untilExpire;
+            }
+        }
+        var seconds = (long)lifetime.TotalSeconds;
+        return seconds <= 0 ? 0 : (seconds > int.MaxValue ? int.MaxValue : (int)seconds);
+    }
+
+    private static DateTimeOffset? GetAuthenticationExpiresOn(HttpContext context)
+    {
+        var authResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+        if (authResultFeature?.AuthenticateResult?.Succeeded == true)
+        {
+            return authResultFeature.AuthenticateResult.Properties.ExpiresUtc;
+        }
+        return null;
+    }
+
+    internal static bool HasWindowsIdentity(ClaimsPrincipal user)
+    {
+        if (user == null)
+        {
+            return false;
+        }
+        foreach (var identity in user.Identities)
+        {
+            if (identity is System.Security.Principal.WindowsIdentity)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal bool IsAuthenticationRefreshEnabled => _dispatcherOptions.EnableAuthenticationRefresh;
+
+
+    internal Func<AuthenticationRefreshContext, ValueTask<bool>> AuthenticationRefreshCallback => _dispatcherOptions.OnAuthenticationRefresh;
+
+    internal Claim[] BuildRefreshClaims(HttpContext context) => BuildClaims(context).ToArray();
+
+    internal DateTimeOffset GetRefreshExpiration(HttpContext context) =>
+        GetAuthenticationExpiresOn(context) ?? DateTimeOffset.UtcNow.Add(_accessTokenLifetime);
+#endif
 
     private static string GetOriginalPath(string path)
     {

--- a/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/NegotiateHandler.cs
@@ -150,7 +150,7 @@ internal class NegotiateHandler<THub> where THub : Hub
     /// Mints a refreshed client access token from the runtime-returned post-refresh claim set for the connection's owning endpoint.
     /// </summary>
     public async Task<(string AccessToken, int TokenLifetimeSeconds)> GenerateRefreshedAccessTokenAsync(
-        HubServiceEndpoint endpoint, IReadOnlyList<Claim> claims, DateTimeOffset newExpiration)
+        HubServiceEndpoint endpoint, IReadOnlyList<Claim> claims)
     {
         var provider = _endpointManager.GetEndpointProvider(endpoint);
         if (provider == null)
@@ -158,22 +158,22 @@ internal class NegotiateHandler<THub> where THub : Hub
             throw new AzureSignalRNotConnectedException();
         }
 
-        var tokenClaims = ApplyRefreshedExpiration(claims, newExpiration);
-        var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, tokenClaims);
-        var tokenLifetimeSeconds = ComputeTokenLifetimeSeconds(newExpiration);
+        var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, claims);
+        var tokenLifetimeSeconds = ComputeTokenLifetimeSeconds(GetAuthExpiresOnFromClaims(claims));
         return (accessToken, tokenLifetimeSeconds);
     }
 
-    private static IReadOnlyList<Claim> ApplyRefreshedExpiration(IReadOnlyList<Claim> claims, DateTimeOffset newExpiration)
+    private static DateTimeOffset? GetAuthExpiresOnFromClaims(IReadOnlyList<Claim> claims)
     {
-        var result = new List<Claim>(claims.Count);
         foreach (var claim in claims)
         {
-            result.Add(claim.Type == Constants.ClaimType.AuthExpiresOn
-                ? new Claim(Constants.ClaimType.AuthExpiresOn, newExpiration.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture))
-                : claim);
+            if (claim.Type == Constants.ClaimType.AuthExpiresOn
+                && long.TryParse(claim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixSeconds))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
+            }
         }
-        return result;
+        return null;
     }
 
     private int ComputeTokenLifetimeSeconds(DateTimeOffset? authenticationExpiresOn)

--- a/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET11_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
+using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.SignalR;
+
+/// <summary>
+/// Handler for the /refresh endpoint, which mints a refreshed access token for an existing connection and sends a RefreshAuthMessage to the runtime.
+/// </summary>
+internal class RefreshHandler<THub> where THub : Hub
+{
+    private readonly NegotiateHandler<THub> _negotiateHandler;
+
+    private readonly IServiceConnectionManager<THub> _serviceConnectionManager;
+
+    private readonly ILogger<RefreshHandler<THub>> _logger;
+
+    public RefreshHandler(
+        NegotiateHandler<THub> negotiateHandler,
+        IServiceConnectionManager<THub> serviceConnectionManager,
+        ILogger<RefreshHandler<THub>> logger)
+    {
+        _negotiateHandler = negotiateHandler ?? throw new ArgumentNullException(nameof(negotiateHandler));
+        _serviceConnectionManager = serviceConnectionManager ?? throw new ArgumentNullException(nameof(serviceConnectionManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ProcessAsync(HttpContext context)
+    {
+        if (!HttpMethods.IsPost(context.Request.Method))
+        {
+            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            return;
+        }
+
+        if (!_negotiateHandler.IsAuthenticationRefreshEnabled)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status404NotFound, "refresh_disabled");
+            return;
+        }
+
+        var connectionToken = context.Request.Query["id"].ToString();
+        if (string.IsNullOrEmpty(connectionToken))
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "missing_connection_token");
+            return;
+        }
+
+        var newUser = context.User;
+        if (newUser?.Identity?.IsAuthenticated != true)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status401Unauthorized, "invalid_token");
+            return;
+        }
+
+        if (NegotiateHandler<THub>.HasWindowsIdentity(newUser))
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "windows_identity_not_supported");
+            return;
+        }
+
+        var newExpiration = _negotiateHandler.GetRefreshExpiration(context);
+
+        // When an OnAuthenticationRefresh callback is configured, fetch PreviousUser from the runtime
+        var callback = _negotiateHandler.AuthenticationRefreshCallback;
+        if (callback != null)
+        {
+            var (claimsStatus, previousClaims) = await _serviceConnectionManager.GetConnectionClaimsAsync(
+                new GetConnectionClaimsMessage(connectionToken, 0), context.RequestAborted);
+            switch (claimsStatus)
+            {
+                case AckStatus.Ok:
+                    break;
+                case AckStatus.NotFound:
+                    await WriteErrorAsync(context, StatusCodes.Status404NotFound, "connection_not_found");
+                    return;
+                default:
+                    Log.RefreshFailed(_logger, connectionToken, claimsStatus);
+                    await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
+                    return;
+            }
+
+            var refreshContext = new AuthenticationRefreshContext
+            {
+                HttpContext = context,
+                // Server doesn't know the public connection id
+                ConnectionId = string.Empty,
+                PreviousUser = BuildPreviousUser(previousClaims),
+                NewUser = newUser,
+                NewExpiration = newExpiration,
+            };
+
+            if (!await callback(refreshContext))
+            {
+                await WriteErrorAsync(context, StatusCodes.Status403Forbidden, "permission_change_rejected");
+                return;
+            }
+        }
+
+        var projectedClaims = _negotiateHandler.BuildRefreshClaims(context);
+        var claims = projectedClaims.Length == 0 ? null : projectedClaims;
+
+        AckStatus refreshStatus;
+        try
+        {
+            refreshStatus = await _serviceConnectionManager.RefreshConnectionAuthAsync(
+                new RefreshAuthMessage(connectionToken, claims, newExpiration, 0), context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            Log.RefreshServiceCallFailed(_logger, ex);
+            await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
+            return;
+        }
+
+        switch (refreshStatus)
+        {
+            case AckStatus.Ok:
+                break;
+            case AckStatus.NotFound:
+                await WriteErrorAsync(context, StatusCodes.Status404NotFound, "connection_not_found");
+                return;
+            case AckStatus.Forbidden:
+                await WriteErrorAsync(context, StatusCodes.Status403Forbidden, "permission_change_rejected");
+                return;
+            default:
+                Log.RefreshFailed(_logger, connectionToken, refreshStatus);
+                await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
+                return;
+        }
+
+        // Mint the refreshed access token only after ASRS confirms the refresh
+        try
+        {
+            var (accessToken, tokenLifetimeSeconds) = await _negotiateHandler.GenerateRefreshedAccessTokenAsync(context);
+            await WriteSuccessAsync(context, accessToken, tokenLifetimeSeconds);
+        }
+        catch (Exception ex)
+        {
+            Log.RefreshTokenGenerationFailed(_logger, ex);
+            await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
+        }
+    }
+
+    /// <summary>
+    /// Reconstructs a claims-only ClaimsPrincipal from the service-token claim set returned by the runtime.
+    /// </summary>
+    private static ClaimsPrincipal BuildPreviousUser(IReadOnlyList<Claim> serviceClaims)
+    {
+        if (serviceClaims == null || serviceClaims.Count == 0)
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity());
+        }
+
+        var authenticationType = "Bearer";
+        var nameType = ClaimsIdentity.DefaultNameClaimType;
+        var roleType = ClaimsIdentity.DefaultRoleClaimType;
+        var appClaims = new List<Claim>(serviceClaims.Count);
+
+        foreach (var claim in serviceClaims)
+        {
+            switch (claim.Type)
+            {
+                case Constants.ClaimType.AuthenticationType:
+                    authenticationType = claim.Value;
+                    break;
+                case Constants.ClaimType.NameType:
+                    nameType = claim.Value;
+                    break;
+                case Constants.ClaimType.RoleType:
+                    roleType = claim.Value;
+                    break;
+                default:
+                    if (claim.Type.StartsWith(Constants.ClaimType.AzureSignalRUserPrefix, StringComparison.Ordinal))
+                    {
+                        appClaims.Add(new Claim(claim.Type.Substring(Constants.ClaimType.AzureSignalRUserPrefix.Length), claim.Value));
+                    }
+                    else if (!claim.Type.StartsWith(Constants.ClaimType.AzureSignalRSysPrefix, StringComparison.Ordinal))
+                    {
+                        appClaims.Add(claim);
+                    }
+                    break;
+            }
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(appClaims, authenticationType, nameType, roleType));
+    }
+
+    private static Task WriteErrorAsync(HttpContext context, int statusCode, string error)
+    {
+        if (context.Response.HasStarted)
+        {
+            return Task.CompletedTask;
+        }
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/json";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(new RefreshErrorResponse { Error = error }));
+    }
+
+    private static Task WriteSuccessAsync(HttpContext context, string accessToken, int tokenLifetimeSeconds)
+    {
+        context.Response.ContentType = "application/json";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(new RefreshSuccessResponse
+        {
+            AccessToken = accessToken,
+            TokenLifetimeSeconds = tokenLifetimeSeconds,
+        }));
+    }
+
+    private sealed class RefreshErrorResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("error")]
+        public string Error { get; set; }
+    }
+
+    private sealed class RefreshSuccessResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("accessToken")]
+        public string AccessToken { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("tokenLifetimeSeconds")]
+        public int TokenLifetimeSeconds { get; set; }
+    }
+
+    private static class Log
+    {
+        private static readonly Action<ILogger, string, AckStatus, Exception> _refreshFailed =
+            LoggerMessage.Define<string, AckStatus>(LogLevel.Warning, new EventId(1, "RefreshAuthFailed"), "Refresh auth for connection token {ConnectionToken} failed with status {Status}.");
+
+        private static readonly Action<ILogger, Exception> _refreshServiceCallFailed =
+            LoggerMessage.Define(LogLevel.Error, new EventId(2, "RefreshAuthServiceCallFailed"), "Refresh auth failed while communicating with the Azure SignalR service.");
+
+        private static readonly Action<ILogger, Exception> _refreshTokenGenerationFailed =
+            LoggerMessage.Define(LogLevel.Error, new EventId(3, "RefreshAuthTokenGenerationFailed"), "Failed to generate the refreshed access token after the service confirmed the refresh.");
+
+        public static void RefreshFailed(ILogger logger, string connectionToken, AckStatus status) => _refreshFailed(logger, connectionToken, status, null);
+
+        public static void RefreshServiceCallFailed(ILogger logger, Exception ex) => _refreshServiceCallFailed(logger, ex);
+
+        public static void RefreshTokenGenerationFailed(ILogger logger, Exception ex) => _refreshTokenGenerationFailed(logger, ex);
+    }
+}
+#endif

--- a/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
@@ -74,15 +74,19 @@ internal class RefreshHandler<THub> where THub : Hub
 
         var newExpiration = _negotiateHandler.GetRefreshExpiration(context);
 
-        // When an OnAuthenticationRefresh callback is configured, fetch PreviousUser from the runtime
+        // When an OnAuthenticationRefresh callback is configured, fetch PreviousUser from the runtime.
+        // The endpoint that answers the read is remembered so the refresh below can be pinned to it
+        // instead of fanning out to every endpoint a second time.
+        HubServiceEndpoint owningEndpoint = null;
         var callback = _negotiateHandler.AuthenticationRefreshCallback;
         if (callback != null)
         {
-            var (claimsStatus, previousClaims) = await _serviceConnectionManager.GetConnectionClaimsAsync(
+            var (claimsStatus, previousClaims, answeringEndpoint) = await _serviceConnectionManager.GetConnectionClaimsAsync(
                 new GetConnectionClaimsMessage(connectionToken, 0), context.RequestAborted);
             switch (claimsStatus)
             {
                 case AckStatus.Ok:
+                    owningEndpoint = answeringEndpoint;
                     break;
                 case AckStatus.NotFound:
                     await WriteErrorAsync(context, StatusCodes.Status404NotFound, "connection_not_found");
@@ -118,7 +122,7 @@ internal class RefreshHandler<THub> where THub : Hub
         try
         {
             refreshResult = await _serviceConnectionManager.RefreshConnectionAuthAsync(
-                new RefreshAuthMessage(connectionToken, claims, newExpiration, 0), context.RequestAborted);
+                new RefreshAuthMessage(connectionToken, claims, newExpiration, 0), owningEndpoint, context.RequestAborted);
         }
         catch (Exception ex)
         {
@@ -144,8 +148,8 @@ internal class RefreshHandler<THub> where THub : Hub
                 return;
         }
 
-        // Mint the refreshed access token only after ASRS confirms the refresh
-        if (refreshResult.Claims == null || refreshResult.OwningEndpoint == null)
+        // Mint the refreshed access token only after ASRS confirms the refresh.
+        if (refreshResult.Claims == null || refreshResult.Claims.Count == 0 || refreshResult.OwningEndpoint == null)
         {
             Log.RefreshMissingClaimPayload(_logger, connectionToken);
             await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
@@ -155,7 +159,7 @@ internal class RefreshHandler<THub> where THub : Hub
         try
         {
             var (accessToken, tokenLifetimeSeconds) = await _negotiateHandler.GenerateRefreshedAccessTokenAsync(
-                refreshResult.OwningEndpoint, refreshResult.Claims, newExpiration);
+                refreshResult.OwningEndpoint, refreshResult.Claims);
             await WriteSuccessAsync(context, accessToken, tokenLifetimeSeconds);
         }
         catch (Exception ex)
@@ -222,6 +226,10 @@ internal class RefreshHandler<THub> where THub : Hub
 
     private static Task WriteSuccessAsync(HttpContext context, string accessToken, int tokenLifetimeSeconds)
     {
+        if (context.Response.HasStarted)
+        {
+            return Task.CompletedTask;
+        }
         context.Response.ContentType = "application/json";
         return context.Response.WriteAsync(JsonSerializer.Serialize(new RefreshSuccessResponse
         {

--- a/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
+++ b/src/Microsoft.Azure.SignalR/HubHost/RefreshHandler.cs
@@ -114,9 +114,10 @@ internal class RefreshHandler<THub> where THub : Hub
         var claims = projectedClaims.Length == 0 ? null : projectedClaims;
 
         AckStatus refreshStatus;
+        RefreshConnectionAuthResult refreshResult;
         try
         {
-            refreshStatus = await _serviceConnectionManager.RefreshConnectionAuthAsync(
+            refreshResult = await _serviceConnectionManager.RefreshConnectionAuthAsync(
                 new RefreshAuthMessage(connectionToken, claims, newExpiration, 0), context.RequestAborted);
         }
         catch (Exception ex)
@@ -126,6 +127,7 @@ internal class RefreshHandler<THub> where THub : Hub
             return;
         }
 
+        refreshStatus = refreshResult.Status;
         switch (refreshStatus)
         {
             case AckStatus.Ok:
@@ -143,9 +145,17 @@ internal class RefreshHandler<THub> where THub : Hub
         }
 
         // Mint the refreshed access token only after ASRS confirms the refresh
+        if (refreshResult.Claims == null || refreshResult.OwningEndpoint == null)
+        {
+            Log.RefreshMissingClaimPayload(_logger, connectionToken);
+            await WriteErrorAsync(context, StatusCodes.Status500InternalServerError, "internal_server_error");
+            return;
+        }
+
         try
         {
-            var (accessToken, tokenLifetimeSeconds) = await _negotiateHandler.GenerateRefreshedAccessTokenAsync(context);
+            var (accessToken, tokenLifetimeSeconds) = await _negotiateHandler.GenerateRefreshedAccessTokenAsync(
+                refreshResult.OwningEndpoint, refreshResult.Claims, newExpiration);
             await WriteSuccessAsync(context, accessToken, tokenLifetimeSeconds);
         }
         catch (Exception ex)
@@ -246,11 +256,16 @@ internal class RefreshHandler<THub> where THub : Hub
         private static readonly Action<ILogger, Exception> _refreshTokenGenerationFailed =
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "RefreshAuthTokenGenerationFailed"), "Failed to generate the refreshed access token after the service confirmed the refresh.");
 
+        private static readonly Action<ILogger, string, Exception> _refreshMissingClaimPayload =
+            LoggerMessage.Define<string>(LogLevel.Error, new EventId(4, "RefreshAuthMissingClaimPayload"), "The service confirmed the refresh for connection token {ConnectionToken} but returned no claim payload; the runtime does not understand the refresh contract. Rejecting.");
+
         public static void RefreshFailed(ILogger logger, string connectionToken, AckStatus status) => _refreshFailed(logger, connectionToken, status, null);
 
         public static void RefreshServiceCallFailed(ILogger logger, Exception ex) => _refreshServiceCallFailed(logger, ex);
 
         public static void RefreshTokenGenerationFailed(ILogger logger, Exception ex) => _refreshTokenGenerationFailed(logger, ex);
+
+        public static void RefreshMissingClaimPayload(ILogger logger, string connectionToken) => _refreshMissingClaimPayload(logger, connectionToken, null);
     }
 }
 #endif

--- a/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
+++ b/src/Microsoft.Azure.SignalR/Microsoft.Azure.SignalR.csproj
@@ -6,14 +6,14 @@
     <RootNamespace>Microsoft.Azure.SignalR</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.SignalR.Protocols\Microsoft.Azure.SignalR.Protocols.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.SignalR.Common\Microsoft.Azure.SignalR.Common.csproj" PrivateAssets="all" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <Compile Include="..\Common\MemoryBufferWriter.cs" Link="Internals\MemoryBufferWriter.cs" />
     <Compile Include="..\Common\BinaryMessageParser.cs" Link="Internal\BinaryMessageParser.cs" />

--- a/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
@@ -17,8 +17,8 @@ internal interface IServiceConnectionManager<THub> : IServiceConnectionManager w
 {
     void SetServiceConnection(IServiceConnectionContainer serviceConnection);
 
-    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint? preferredEndpoint = null, CancellationToken cancellationToken = default);
 
-    Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
+    Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }
 

--- a/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
@@ -1,11 +1,24 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Protocol;
 
 namespace Microsoft.Azure.SignalR;
+
+#nullable enable
 
 internal interface IServiceConnectionManager<THub> : IServiceConnectionManager where THub : Hub
 {
     void SetServiceConnection(IServiceConnectionContainer serviceConnection);
+
+    Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+
+    Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }
+

--- a/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/IServiceConnectionManager.cs
@@ -17,7 +17,7 @@ internal interface IServiceConnectionManager<THub> : IServiceConnectionManager w
 {
     void SetServiceConnection(IServiceConnectionContainer serviceConnection);
 
-    Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
+    Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default);
 
     Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.Log.cs
@@ -100,6 +100,11 @@ internal partial class ServiceConnection
             ReceivedMessageForNonExistentConnectionAction(logger, message.TracingId, message.ConnectionId, null);
         }
 
+        public static void ReceivedMessageForNonExistentConnection(ILogger logger, string connectionId)
+        {
+            ReceivedMessageForNonExistentConnectionAction(logger, null, connectionId, null);
+        }
+
         public static void ConnectedEnding(ILogger logger, string connectionId)
         {
             ConnectedEndingAction(logger, connectionId, null);

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnection.cs
@@ -280,8 +280,24 @@ internal partial class ServiceConnection : ServiceConnectionBase
             ClientCompletionMessage clientCompletionMessage => OnClientCompletionAsync(clientCompletionMessage),
             ErrorCompletionMessage errorCompletionMessage => OnErrorCompletionAsync(errorCompletionMessage),
             ConnectionReconnectMessage connectionReconnectMessage => OnConnectionReconnectAsync(connectionReconnectMessage),
+            UpdateConnectionClaimsMessage updateConnectionClaimsMessage => OnUpdateConnectionClaimsAsync(updateConnectionClaimsMessage),
             _ => base.DispatchMessageAsync(message)
         };
+    }
+
+    private Task OnUpdateConnectionClaimsAsync(UpdateConnectionClaimsMessage updateConnectionClaimsMessage)
+    {
+        if (_clientConnectionManager.TryGetClientConnection(updateConnectionClaimsMessage.ConnectionId, out var connection)
+            && connection is ClientConnectionContext clientConnection)
+        {
+            var user = ClaimsUtility.GetUserPrincipal(updateConnectionClaimsMessage.Claims);
+            clientConnection.UpdateUser(user);
+        }
+        else
+        {
+            Log.ReceivedMessageForNonExistentConnection(Logger, updateConnectionClaimsMessage.ConnectionId);
+        }
+        return Task.CompletedTask;
     }
 
     protected override Task OnPingMessageAsync(PingMessage pingMessage)

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,6 +63,26 @@ internal class ServiceConnectionManager<THub> : IDisposable, IServiceConnectionM
         }
 
         return _serviceConnection.WriteAckableMessageAsync(seviceMessage, cancellationToken);
+    }
+
+    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        if (_serviceConnection == null)
+        {
+            throw new AzureSignalRNotConnectedException();
+        }
+
+        return _serviceConnection.RefreshConnectionAuthAsync(message, cancellationToken);
+    }
+
+    public Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        if (_serviceConnection == null)
+        {
+            throw new AzureSignalRNotConnectedException();
+        }
+
+        return _serviceConnection.GetConnectionClaimsAsync(message, cancellationToken);
     }
 
     public void Dispose()

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -65,17 +65,17 @@ internal class ServiceConnectionManager<THub> : IDisposable, IServiceConnectionM
         return _serviceConnection.WriteAckableMessageAsync(seviceMessage, cancellationToken);
     }
 
-    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint? preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
         if (_serviceConnection == null)
         {
             throw new AzureSignalRNotConnectedException();
         }
 
-        return _serviceConnection.RefreshConnectionAuthAsync(message, cancellationToken);
+        return _serviceConnection.RefreshConnectionAuthAsync(message, preferredEndpoint, cancellationToken);
     }
 
-    public Task<(AckStatus Status, IReadOnlyList<Claim>? Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         if (_serviceConnection == null)
         {

--- a/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
+++ b/src/Microsoft.Azure.SignalR/ServerConnections/ServiceConnectionManager.cs
@@ -65,7 +65,7 @@ internal class ServiceConnectionManager<THub> : IDisposable, IServiceConnectionM
         return _serviceConnection.WriteAckableMessageAsync(seviceMessage, cancellationToken);
     }
 
-    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         if (_serviceConnection == null)
         {

--- a/src/Microsoft.Azure.SignalR/Startup/AuthRefreshMatcherPolicy.cs
+++ b/src/Microsoft.Azure.SignalR/Startup/AuthRefreshMatcherPolicy.cs
@@ -56,7 +56,10 @@ namespace Microsoft.Azure.SignalR
                     // Only replace the refresh endpoint, leaving negotiate/connect endpoints untouched.
                     if (refreshMetadata != null && hubMetadata != null)
                     {
-                        var newEndpoint = _refreshEndpointCache.GetOrAdd(hubMetadata.HubType, CreateRefreshEndpoint(hubMetadata.HubType, routeEndpoint));
+                        if (!_refreshEndpointCache.TryGetValue(hubMetadata.HubType, out var newEndpoint))
+                        {
+                            newEndpoint = _refreshEndpointCache.GetOrAdd(hubMetadata.HubType, CreateRefreshEndpoint(hubMetadata.HubType, routeEndpoint));
+                        }
 
                         candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
                     }

--- a/src/Microsoft.Azure.SignalR/Startup/AuthRefreshMatcherPolicy.cs
+++ b/src/Microsoft.Azure.SignalR/Startup/AuthRefreshMatcherPolicy.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET11_0_OR_GREATER
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Microsoft.Azure.SignalR
+{
+    /// <summary>
+    /// Intercepts ASP.NET Core's /refresh endpoint for ASRS-connected hubs and routes it through the Azure SignalR refresh flow.
+    /// Detects endpoints carrying both <see cref="AuthenticationRefreshMetadata"/> and <see cref="HubMetadata"/>
+    /// </summary>
+    internal class AuthRefreshMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+    {
+        private static readonly MethodInfo _createRefreshEndpointCoreMethodInfo = typeof(AuthRefreshMatcherPolicy).GetMethod(nameof(CreateRefreshEndpointCore), BindingFlags.NonPublic | BindingFlags.Static);
+
+        private readonly ConcurrentDictionary<Type, Endpoint> _refreshEndpointCache = new ConcurrentDictionary<Type, Endpoint>();
+
+        public override int Order => 1;
+
+        public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+        {
+            foreach (var endpoint in endpoints)
+            {
+                var hubMetadata = endpoint.Metadata.GetMetadata<HubMetadata>();
+                var refreshMetadata = endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>();
+
+                if (hubMetadata != null && refreshMetadata != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+        {
+            for (var i = 0; i < candidates.Count; i++)
+            {
+                ref var candidate = ref candidates[i];
+                if (candidate.Endpoint is RouteEndpoint routeEndpoint)
+                {
+                    var refreshMetadata = routeEndpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>();
+                    var hubMetadata = routeEndpoint.Metadata.GetMetadata<HubMetadata>();
+                    // Only replace the refresh endpoint, leaving negotiate/connect endpoints untouched.
+                    if (refreshMetadata != null && hubMetadata != null)
+                    {
+                        var newEndpoint = _refreshEndpointCache.GetOrAdd(hubMetadata.HubType, CreateRefreshEndpoint(hubMetadata.HubType, routeEndpoint));
+
+                        candidates.ReplaceEndpoint(i, newEndpoint, candidate.Values);
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Func<Type, Endpoint> CreateRefreshEndpoint(Type hubType, RouteEndpoint routeEndpoint)
+        {
+            var genericMethodInfo = _createRefreshEndpointCoreMethodInfo.MakeGenericMethod(hubType);
+            return type =>
+            {
+                return (Endpoint)genericMethodInfo.Invoke(this, new object[] { routeEndpoint });
+            };
+        }
+
+        private static Endpoint CreateRefreshEndpointCore<THub>(RouteEndpoint routeEndpoint) where THub : Hub
+        {
+            var routeEndpointBuilder = new RouteEndpointBuilder(async context =>
+            {
+                await ServiceRouteHelper.RefreshToService<THub>(context);
+            },
+            routeEndpoint.RoutePattern,
+            routeEndpoint.Order);
+
+            routeEndpointBuilder.DisplayName = routeEndpoint.DisplayName;
+
+            foreach (var metadata in routeEndpoint.Metadata)
+            {
+                routeEndpointBuilder.Metadata.Add(metadata);
+            }
+
+            return routeEndpointBuilder.Build();
+        }
+    }
+}
+#endif

--- a/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
+++ b/src/Microsoft.Azure.SignalR/Utilities/ServiceRouteHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -84,6 +84,14 @@ namespace Microsoft.Azure.SignalR
                 writer.Reset();
             }
         }
+
+#if NET11_0_OR_GREATER
+        public static Task RefreshToService<THub>(HttpContext context) where THub : Hub
+        {
+            var handler = context.RequestServices.GetRequiredService<RefreshHandler<THub>>();
+            return handler.ProcessAsync(context);
+        }
+#endif
 
         private static class Log
         {

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -84,6 +84,18 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
         return Task.FromResult(true);
     }
 
+    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        _validator?.Invoke((message, this));
+        return Task.FromResult(AckStatus.Ok);
+    }
+
+    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        _validator?.Invoke((message, this));
+        return Task.FromResult((AckStatus.Ok, (IReadOnlyList<System.Security.Claims.Claim>)Array.Empty<System.Security.Claims.Claim>()));
+    }
+
     public Task StopAsync()
     {
         return Task.CompletedTask;

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -84,16 +84,16 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
         return Task.FromResult(true);
     }
 
-    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
         _validator?.Invoke((message, this));
         return Task.FromResult(new RefreshConnectionAuthResult(AckStatus.Ok));
     }
 
-    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         _validator?.Invoke((message, this));
-        return Task.FromResult((AckStatus.Ok, (IReadOnlyList<System.Security.Claims.Claim>)Array.Empty<System.Security.Claims.Claim>()));
+        return Task.FromResult(new GetConnectionClaimsResult(AckStatus.Ok, Array.Empty<System.Security.Claims.Claim>()));
     }
 
     public Task StopAsync()

--- a/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
+++ b/test/Microsoft.Azure.SignalR.Tests.Common/TestClasses/TestServiceConnectionContainer.cs
@@ -84,10 +84,10 @@ internal sealed class TestServiceConnectionContainer : IServiceConnectionContain
         return Task.FromResult(true);
     }
 
-    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         _validator?.Invoke((message, this));
-        return Task.FromResult(AckStatus.Ok);
+        return Task.FromResult(new RefreshConnectionAuthResult(AckStatus.Ok));
     }
 
     public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -48,18 +48,18 @@ internal sealed class TestServiceConnectionManager<THub> : IServiceConnectionMan
         return true;
     }
 
-    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
     {
         _writeAsyncCallCount.AddOrUpdate(message.GetType(), 1, (_, value) => value + 1);
         ServiceMessage = message;
         return Task.FromResult(new RefreshConnectionAuthResult(AckStatus.Ok));
     }
 
-    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
     {
         _writeAsyncCallCount.AddOrUpdate(message.GetType(), 1, (_, value) => value + 1);
         ServiceMessage = message;
-        return Task.FromResult((AckStatus.Ok, (IReadOnlyList<System.Security.Claims.Claim>)Array.Empty<System.Security.Claims.Claim>()));
+        return Task.FromResult(new GetConnectionClaimsResult(AckStatus.Ok, Array.Empty<System.Security.Claims.Claim>()));
     }
 
     public int GetCallCount(Type type)

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -48,6 +48,20 @@ internal sealed class TestServiceConnectionManager<THub> : IServiceConnectionMan
         return true;
     }
 
+    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    {
+        _writeAsyncCallCount.AddOrUpdate(message.GetType(), 1, (_, value) => value + 1);
+        ServiceMessage = message;
+        return Task.FromResult(AckStatus.Ok);
+    }
+
+    public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+    {
+        _writeAsyncCallCount.AddOrUpdate(message.GetType(), 1, (_, value) => value + 1);
+        ServiceMessage = message;
+        return Task.FromResult((AckStatus.Ok, (IReadOnlyList<System.Security.Claims.Claim>)Array.Empty<System.Security.Claims.Claim>()));
+    }
+
     public int GetCallCount(Type type)
     {
         return _writeAsyncCallCount.TryGetValue(type, out var count) ? count : 0;

--- a/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/Infrastructure/TestServiceConnectionManager.cs
@@ -48,11 +48,11 @@ internal sealed class TestServiceConnectionManager<THub> : IServiceConnectionMan
         return true;
     }
 
-    public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+    public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
     {
         _writeAsyncCallCount.AddOrUpdate(message.GetType(), 1, (_, value) => value + 1);
         ServiceMessage = message;
-        return Task.FromResult(AckStatus.Ok);
+        return Task.FromResult(new RefreshConnectionAuthResult(AckStatus.Ok));
     }
 
     public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -150,6 +151,158 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
 
     public MultiEndpointServiceConnectionContainerTests(ITestOutputHelper output) : base(output)
     {
+    }
+
+    [Fact]
+    public async Task RefreshConnectionAuth_SingleOwner_ReturnsOwnerStatus()
+    {
+        var container = CreateRefreshContainer(
+            ("1", AckStatus.NotFound),
+            ("2", AckStatus.Ok));
+
+        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+
+        Assert.Equal(AckStatus.Ok, status);
+    }
+
+    [Fact]
+    public async Task RefreshConnectionAuth_SingleOwnerForbidden_ReturnsForbidden()
+    {
+        var container = CreateRefreshContainer(
+            ("1", AckStatus.NotFound),
+            ("2", AckStatus.Forbidden));
+
+        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+
+        Assert.Equal(AckStatus.Forbidden, status);
+    }
+
+    [Fact]
+    public async Task RefreshConnectionAuth_NoOwner_ReturnsNotFound()
+    {
+        var container = CreateRefreshContainer(
+            ("1", AckStatus.NotFound),
+            ("2", AckStatus.NotFound));
+
+        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+
+        Assert.Equal(AckStatus.NotFound, status);
+    }
+
+    [Fact]
+    public async Task RefreshConnectionAuth_MultipleOwners_ReturnsAmbiguousShardingFailure()
+    {
+        // Two endpoints both claim the connection -> ambiguous sharding, must not pick one arbitrarily.
+        var container = CreateRefreshContainer(
+            ("1", AckStatus.Ok),
+            ("2", AckStatus.Ok));
+
+        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+
+        Assert.Equal(AckStatus.InternalServerError, status);
+    }
+
+    [Fact]
+    public async Task GetConnectionClaims_SingleOwner_ReturnsOwnerClaims()
+    {
+        var claims = new List<Claim> { new("role", "admin") };
+        var container = CreateRefreshContainer(
+            ("1", (AckStatus.NotFound, (IReadOnlyList<Claim>)null)),
+            ("2", (AckStatus.Ok, claims)));
+
+        var (status, returned) = await container.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0));
+
+        Assert.Equal(AckStatus.Ok, status);
+        Assert.Same(claims, returned);
+    }
+
+    [Fact]
+    public async Task GetConnectionClaims_MultipleOwners_ReturnsAmbiguousShardingFailure()
+    {
+        var container = CreateRefreshContainer(
+            ("1", (AckStatus.Ok, (IReadOnlyList<Claim>)new List<Claim> { new("role", "a") })),
+            ("2", (AckStatus.Ok, (IReadOnlyList<Claim>)new List<Claim> { new("role", "b") })));
+
+        var (status, returned) = await container.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0));
+
+        Assert.Equal(AckStatus.InternalServerError, status);
+        Assert.Null(returned);
+    }
+
+    private static RefreshAuthMessage NewRefreshMessage() =>
+        new("connection-token", null, DateTimeOffset.UtcNow.AddMinutes(30), 0);
+
+    private static TestMultiEndpointServiceConnectionContainer CreateRefreshContainer(params (string Name, AckStatus RefreshStatus)[] endpoints)
+    {
+        return CreateRefreshContainer(endpoints.Select(e => (e.Name, e.RefreshStatus, (AckStatus.NotFound, (IReadOnlyList<Claim>)null))).ToArray());
+    }
+
+    private static TestMultiEndpointServiceConnectionContainer CreateRefreshContainer(params (string Name, (AckStatus Status, IReadOnlyList<Claim> Claims) ClaimsResult)[] endpoints)
+    {
+        return CreateRefreshContainer(endpoints.Select(e => (e.Name, AckStatus.NotFound, e.ClaimsResult)).ToArray());
+    }
+
+    private static TestMultiEndpointServiceConnectionContainer CreateRefreshContainer((string Name, AckStatus RefreshStatus, (AckStatus Status, IReadOnlyList<Claim> Claims) ClaimsResult)[] endpoints)
+    {
+        var connectionStrings = new[] { ConnectionString1, ConnectionString2, ConnectionString3 };
+        var serviceEndpoints = endpoints
+            .Select((e, i) => new ServiceEndpoint(connectionStrings[i], EndpointType.Primary, e.Name))
+            .ToArray();
+        var sem = new TestServiceEndpointManager(serviceEndpoints);
+        var router = new TestEndpointRouter();
+        var byName = endpoints.ToDictionary(e => e.Name, e => e);
+        return new TestMultiEndpointServiceConnectionContainer("hub",
+            e => new RefreshResultContainer(byName[e.Name].RefreshStatus, byName[e.Name].ClaimsResult),
+            sem, router, NullLoggerFactory.Instance);
+    }
+
+    private sealed class RefreshResultContainer : IServiceConnectionContainer
+    {
+        private readonly AckStatus _refreshStatus;
+
+        private readonly (AckStatus Status, IReadOnlyList<Claim> Claims) _claimsResult;
+
+        public RefreshResultContainer(AckStatus refreshStatus, (AckStatus Status, IReadOnlyList<Claim> Claims) claimsResult)
+        {
+            _refreshStatus = refreshStatus;
+            _claimsResult = claimsResult;
+        }
+
+        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+            => Task.FromResult(_refreshStatus);
+
+        public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+            => Task.FromResult(_claimsResult);
+
+        public ServiceConnectionStatus Status => ServiceConnectionStatus.Connected;
+
+        public Task ConnectionInitializedTask => Task.CompletedTask;
+
+        public string ServersTag => string.Empty;
+
+        public bool HasClients => false;
+
+        public Task StartGetServersPing() => Task.CompletedTask;
+
+        public Task StopGetServersPing() => Task.CompletedTask;
+
+        public Task StartAsync() => Task.CompletedTask;
+
+        public Task StopAsync() => Task.CompletedTask;
+
+        public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token) => Task.CompletedTask;
+
+        public Task CloseClientConnections(CancellationToken token) => Task.CompletedTask;
+
+        public Task WriteAsync(ServiceMessage serviceMessage) => Task.CompletedTask;
+
+        public Task<bool> WriteAckableMessageAsync(ServiceMessage serviceMessage, CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public System.Collections.Generic.IAsyncEnumerable<global::Azure.Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, CancellationToken token = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
     }
 
     private enum EndpointStatus

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -160,9 +160,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             ("1", AckStatus.NotFound),
             ("2", AckStatus.Ok));
 
-        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+        var result = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
 
-        Assert.Equal(AckStatus.Ok, status);
+        Assert.Equal(AckStatus.Ok, result.Status);
     }
 
     [Fact]
@@ -172,9 +172,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             ("1", AckStatus.NotFound),
             ("2", AckStatus.Forbidden));
 
-        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+        var result = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
 
-        Assert.Equal(AckStatus.Forbidden, status);
+        Assert.Equal(AckStatus.Forbidden, result.Status);
     }
 
     [Fact]
@@ -184,9 +184,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             ("1", AckStatus.NotFound),
             ("2", AckStatus.NotFound));
 
-        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+        var result = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
 
-        Assert.Equal(AckStatus.NotFound, status);
+        Assert.Equal(AckStatus.NotFound, result.Status);
     }
 
     [Fact]
@@ -197,9 +197,9 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             ("1", AckStatus.Ok),
             ("2", AckStatus.Ok));
 
-        var status = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+        var result = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
 
-        Assert.Equal(AckStatus.InternalServerError, status);
+        Assert.Equal(AckStatus.InternalServerError, result.Status);
     }
 
     [Fact]
@@ -268,8 +268,8 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             _claimsResult = claimsResult;
         }
 
-        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
-            => Task.FromResult(_refreshStatus);
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+            => Task.FromResult(new RefreshConnectionAuthResult(_refreshStatus));
 
         public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
             => Task.FromResult(_claimsResult);

--- a/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/MultiEndpointServiceConnectionContainerTests.cs
@@ -229,6 +229,28 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
         Assert.Null(returned);
     }
 
+    [Fact]
+    public async Task RefreshConnectionAuth_PinnedToAnsweringEndpoint_SkipsSecondFanOut()
+    {
+        // Endpoint "2" owns the connection for the claims read; endpoint "1" reports NotFound.
+        var container = CreateRefreshContainer(new[]
+        {
+            ("1", AckStatus.Ok, (AckStatus.NotFound, (IReadOnlyList<Claim>)null)),
+            ("2", AckStatus.Ok, (AckStatus.Ok, (IReadOnlyList<Claim>)new List<Claim> { new("role", "admin") })),
+        });
+
+        var claims = await container.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0));
+        Assert.Equal(AckStatus.Ok, claims.Status);
+        Assert.NotNull(claims.OwningEndpoint);
+
+        var pinned = await container.RefreshConnectionAuthAsync(NewRefreshMessage(), claims.OwningEndpoint);
+        Assert.Equal(AckStatus.Ok, pinned.Status);
+
+        // Both endpoints would ack the refresh with Ok, so a second fan-out would resolve two owners and fail as ambiguous.
+        var fannedOut = await container.RefreshConnectionAuthAsync(NewRefreshMessage());
+        Assert.Equal(AckStatus.InternalServerError, fannedOut.Status);
+    }
+
     private static RefreshAuthMessage NewRefreshMessage() =>
         new("connection-token", null, DateTimeOffset.UtcNow.AddMinutes(30), 0);
 
@@ -268,11 +290,11 @@ public class MultiEndpointServiceConnectionContainerTests : VerifiableLoggedTest
             _claimsResult = claimsResult;
         }
 
-        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
             => Task.FromResult(new RefreshConnectionAuthResult(_refreshStatus));
 
-        public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
-            => Task.FromResult(_claimsResult);
+        public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+            => Task.FromResult(new GetConnectionClaimsResult(_claimsResult.Status, _claimsResult.Claims));
 
         public ServiceConnectionStatus Status => ServiceConnectionStatus.Connected;
 

--- a/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
@@ -12,6 +12,7 @@ using Azure;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Tests.Common;
 
 using Xunit;
 
@@ -21,6 +22,59 @@ public class RefreshAuthFacts
 {
     private sealed class TestHub : Hub
     {
+    }
+
+    [Fact]
+    public async Task ServiceConnection_UpdateConnectionClaims_UpdatesLiveConnectionUser()
+    {
+        var connectionId = Guid.NewGuid().ToString("N");
+
+        var proxy = new ServiceConnectionProxy();
+        var serverTask = proxy.WaitForServerConnectionAsync(1);
+        _ = proxy.StartAsync();
+        await serverTask.OrTimeout();
+
+        // Open a live client connection with an initial claim.
+        var connectionTask = proxy.WaitForConnectionAsync(connectionId);
+        await proxy.WriteMessageAsync(new OpenConnectionMessage(connectionId, new[] { new Claim("my-claim", "original") }));
+        var connection = (ClientConnectionContext)await connectionTask.OrTimeout();
+
+        Assert.Equal("original", connection.User.FindFirst("my-claim")?.Value);
+
+        // The service pushes refreshed claims for the live client connection.
+        await proxy.WriteMessageAsync(new UpdateConnectionClaimsMessage(connectionId, new[] { new Claim("my-claim", "updated") }));
+
+        // The message is dispatched asynchronously; poll until the user is updated.
+        var updated = false;
+        for (var i = 0; i < 100 && !updated; i++)
+        {
+            if (connection.User?.FindFirst("my-claim")?.Value == "updated")
+            {
+                updated = true;
+                break;
+            }
+            await Task.Delay(20);
+        }
+
+        Assert.True(updated, "The client connection user was not updated by UpdateConnectionClaimsMessage.");
+
+        proxy.Stop();
+    }
+
+    [Fact]
+    public async Task ServiceConnection_UpdateConnectionClaims_ForUnknownConnection_IsIgnored()
+    {
+        var proxy = new ServiceConnectionProxy();
+        var serverTask = proxy.WaitForServerConnectionAsync(1);
+        _ = proxy.StartAsync();
+        await serverTask.OrTimeout();
+
+        // Dispatching for a non-existent connection should be a no-op and must not throw.
+        await proxy.WriteMessageAsync(new UpdateConnectionClaimsMessage(Guid.NewGuid().ToString("N"), new[] { new Claim("my-claim", "updated") }));
+
+        Assert.Empty(proxy.ClientConnectionManager.ClientConnections);
+
+        proxy.Stop();
     }
 
     [Fact]

--- a/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Azure;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
+using Microsoft.Azure.SignalR.Protocol;
+
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Tests;
+
+public class RefreshAuthFacts
+{
+    private sealed class TestHub : Hub
+    {
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_RefreshConnectionAuth_DelegatesOk()
+    {
+        await AssertRefreshDelegates(AckStatus.Ok);
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_RefreshConnectionAuth_DelegatesNotFound()
+    {
+        await AssertRefreshDelegates(AckStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_RefreshConnectionAuth_DelegatesForbidden()
+    {
+        await AssertRefreshDelegates(AckStatus.Forbidden);
+    }
+
+    private static async Task AssertRefreshDelegates(AckStatus expected)
+    {
+        var container = new FakeServiceConnectionContainer { RefreshResult = expected };
+        var manager = new ServiceConnectionManager<TestHub>();
+        manager.SetServiceConnection(container);
+
+        var message = new RefreshAuthMessage("connection-token", null, DateTimeOffset.UtcNow.AddMinutes(30), 0);
+        var status = await manager.RefreshConnectionAuthAsync(message);
+
+        Assert.Equal(expected, status);
+        Assert.Same(message, container.LastRefreshMessage);
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_GetConnectionClaims_DelegatesResult()
+    {
+        var claims = new List<Claim> { new("role", "admin") };
+        var container = new FakeServiceConnectionContainer { ClaimsResult = (AckStatus.Ok, claims) };
+        var manager = new ServiceConnectionManager<TestHub>();
+        manager.SetServiceConnection(container);
+
+        var (status, returned) = await manager.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0));
+
+        Assert.Equal(AckStatus.Ok, status);
+        Assert.Same(claims, returned);
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_GetConnectionClaims_NotFound_HasNoClaims()
+    {
+        var container = new FakeServiceConnectionContainer { ClaimsResult = (AckStatus.NotFound, null) };
+        var manager = new ServiceConnectionManager<TestHub>();
+        manager.SetServiceConnection(container);
+
+        var (status, returned) = await manager.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0));
+
+        Assert.Equal(AckStatus.NotFound, status);
+        Assert.Null(returned);
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_RefreshConnectionAuth_ThrowsWhenNotConnected()
+    {
+        var manager = new ServiceConnectionManager<TestHub>();
+        await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(
+            () => manager.RefreshConnectionAuthAsync(new RefreshAuthMessage("connection-token", null, DateTimeOffset.UtcNow, 0)));
+    }
+
+    [Fact]
+    public async Task ServiceConnectionManager_GetConnectionClaims_ThrowsWhenNotConnected()
+    {
+        var manager = new ServiceConnectionManager<TestHub>();
+        await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(
+            () => manager.GetConnectionClaimsAsync(new GetConnectionClaimsMessage("connection-token", 0)));
+    }
+
+    private sealed class FakeServiceConnectionContainer : IServiceConnectionContainer
+    {
+        public AckStatus RefreshResult { get; set; } = AckStatus.Ok;
+
+        public (AckStatus Status, IReadOnlyList<Claim> Claims) ClaimsResult { get; set; } = (AckStatus.Ok, Array.Empty<Claim>());
+
+        public RefreshAuthMessage LastRefreshMessage { get; private set; }
+
+        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        {
+            LastRefreshMessage = message;
+            return Task.FromResult(RefreshResult);
+        }
+
+        public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ClaimsResult);
+        }
+
+        public ServiceConnectionStatus Status => ServiceConnectionStatus.Connected;
+
+        public Task ConnectionInitializedTask => Task.CompletedTask;
+
+        public string ServersTag => string.Empty;
+
+        public bool HasClients => false;
+
+        public Task StartGetServersPing() => Task.CompletedTask;
+
+        public Task StopGetServersPing() => Task.CompletedTask;
+
+        public Task StartAsync() => Task.CompletedTask;
+
+        public Task StopAsync() => Task.CompletedTask;
+
+        public Task OfflineAsync(GracefulShutdownMode mode, CancellationToken token) => Task.CompletedTask;
+
+        public Task CloseClientConnections(CancellationToken token) => Task.CompletedTask;
+
+        public Task WriteAsync(ServiceMessage serviceMessage) => Task.CompletedTask;
+
+        public Task<bool> WriteAckableMessageAsync(ServiceMessage serviceMessage, CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+        public IAsyncEnumerable<Page<SignalRGroupMember>> ListConnectionsInGroupAsync(string groupName, int? top = null, int? maxPageSize = null, string continuationToken = null, ulong? tracingId = null, CancellationToken token = default) => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
@@ -102,9 +102,9 @@ public class RefreshAuthFacts
         manager.SetServiceConnection(container);
 
         var message = new RefreshAuthMessage("connection-token", null, DateTimeOffset.UtcNow.AddMinutes(30), 0);
-        var status = await manager.RefreshConnectionAuthAsync(message);
+        var result = await manager.RefreshConnectionAuthAsync(message);
 
-        Assert.Equal(expected, status);
+        Assert.Equal(expected, result.Status);
         Assert.Same(message, container.LastRefreshMessage);
     }
 
@@ -159,10 +159,10 @@ public class RefreshAuthFacts
 
         public RefreshAuthMessage LastRefreshMessage { get; private set; }
 
-        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
         {
             LastRefreshMessage = message;
-            return Task.FromResult(RefreshResult);
+            return Task.FromResult(new RefreshConnectionAuthResult(RefreshResult));
         }
 
         public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/RefreshAuthFacts.cs
@@ -159,15 +159,15 @@ public class RefreshAuthFacts
 
         public RefreshAuthMessage LastRefreshMessage { get; private set; }
 
-        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
         {
             LastRefreshMessage = message;
             return Task.FromResult(new RefreshConnectionAuthResult(RefreshResult));
         }
 
-        public Task<(AckStatus Status, IReadOnlyList<Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+        public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(ClaimsResult);
+            return Task.FromResult(new GetConnectionClaimsResult(ClaimsResult.Status, ClaimsResult.Claims));
         }
 
         public ServiceConnectionStatus Status => ServiceConnectionStatus.Connected;

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -139,7 +139,7 @@ public class ServiceHubDispatcherTests
             throw new NotImplementedException();
         }
 
-        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -139,12 +139,12 @@ public class ServiceHubDispatcherTests
             throw new NotImplementedException();
         }
 
-        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        public Task<RefreshConnectionAuthResult> RefreshConnectionAuthAsync(RefreshAuthMessage message, HubServiceEndpoint preferredEndpoint = null, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+        public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
+++ b/test/Microsoft.Azure.SignalR.Tests/ServiceHubDispatcherTests.cs
@@ -139,6 +139,16 @@ public class ServiceHubDispatcherTests
             throw new NotImplementedException();
         }
 
+        public Task<AckStatus> RefreshConnectionAuthAsync(RefreshAuthMessage message, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<(AckStatus Status, IReadOnlyList<System.Security.Claims.Claim> Claims)> GetConnectionClaimsAsync(GetConnectionClaimsMessage message, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task WriteAsync(ServiceMessage seviceMessage)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
## Summary
Implements the Default-mode SDK side of #2278.  See the issue for the full background, API design, and behavior/semantics. This PR is the server-SDK implementation.

## What this PR does

Lets an app refresh an Azure SignalR client connection's auth expiration and application claims without reconnecting. The SDK intercepts `{hubUrl}/refresh` for ASRS-connected hubs and applies the refresh over the service connection. Apps opt in through the same `HttpConnectionDispatcherOptions` self-hosted SignalR uses without new public API introduced in Microsoft.Azure.SignalR.

## Changes

All new code is `internal` and net11-guarded (`#if NET11_0_OR_GREATER`); `netstandard2.0` /`net8.0` builds are unaffected. The service protocol messages `RefreshAuthMessage` (41), `GetConnectionClaimsMessage` (42), `UpdateConnectionClaimsMessage` (43) have already been released in v1.33.1.

- **`AuthRefreshMatcherPolicy`** — intercepts `/refresh` for ASRS-connected hubs.
- **`RefreshHandler`** — request validation + optional `OnAuthenticationRefresh` gate; sends `RefreshAuthMessage`; mints the refreshed service access token; returns `{ accessToken, tokenLifetimeSeconds }` or `{ error }`.
- **`NegotiateHandler`** — advertises `tokenLifetimeSeconds` for eligible connections.
- **Claims propagation** — the owning app server applies `UpdateConnectionClaimsMessage` to `Context.User` (`IConnectionUserFeature` + net11 `IConnectionUserRefreshFeature`), then `Hub.OnAuthenticationRefreshedAsync()` runs.
- **Container/manager** — `RefreshConnectionAuthAsync` / `GetConnectionClaimsAsync` with new result records; `AckHandler` carries claim payloads; `AckStatus.Forbidden` added.
- **Multi-endpoint sharding** — refresh pins to the connection's owning `ServiceEndpoint` (no rebalance / re-negotiate).
- **Build/CI** — adds the `net11.0` target; workflows install the .NET 11 daily SDK (Remove it when .NET 11 is GA)

## Not in scope

- **Serverless / Management mode** — interface members are stubbed and throw `NotSupportedException` (`// TODO: Serverless refresh support`); a later PR implements it.

## Tests

- `RefreshAuthFacts` — handler success, gating (opt-in / auth / Windows / anonymous), `OnAuthenticationRefresh` accept/reject, typed failures, token minting.
- `MultiEndpointServiceConnectionContainerTests` — owner pinning, fan-out discovery, ambiguous-owner failure.
- `ServiceHubDispatcherTests` + test-infra updates for the new container/manager members.