### PR TITLE
Fix API breaking-change check workflow

### DIFF
--- a/.github/workflows/apichecks.yml
+++ b/.github/workflows/apichecks.yml
@@ -84,8 +84,7 @@ jobs:
         id: check_label
         if: steps.api-check.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'api-breaking-change-signoff') # Run only if the api-check step failed
         run: |
-          LABELS="${{ toJson(github.event.pull_request.labels) }}"
-          echo "PR Labels: $LABELS"
+          echo "Label 'api-breaking-change-signoff' found on PR; API breaking change is signed off."
           echo "HAS_SPECIAL_LABEL=true" >> $GITHUB_ENV
         shell: bash
       - name: Determine merge eligibility


### PR DESCRIPTION
### Summary of the changes (Less than 80 chars)
Fix bash failure (`feature: command not found`) at `Check for special label`
The step interpolated the PR's labels as JSON into a shell variable:
```bash
LABELS="${{ toJson(github.event.pull_request.labels) }}"
echo "PR Labels: $LABELS"
```
`toJson` renders multi-line JSON that GitHub pastes verbatim into the script. The JSON's own `"` characters desync the `LABELS="..."` quoting, dropping label text (e.g. the `enhancement` label's `description: "New feature or request"` into command position — so bash ran `feature` and the step failed with `feature: command not found`. See https://github.com/Azure/azure-signalr/actions/runs/28922037290/job/85803190762.
 
Removed the echo PR Labels step and just set the flag.