### PR TITLE
Support Authentication Refresh for Azure SignalR (Serverless mode)

### DIFF
--- a/api/Microsoft.Azure.SignalR.Management.net8.0.cs
+++ b/api/Microsoft.Azure.SignalR.Management.net8.0.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Azure.SignalR.Management
         public abstract System.Threading.Tasks.Task<bool> GroupExistsAsync(string groupName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract System.Threading.Tasks.Task<bool> UserExistsAsync(string userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
     }
+    public sealed partial class ConnectionClaimsResult
+    {
+        internal ConnectionClaimsResult() { }
+        public System.Collections.Generic.IReadOnlyList<System.Security.Claims.Claim> Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+    }
     public abstract partial class GroupManager : Microsoft.AspNetCore.SignalR.IGroupManager
     {
         protected GroupManager() { }
@@ -69,6 +74,12 @@ namespace Microsoft.Azure.SignalR.Management
         public NewtonsoftServiceHubProtocolOptions() { }
         public Newtonsoft.Json.JsonSerializerSettings PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
+    public sealed partial class RefreshAuthResult
+    {
+        internal RefreshAuthResult() { }
+        public string AccessToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public int TokenLifetimeSeconds { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+    }
     public abstract partial class ServiceHubContext : Microsoft.AspNetCore.SignalR.IHubContext<Microsoft.AspNetCore.SignalR.Hub>, Microsoft.Azure.SignalR.Management.IServiceHubContext, System.IDisposable
     {
         protected ServiceHubContext() { }
@@ -81,9 +92,11 @@ namespace Microsoft.Azure.SignalR.Management
         public virtual Microsoft.Azure.SignalR.Management.UserGroupManager UserGroups { get { throw null; } }
         public virtual void Dispose() { }
         public virtual System.Threading.Tasks.Task DisposeAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetServiceEndpoints() { throw null; }
         public virtual System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Http.Connections.NegotiationResponse> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions negotiationOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.RefreshAuthResult> RefreshAuthAsync(string connectionToken, System.DateTimeOffset expireTime, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual Microsoft.Azure.SignalR.Management.ServiceHubContext WithEndpoints(System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
     }

--- a/api/Microsoft.Azure.SignalR.Management.netstandard2.0.cs
+++ b/api/Microsoft.Azure.SignalR.Management.netstandard2.0.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Azure.SignalR.Management
         public abstract System.Threading.Tasks.Task<bool> GroupExistsAsync(string groupName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract System.Threading.Tasks.Task<bool> UserExistsAsync(string userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
     }
+    public sealed partial class ConnectionClaimsResult
+    {
+        internal ConnectionClaimsResult() { }
+        public System.Collections.Generic.IReadOnlyList<System.Security.Claims.Claim> Claims { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+    }
     public abstract partial class GroupManager : Microsoft.AspNetCore.SignalR.IGroupManager
     {
         protected GroupManager() { }
@@ -69,6 +74,12 @@ namespace Microsoft.Azure.SignalR.Management
         public NewtonsoftServiceHubProtocolOptions() { }
         public Newtonsoft.Json.JsonSerializerSettings PayloadSerializerSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
     }
+    public sealed partial class RefreshAuthResult
+    {
+        internal RefreshAuthResult() { }
+        public string AccessToken { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public int TokenLifetimeSeconds { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+    }
     public abstract partial class ServiceHubContext : Microsoft.AspNetCore.SignalR.IHubContext<Microsoft.AspNetCore.SignalR.Hub>, Microsoft.Azure.SignalR.Management.IServiceHubContext, System.IDisposable
     {
         protected ServiceHubContext() { }
@@ -81,9 +92,11 @@ namespace Microsoft.Azure.SignalR.Management
         public virtual Microsoft.Azure.SignalR.Management.UserGroupManager UserGroups { get { throw null; } }
         public virtual void Dispose() { }
         public virtual System.Threading.Tasks.Task DisposeAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> GetServiceEndpoints() { throw null; }
         public virtual System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Http.Connections.NegotiationResponse> NegotiateAsync(Microsoft.Azure.SignalR.Management.NegotiationOptions negotiationOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Microsoft.Azure.SignalR.Management.RefreshAuthResult> RefreshAuthAsync(string connectionToken, System.DateTimeOffset expireTime, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual Microsoft.Azure.SignalR.Management.ServiceHubContext WithEndpoints(System.Collections.Generic.IEnumerable<Microsoft.Azure.SignalR.ServiceEndpoint> endpoints) { throw null; }
     }

--- a/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
+++ b/src/Microsoft.Azure.SignalR.Common/Utilities/RestClient.cs
@@ -77,6 +77,17 @@ internal class RestClient
         return SendAsyncCore(Constants.HttpClientNames.Resilient, api, httpMethod, null, null, handleExpectedResponseAsync, null, cancellationToken);
     }
 
+    // Sends a request with a caller-provided body rather than a HubMessage
+    public Task SendWithRetryAsync(
+        RestApiEndpoint api,
+        HttpMethod httpMethod,
+        HttpContent content,
+        Func<HttpResponseMessage, Task<bool>>? handleExpectedResponseAsync = null,
+        CancellationToken cancellationToken = default)
+    {
+        return SendAsyncCore(Constants.HttpClientNames.Resilient, api, httpMethod, null, null, handleExpectedResponseAsync, null, cancellationToken, content);
+    }
+
     public Task SendMessageWithRetryAsync(
         RestApiEndpoint api,
         HttpMethod httpMethod,
@@ -178,10 +189,11 @@ $"Response status code does not indicate success: {(int)response.StatusCode} ({r
         Type? typeHint,
         Func<HttpResponseMessage, Task<bool>>? handleExpectedResponseAsync = null,
         MediaTypeWithQualityHeaderValue? accepts = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        HttpContent? content = null)
     {
         using var httpClient = _httpClientFactory.CreateClient(httpClientName);
-        using var request = BuildRequest(api, httpMethod, body, typeHint);
+        using var request = BuildRequest(api, httpMethod, body, typeHint, content);
         if (accepts != null)
         {
             request.Headers.Accept.Add(accepts);
@@ -207,15 +219,15 @@ $"Response status code does not indicate success: {(int)response.StatusCode} ({r
         }
     }
 
-    private HttpRequestMessage BuildRequest(RestApiEndpoint api, HttpMethod httpMethod, HubMessage? body, Type? typeHint)
+    private HttpRequestMessage BuildRequest(RestApiEndpoint api, HttpMethod httpMethod, HubMessage? body, Type? typeHint, HttpContent? content = null)
     {
-        return GenerateHttpRequest(api.Audience, api.Query, httpMethod, body, typeHint);
+        return GenerateHttpRequest(api.Audience, api.Query, httpMethod, body, typeHint, content);
     }
 
-    private HttpRequestMessage GenerateHttpRequest(string url, IDictionary<string, StringValues>? query, HttpMethod httpMethod, HubMessage? body, Type? typeHint)
+    private HttpRequestMessage GenerateHttpRequest(string url, IDictionary<string, StringValues>? query, HttpMethod httpMethod, HubMessage? body, Type? typeHint, HttpContent? content = null)
     {
         var request = new HttpRequestMessage(httpMethod, GetUri(url, query));
-        request.Content = _payloadContentBuilder.Build(body, typeHint);
+        request.Content = content ?? _payloadContentBuilder.Build(body, typeHint);
         return request;
     }
 

--- a/src/Microsoft.Azure.SignalR.Management/HubContext/ConnectionClaimsResult.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubContext/ConnectionClaimsResult.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    /// <summary>
+    /// The result of a <see cref="ServiceHubContext.GetConnectionClaimsAsync"/> call.
+    /// </summary>
+    public sealed class ConnectionClaimsResult
+    {
+        internal ConnectionClaimsResult(IReadOnlyList<Claim> claims)
+        {
+            Claims = claims;
+        }
+
+        /// <summary>
+        /// The connection's current claim set, usable as <c>PreviousUser</c> for an accept/reject policy.
+        /// </summary>
+        public IReadOnlyList<Claim> Claims { get; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/HubContext/RefreshAuthResult.cs
+++ b/src/Microsoft.Azure.SignalR.Management/HubContext/RefreshAuthResult.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SignalR.Management
+{
+    /// <summary>
+    /// The result of a successful <see cref="ServiceHubContext.RefreshAuthAsync"/> call.
+    /// </summary>
+    public sealed class RefreshAuthResult
+    {
+        internal RefreshAuthResult(string accessToken, int tokenLifetimeSeconds)
+        {
+            AccessToken = accessToken;
+            TokenLifetimeSeconds = tokenLifetimeSeconds;
+        }
+
+        /// <summary>
+        /// The refreshed service access token to return to the client. It is minted locally from the
+        /// post-refresh claim set the service returns, for the connection's owning endpoint.
+        /// </summary>
+        public string AccessToken { get; }
+
+        /// <summary>
+        /// Seconds until the client should refresh again: <c>min(AccessTokenLifetime, expireTime - now)</c>.
+        /// </summary>
+        public int TokenLifetimeSeconds { get; }
+    }
+}

--- a/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/IServiceHubLifetimeManager.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,6 +24,10 @@ internal interface IServiceHubLifetimeManager : IHubLifetimeManager, IUserGroupH
     Task<bool> UserExistsAsync(string userId, CancellationToken cancellationToken);
 
     Task<bool> GroupExistsAsync(string groupName, CancellationToken cancellationToken);
+
+    Task<RefreshConnectionAuthResult> RefreshAuthAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim>? claims, CancellationToken cancellationToken);
+
+    Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken);
 
     AsyncPageable<SignalRGroupMember> ListConnectionsInGroup(string groupName, int? top = null, CancellationToken token = default);
 }

--- a/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestApiProvider.cs
@@ -14,6 +14,8 @@ internal class RestApiProvider
     internal const string Version = "2024-12-01";
     public const string HealthApiPath = $"api/health?api-version={Version}";
 
+    internal const string RefreshApiVersion = "2026-07-01";
+
     private readonly string _serverEndpoint;
 
     public RestApiProvider(ServiceEndpoint endpoint)
@@ -110,12 +112,22 @@ internal class RestApiProvider
         return GenerateRestApiEndpoint(appName, hubName, $"/connections/{Uri.EscapeDataString(connectionId)}/:invoke");
     }
 
-    private RestApiEndpoint GenerateRestApiEndpoint(string appName, string hubName, string pathAfterHub, IDictionary<string, StringValues> queries = null)
+    public RestApiEndpoint GetRefreshConnectionAuthEndpoint(string appName, string hubName)
+    {
+        return GenerateRestApiEndpoint(appName, hubName, "/connections/:refreshAuth", apiVersion: RefreshApiVersion);
+    }
+
+    public RestApiEndpoint GetConnectionClaimsEndpoint(string appName, string hubName)
+    {
+        return GenerateRestApiEndpoint(appName, hubName, "/connections/:getClaims", apiVersion: RefreshApiVersion);
+    }
+
+    private RestApiEndpoint GenerateRestApiEndpoint(string appName, string hubName, string pathAfterHub, IDictionary<string, StringValues> queries = null, string apiVersion = Version)
     {
         var requestPrefixWithHub = $"{_serverEndpoint}api/hubs/{Uri.EscapeDataString(hubName.ToLowerInvariant())}";
         pathAfterHub = string.IsNullOrEmpty(appName)
-            ? $"{pathAfterHub}?api-version={Version}"
-            : $"{pathAfterHub}?application={Uri.EscapeDataString(appName.ToLowerInvariant())}&api-version={Version}";
+            ? $"{pathAfterHub}?api-version={apiVersion}"
+            : $"{pathAfterHub}?application={Uri.EscapeDataString(appName.ToLowerInvariant())}&api-version={apiVersion}";
         return new RestApiEndpoint($"{requestPrefixWithHub}{pathAfterHub}") { Query = queries };
     }
 }

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -35,6 +35,9 @@ internal class RestHubLifetimeManager<THub> : HubLifetimeManager<THub>, IService
     private const string NullOrEmptyStringErrorMessage = "Argument cannot be null or empty.";
     private const string TtlOutOfRangeErrorMessage = "Ttl cannot be less than 0.";
 
+    // HttpMethod.Query only exists on .NET 10+, so use a shared instance for the netstandard2.0/net8.0 targets.
+    private static readonly HttpMethod QueryMethod = new("QUERY");
+
     private readonly RestClient _restClient;
     private readonly RestApiProvider _restApiProvider;
     private readonly string _hubName;
@@ -349,7 +352,7 @@ internal class RestHubLifetimeManager<THub> : HubLifetimeManager<THub>, IService
         var status = AckStatus.InternalServerError;
         IReadOnlyList<Claim>? resultClaims = null;
         using var content = CreateJsonContent(requestBody);
-        await _restClient.SendWithRetryAsync(api, HttpMethod.Post, content, async response =>
+        await _restClient.SendWithRetryAsync(api, QueryMethod, content, async response =>
         {
             switch (response.StatusCode)
             {

--- a/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/RestHubLifetimeManager.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 
+using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -292,6 +294,145 @@ internal class RestHubLifetimeManager<THub> : HubLifetimeManager<THub>, IService
             return FilterExpectedResponse(response, ErrorCodes.WarningConnectionNotExisted);
         }, cancellationToken: cancellationToken);
         return exists;
+    }
+
+    public async Task<RefreshConnectionAuthResult> RefreshAuthAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim>? claims, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(connectionToken))
+        {
+            throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionToken));
+        }
+
+        var api = _restApiProvider.GetRefreshConnectionAuthEndpoint(_appName, _hubName);
+        var requestBody = new RefreshConnectionAuthRequestBody
+        {
+            ConnectionToken = connectionToken,
+            ExpireTime = expireTime,
+            Claims = ToClaimDtos(claims),
+        };
+
+        var status = AckStatus.InternalServerError;
+        IReadOnlyList<Claim>? resultClaims = null;
+        using var content = CreateJsonContent(requestBody);
+        await _restClient.SendWithRetryAsync(api, HttpMethod.Post, content, async response =>
+        {
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    status = AckStatus.Ok;
+                    resultClaims = await ReadClaimsAsync(response);
+                    return true;
+                case HttpStatusCode.Forbidden:
+                    status = AckStatus.Forbidden;
+                    return true;
+                case HttpStatusCode.NotFound:
+                    status = AckStatus.NotFound;
+                    return true;
+                default:
+                    return false;
+            }
+        }, cancellationToken: cancellationToken);
+
+        return new RefreshConnectionAuthResult(status, resultClaims);
+    }
+
+    public async Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(connectionToken))
+        {
+            throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionToken));
+        }
+
+        var api = _restApiProvider.GetConnectionClaimsEndpoint(_appName, _hubName);
+        var requestBody = new GetConnectionClaimsRequestBody { ConnectionToken = connectionToken };
+
+        var status = AckStatus.InternalServerError;
+        IReadOnlyList<Claim>? resultClaims = null;
+        using var content = CreateJsonContent(requestBody);
+        await _restClient.SendWithRetryAsync(api, HttpMethod.Post, content, async response =>
+        {
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    status = AckStatus.Ok;
+                    resultClaims = await ReadClaimsAsync(response);
+                    return true;
+                case HttpStatusCode.NotFound:
+                    status = AckStatus.NotFound;
+                    return true;
+                default:
+                    return false;
+            }
+        }, cancellationToken: cancellationToken);
+
+        return new GetConnectionClaimsResult(status, resultClaims);
+    }
+
+    private static HttpContent CreateJsonContent<T>(T body) =>
+        new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
+
+    private static async Task<IReadOnlyList<Claim>> ReadClaimsAsync(HttpResponseMessage response)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync();
+        var body = await JsonSerializer.DeserializeAsync<ClaimsResponseBody>(stream);
+        var dtos = body?.Claims;
+        if (dtos == null || dtos.Length == 0)
+        {
+            return Array.Empty<Claim>();
+        }
+        var result = new Claim[dtos.Length];
+        for (var i = 0; i < dtos.Length; i++)
+        {
+            result[i] = new Claim(dtos[i].Type, dtos[i].Value);
+        }
+        return result;
+    }
+
+    private static ClaimDto[]? ToClaimDtos(IEnumerable<Claim>? claims)
+    {
+        if (claims == null)
+        {
+            return null;
+        }
+        var list = new List<ClaimDto>();
+        foreach (var claim in claims)
+        {
+            list.Add(new ClaimDto { Type = claim.Type, Value = claim.Value });
+        }
+        return list.Count == 0 ? null : list.ToArray();
+    }
+
+    private sealed class RefreshConnectionAuthRequestBody
+    {
+        [JsonPropertyName("connectionToken")]
+        public string ConnectionToken { get; set; } = string.Empty;
+
+        [JsonPropertyName("expireTime")]
+        public DateTimeOffset ExpireTime { get; set; }
+
+        [JsonPropertyName("claims")]
+        public ClaimDto[]? Claims { get; set; }
+    }
+
+    private sealed class GetConnectionClaimsRequestBody
+    {
+        [JsonPropertyName("connectionToken")]
+        public string ConnectionToken { get; set; } = string.Empty;
+    }
+
+    private sealed class ClaimsResponseBody
+    {
+        [JsonPropertyName("claims")]
+        public ClaimDto[]? Claims { get; set; }
+    }
+
+    private sealed class ClaimDto
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("value")]
+        public string Value { get; set; } = string.Empty;
     }
 
     public async Task<bool> UserExistsAsync(string userId, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,6 +38,23 @@ namespace Microsoft.Azure.SignalR.Management
         /// </summary>
         /// <returns>A negotiation response object that contains an endpoint url and an access token for the client to connect to the Azure SignalR instance. </returns>
         public virtual ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions negotiationOptions = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Refreshes the authentication expiration and the application claims of a live client connection without reconnecting,
+        /// then returns a refreshed service access token for the client.
+        /// </summary>
+        /// <param name="connectionToken">The connection token (the <c>id</c> from the client-facing refresh endpoint).</param>
+        /// <param name="expireTime">The new authentication expiration deadline (UTC).</param>
+        /// <param name="claims">The projected application claim set; applied after the same-user check passes. When null, the refresh is expiration-only.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public virtual Task<RefreshAuthResult> RefreshAuthAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim> claims = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Reads the current claim set of a live client connection. 
+        /// </summary>
+        /// <param name="connectionToken">The connection token (the <c>id</c> from the client-facing refresh endpoint).</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public virtual Task<ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public virtual Task DisposeAsync() => Task.CompletedTask;
 

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,7 @@ namespace Microsoft.Azure.SignalR.Management
     {
         private readonly string _hubName;
         private readonly IHubContext<Hub> _hubContext;
+        private readonly IServiceHubLifetimeManager _lifetimeManager;
         private readonly NegotiateProcessor _negotiateProcessor;
         private readonly IServiceEndpointManager _endpointManager;
 
@@ -49,11 +51,74 @@ namespace Microsoft.Azure.SignalR.Management
             ServiceProvider = serviceProvider;
             _negotiateProcessor = negotiateProcessor;
             _endpointManager = endpointManager;
+            _lifetimeManager = lifetimeManager;
         }
 
         public override ValueTask<NegotiationResponse> NegotiateAsync(NegotiationOptions options, CancellationToken cancellationToken)
         {
             return new ValueTask<NegotiationResponse>(_negotiateProcessor.NegotiateAsync(_hubName, options, cancellationToken));
+        }
+
+        public override async Task<RefreshAuthResult> RefreshAuthAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim> claims = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(connectionToken))
+            {
+                throw new ArgumentException("Argument cannot be null or empty.", nameof(connectionToken));
+            }
+
+            var result = await _lifetimeManager.RefreshAuthAsync(connectionToken, expireTime, claims, cancellationToken);
+            ThrowOnNonSuccess(result.Status);
+
+            if (result.Claims == null)
+            {
+                throw new AzureSignalRException("The service did not return the post-refresh claim set required to mint the refreshed access token.");
+            }
+
+            var accessTokenLifetime = Constants.Periods.DefaultAccessTokenLifetime;
+            ServiceEndpoint owningEndpoint = result.OwningEndpoint;
+            if (owningEndpoint == null)
+            {
+                var endpoints = _endpointManager.GetEndpoints(_hubName);
+                if (endpoints.Count == 0)
+                {
+                    throw new AzureSignalRException("No service endpoint is available to mint the refreshed access token.");
+                }
+                owningEndpoint = endpoints[0];
+            }
+            var provider = _endpointManager.GetEndpointProvider(owningEndpoint);
+            var accessToken = await provider.GenerateClientAccessTokenAsync(_hubName, result.Claims, accessTokenLifetime);
+            var remainingSeconds = (expireTime - DateTimeOffset.UtcNow).TotalSeconds;
+            var tokenLifetimeSeconds = (int)Math.Max(0, Math.Min(accessTokenLifetime.TotalSeconds, remainingSeconds));
+            return new RefreshAuthResult(accessToken, tokenLifetimeSeconds);
+        }
+
+        public override async Task<ConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(connectionToken))
+            {
+                throw new ArgumentException("Argument cannot be null or empty.", nameof(connectionToken));
+            }
+
+            var result = await _lifetimeManager.GetConnectionClaimsAsync(connectionToken, cancellationToken);
+            ThrowOnNonSuccess(result.Status);
+            return new ConnectionClaimsResult(result.Claims ?? Array.Empty<Claim>());
+        }
+
+        private static void ThrowOnNonSuccess(AckStatus status)
+        {
+            switch (status)
+            {
+                case AckStatus.Ok:
+                    return;
+                case AckStatus.Forbidden:
+                    throw new AzureSignalRException("The refreshed token resolves to a different user (ConnectionUserMismatch).");
+                case AckStatus.NotFound:
+                    throw new AzureSignalRException("The target connection was not found, is disconnected, or uses an unsupported negotiate version.");
+                case AckStatus.Timeout:
+                    throw new AzureSignalRException("The operation timed out before the service acknowledged it.");
+                default:
+                    throw new AzureSignalRException("An unexpected error occurred while processing the request.");
+            }
         }
 
         public override IEnumerable<ServiceEndpoint> GetServiceEndpoints() => _endpointManager.GetEndpoints(_hubName);

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
 using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
+++ b/src/Microsoft.Azure.SignalR.Management/ServiceHubContextImpl.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.SignalR.Management
             var result = await _lifetimeManager.RefreshAuthAsync(connectionToken, expireTime, claims, cancellationToken);
             ThrowOnNonSuccess(result.Status);
 
-            if (result.Claims == null)
+            if (result.Claims == null || result.Claims.Count == 0)
             {
                 throw new AzureSignalRException("The service did not return the post-refresh claim set required to mint the refreshed access token.");
             }

--- a/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
+++ b/src/Microsoft.Azure.SignalR.Management/WebsocketsHubLifetimeManager.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #nullable enable
 using System;
+using System.Collections.Generic;
 #if NET7_0_OR_GREATER
 using System.Linq;
 #endif
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -188,6 +190,35 @@ internal class WebSocketsHubLifetimeManager<THub> : ServiceLifetimeManagerBase<T
         }
         return WriteAckableMessageAsync(message, cancellationToken);
     }
+
+    public Task<RefreshConnectionAuthResult> RefreshAuthAsync(string connectionToken, DateTimeOffset expireTime, IEnumerable<Claim>? claims, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(connectionToken))
+        {
+            throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionToken));
+        }
+
+        var message = new RefreshAuthMessage(connectionToken, ToClaimArray(claims), expireTime, 0);
+        return ServiceConnectionContainer.RefreshConnectionAuthAsync(message, cancellationToken: cancellationToken);
+    }
+
+    public Task<GetConnectionClaimsResult> GetConnectionClaimsAsync(string connectionToken, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(connectionToken))
+        {
+            throw new ArgumentException(NullOrEmptyStringErrorMessage, nameof(connectionToken));
+        }
+
+        var message = new GetConnectionClaimsMessage(connectionToken, 0);
+        return ServiceConnectionContainer.GetConnectionClaimsAsync(message, cancellationToken);
+    }
+
+    private static Claim[]? ToClaimArray(IEnumerable<Claim>? claims) => claims switch
+    {
+        null => null,
+        Claim[] array => array,
+        _ => new List<Claim>(claims).ToArray()
+    };
 
     public Task<bool> UserExistsAsync(string userId, CancellationToken cancellationToken = default)
     {

--- a/src/Microsoft.Azure.SignalR.Protocols/Models/ConnectionClaimsResponse.cs
+++ b/src/Microsoft.Azure.SignalR.Protocols/Models/ConnectionClaimsResponse.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.SignalR.Protocol;
 #nullable enable
 
 /// <summary>
-/// Wire model for the <see cref="GetConnectionClaimsMessage"/> ack payload.
 /// The payload is either nil (no claims) or a MessagePack map of claim type to claim value.
 /// </summary>
 internal sealed class ConnectionClaimsResponse : IMessagePackSerializable

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestHubLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestHubLifetimeManagerFacts.cs
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         }
 
         [Fact]
-        public async Task GetConnectionClaimsAsync_Ok_PostsGetClaimsRequest_ReturnsClaims()
+        public async Task GetConnectionClaimsAsync_Ok_SendsQueryGetClaimsRequest_ReturnsClaims()
         {
             HttpRequestMessage? capturedRequest = null;
             string? capturedBody = null;
@@ -428,9 +428,9 @@ namespace Microsoft.Azure.SignalR.Management.Tests
 
             var result = await _manager.GetConnectionClaimsAsync("conn-token-1", default);
 
-            // Read-only :getClaims is a POST with the token in the body, mirroring :refreshAuth.
+            // Read-only :getClaims uses the HTTP QUERY method (RFC 10008) with the token in the body.
             Assert.NotNull(capturedRequest);
-            Assert.Equal(HttpMethod.Post, capturedRequest!.Method);
+            Assert.Equal("QUERY", capturedRequest!.Method.Method);
             var uri = capturedRequest.RequestUri!.ToString();
             Assert.Contains("/connections/:getClaims", uri);
             Assert.Contains("api-version=2026-07-01", uri);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/RestHubLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/RestHubLifetimeManagerFacts.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -311,6 +314,164 @@ namespace Microsoft.Azure.SignalR.Management.Tests
                 () => _manager.InvokeConnectionAsync<string>(connectionId, methodName, args));
 
             Assert.Equal("Response payload is empty.", ex.Message);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _manager.RefreshAuthAsync(null!, DateTimeOffset.UtcNow, null, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _manager.RefreshAuthAsync("", DateTimeOffset.UtcNow, null, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_Ok_PostsRefreshAuthRequest_ReturnsOkWithClaims()
+        {
+            var connectionToken = "conn-token-1";
+            var expireTime = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            HttpRequestMessage? capturedRequest = null;
+            string? capturedBody = null;
+
+            _httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) =>
+                {
+                    capturedRequest = request;
+                    capturedBody = request.Content!.ReadAsStringAsync(CancellationToken.None).Result;
+                })
+                .ReturnsAsync(() => ClaimsResponse(HttpStatusCode.OK, ("role", "admin")));
+
+            var result = await _manager.RefreshAuthAsync(
+                connectionToken, expireTime, new[] { new Claim("role", "admin") }, default);
+
+            // Verify the request targeted the token-keyed :refreshAuth collection endpoint via POST.
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(HttpMethod.Post, capturedRequest!.Method);
+            var uri = capturedRequest.RequestUri!.ToString();
+            Assert.Contains("/connections/:refreshAuth", uri);
+            Assert.Contains("api-version=2026-07-01", uri);
+
+            // The connection token rides in the body (out of the URL / access logs), with expireTime + claims.
+            Assert.NotNull(capturedBody);
+            Assert.Contains("\"connectionToken\":\"conn-token-1\"", capturedBody);
+            Assert.Contains("expireTime", capturedBody);
+            Assert.Contains("\"type\":\"role\"", capturedBody);
+            Assert.Contains("\"value\":\"admin\"", capturedBody);
+            Assert.DoesNotContain("conn-token-1", uri);
+
+            Assert.Equal(AckStatus.Ok, result.Status);
+            var claim = Assert.Single(result.Claims!);
+            Assert.Equal("role", claim.Type);
+            Assert.Equal("admin", claim.Value);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_Forbidden_ReturnsForbiddenStatus()
+        {
+            SetupResponse(HttpStatusCode.Forbidden);
+
+            var result = await _manager.RefreshAuthAsync("conn-token-1", DateTimeOffset.UtcNow, null, default);
+
+            Assert.Equal(AckStatus.Forbidden, result.Status);
+            Assert.Null(result.Claims);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_NotFound_ReturnsNotFoundStatus()
+        {
+            SetupResponse(HttpStatusCode.NotFound);
+
+            var result = await _manager.RefreshAuthAsync("conn-token-1", DateTimeOffset.UtcNow, null, default);
+
+            Assert.Equal(AckStatus.NotFound, result.Status);
+            Assert.Null(result.Claims);
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _manager.GetConnectionClaimsAsync(null!, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _manager.GetConnectionClaimsAsync("", default));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_Ok_PostsGetClaimsRequest_ReturnsClaims()
+        {
+            HttpRequestMessage? capturedRequest = null;
+            string? capturedBody = null;
+
+            _httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) =>
+                {
+                    capturedRequest = request;
+                    capturedBody = request.Content!.ReadAsStringAsync(CancellationToken.None).Result;
+                })
+                .ReturnsAsync(() => ClaimsResponse(HttpStatusCode.OK, ("role", "user"), ("tenant", "contoso")));
+
+            var result = await _manager.GetConnectionClaimsAsync("conn-token-1", default);
+
+            // Read-only :getClaims is a POST with the token in the body, mirroring :refreshAuth.
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(HttpMethod.Post, capturedRequest!.Method);
+            var uri = capturedRequest.RequestUri!.ToString();
+            Assert.Contains("/connections/:getClaims", uri);
+            Assert.Contains("api-version=2026-07-01", uri);
+            Assert.Contains("\"connectionToken\":\"conn-token-1\"", capturedBody);
+            Assert.DoesNotContain("conn-token-1", uri);
+
+            Assert.Equal(AckStatus.Ok, result.Status);
+            Assert.Equal(2, result.Claims!.Count);
+            Assert.Contains(result.Claims!, c => c.Type == "tenant" && c.Value == "contoso");
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_NotFound_ReturnsNotFoundStatus()
+        {
+            SetupResponse(HttpStatusCode.NotFound);
+
+            var result = await _manager.GetConnectionClaimsAsync("conn-token-1", default);
+
+            Assert.Equal(AckStatus.NotFound, result.Status);
+            Assert.Null(result.Claims);
+        }
+
+        private void SetupResponse(HttpStatusCode statusCode) =>
+            _httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => new HttpResponseMessage(statusCode));
+
+        private static HttpResponseMessage ClaimsResponse(HttpStatusCode statusCode, params (string Type, string Value)[] claims)
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                claims = claims.Select(c => new { type = c.Type, value = c.Value }).ToArray(),
+            });
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
         }
 #endif
 

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceHubContextImplFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceHubContextImplFacts.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Common;
+using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.Azure.SignalR.Management.Tests
+{
+    public class ServiceHubContextImplFacts
+    {
+        private const string HubName = "chat";
+        private const string ConnectionToken = "conn-token-1";
+
+        private readonly Mock<IServiceHubLifetimeManager> _lifetimeManagerMock = new();
+        private readonly Mock<IServiceEndpointManager> _endpointManagerMock = new();
+
+        [Fact]
+        public async Task RefreshAuthAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var hubContext = CreateHubContext();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => hubContext.RefreshAuthAsync(null!, DateTimeOffset.UtcNow));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => hubContext.RefreshAuthAsync(string.Empty, DateTimeOffset.UtcNow));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_NonSuccessStatus_ThrowsAzureSignalRException()
+        {
+            foreach (var status in new[] { AckStatus.Forbidden, AckStatus.NotFound, AckStatus.InternalServerError })
+            {
+                _lifetimeManagerMock
+                    .Setup(m => m.RefreshAuthAsync(ConnectionToken, It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new RefreshConnectionAuthResult(status));
+                var hubContext = CreateHubContext();
+
+                await Assert.ThrowsAsync<AzureSignalRException>(
+                    () => hubContext.RefreshAuthAsync(ConnectionToken, DateTimeOffset.UtcNow));
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_OkWithoutClaims_ThrowsAzureSignalRException()
+        {
+            // On success ASRS must return the post-refresh claim set the SDK mints the token from;
+            // a missing claim set is a protocol error, not a silent success.
+            _lifetimeManagerMock
+                .Setup(m => m.RefreshAuthAsync(ConnectionToken, It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RefreshConnectionAuthResult(AckStatus.Ok, claims: null));
+            var hubContext = CreateHubContext();
+
+            await Assert.ThrowsAsync<AzureSignalRException>(
+                () => hubContext.RefreshAuthAsync(ConnectionToken, DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_Ok_MintsTokenForOwningEndpoint_AndComputesLifetime()
+        {
+            var expireTime = DateTimeOffset.UtcNow.AddMinutes(10);
+            var postRefreshClaims = new[] { new Claim("role", "admin") };
+            _lifetimeManagerMock
+                .Setup(m => m.RefreshAuthAsync(ConnectionToken, expireTime, It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RefreshConnectionAuthResult(AckStatus.Ok, postRefreshClaims));
+
+            var providerMock = new Mock<IServiceEndpointProvider>();
+            providerMock
+                .Setup(p => p.GenerateClientAccessTokenAsync(HubName, It.IsAny<IEnumerable<Claim>>(), It.IsAny<TimeSpan?>()))
+                .ReturnsAsync("minted-token");
+
+            var endpoint = new HubServiceEndpoint(HubName, providerMock.Object, new ServiceEndpoint(FakeEndpointUtils.GetFakeConnectionString(1).First()));
+            _endpointManagerMock.Setup(m => m.GetEndpoints(HubName)).Returns(new List<HubServiceEndpoint> { endpoint });
+            _endpointManagerMock.Setup(m => m.GetEndpointProvider(It.IsAny<ServiceEndpoint>())).Returns(providerMock.Object);
+
+            var hubContext = CreateHubContext();
+
+            var result = await hubContext.RefreshAuthAsync(ConnectionToken, expireTime, postRefreshClaims);
+
+            Assert.Equal("minted-token", result.AccessToken);
+            // min(AccessTokenLifetime, expireTime - now) -> capped by the ~10 min expireTime here.
+            Assert.InRange(result.TokenLifetimeSeconds, 1, 600);
+            providerMock.Verify(p => p.GenerateClientAccessTokenAsync(HubName, It.IsAny<IEnumerable<Claim>>(), It.IsAny<TimeSpan?>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_Ok_NoServiceEndpoint_ThrowsAzureSignalRException()
+        {
+            _lifetimeManagerMock
+                .Setup(m => m.RefreshAuthAsync(ConnectionToken, It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RefreshConnectionAuthResult(AckStatus.Ok, new[] { new Claim("role", "admin") }));
+            _endpointManagerMock.Setup(m => m.GetEndpoints(HubName)).Returns(new List<HubServiceEndpoint>());
+            var hubContext = CreateHubContext();
+
+            await Assert.ThrowsAsync<AzureSignalRException>(
+                () => hubContext.RefreshAuthAsync(ConnectionToken, DateTimeOffset.UtcNow.AddMinutes(10)));
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var hubContext = CreateHubContext();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => hubContext.GetConnectionClaimsAsync(null!));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => hubContext.GetConnectionClaimsAsync(string.Empty));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_Ok_ReturnsClaims()
+        {
+            var claims = new[] { new Claim("role", "user"), new Claim("tenant", "contoso") };
+            _lifetimeManagerMock
+                .Setup(m => m.GetConnectionClaimsAsync(ConnectionToken, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetConnectionClaimsResult(AckStatus.Ok, claims));
+            var hubContext = CreateHubContext();
+
+            var result = await hubContext.GetConnectionClaimsAsync(ConnectionToken);
+
+            Assert.Equal(2, result.Claims.Count);
+            Assert.Contains(result.Claims, c => c.Type == "tenant" && c.Value == "contoso");
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_NotFound_ThrowsAzureSignalRException()
+        {
+            _lifetimeManagerMock
+                .Setup(m => m.GetConnectionClaimsAsync(ConnectionToken, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetConnectionClaimsResult(AckStatus.NotFound));
+            var hubContext = CreateHubContext();
+
+            await Assert.ThrowsAsync<AzureSignalRException>(
+                () => hubContext.GetConnectionClaimsAsync(ConnectionToken));
+        }
+
+        private ServiceHubContext CreateHubContext() =>
+            new ServiceHubContextImpl(
+                HubName,
+                Mock.Of<IHubContext<Hub>>(),
+                _lifetimeManagerMock.Object,
+                serviceProvider: null,
+                negotiateProcessor: null,
+                _endpointManagerMock.Object,
+                Mock.Of<ILogger<ServiceHubContext>>());
+    }
+}

--- a/test/Microsoft.Azure.SignalR.Management.Tests/ServiceHubContextImplFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/ServiceHubContextImplFacts.cs
@@ -71,6 +71,19 @@ namespace Microsoft.Azure.SignalR.Management.Tests
         }
 
         [Fact]
+        public async Task RefreshAuthAsync_OkWithEmptyClaims_ThrowsAzureSignalRException()
+        {
+            // An empty claim set (like a null one) can't mint a valid token — it would drop the connect-time asrs.s.* system claims. Reject it instead of minting a corrupt token.
+            _lifetimeManagerMock
+                .Setup(m => m.RefreshAuthAsync(ConnectionToken, It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RefreshConnectionAuthResult(AckStatus.Ok, claims: Array.Empty<Claim>()));
+            var hubContext = CreateHubContext();
+
+            await Assert.ThrowsAsync<AzureSignalRException>(
+                () => hubContext.RefreshAuthAsync(ConnectionToken, DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
         public async Task RefreshAuthAsync_Ok_MintsTokenForOwningEndpoint_AndComputesLifetime()
         {
             var expireTime = DateTimeOffset.UtcNow.AddMinutes(10);

--- a/test/Microsoft.Azure.SignalR.Management.Tests/WebsocketsHubLifetimeManagerFacts.cs
+++ b/test/Microsoft.Azure.SignalR.Management.Tests/WebsocketsHubLifetimeManagerFacts.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Azure.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -65,6 +67,110 @@ namespace Microsoft.Azure.SignalR.Management.Tests
             Assert.NotNull(manager);
             _serverNameProviderMock.Verify(s => s.GetName(), Times.Once);
         }
+
+        [Fact]
+        public async Task RefreshAuthAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var manager = CreateManager();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => manager.RefreshAuthAsync(null!, DateTimeOffset.UtcNow, null, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => manager.RefreshAuthAsync(string.Empty, DateTimeOffset.UtcNow, null, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_DelegatesTokenKeyedMessageToContainer_ReturnsResult()
+        {
+            var manager = CreateManager();
+            var expireTime = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            RefreshAuthMessage captured = null;
+            var expected = new RefreshConnectionAuthResult(AckStatus.Ok, new[] { new Claim("role", "admin") });
+
+            _serviceConnectionManagerMock
+                .Setup(m => m.RefreshConnectionAuthAsync(It.IsAny<RefreshAuthMessage>(), It.IsAny<HubServiceEndpoint>(), It.IsAny<CancellationToken>()))
+                .Callback<RefreshAuthMessage, HubServiceEndpoint, CancellationToken>((message, _, _) => captured = message)
+                .ReturnsAsync(expected);
+
+            var result = await manager.RefreshAuthAsync("conn-token-1", expireTime, new[] { new Claim("role", "admin") }, default);
+
+            // The Persistent transport builds a token-keyed RefreshAuthMessage and delegates to the container.
+            Assert.NotNull(captured);
+            Assert.Equal("conn-token-1", captured!.ConnectionToken);
+            Assert.Equal(expireTime, captured.ExpireTime);
+            var sentClaim = Assert.Single(captured.Claims!);
+            Assert.Equal("role", sentClaim.Type);
+            Assert.Equal("admin", sentClaim.Value);
+
+            Assert.Equal(AckStatus.Ok, result.Status);
+            Assert.Equal("admin", Assert.Single(result.Claims!).Value);
+        }
+
+        [Fact]
+        public async Task RefreshAuthAsync_NoClaims_SendsNullClaims()
+        {
+            var manager = CreateManager();
+            RefreshAuthMessage captured = null;
+
+            _serviceConnectionManagerMock
+                .Setup(m => m.RefreshConnectionAuthAsync(It.IsAny<RefreshAuthMessage>(), It.IsAny<HubServiceEndpoint>(), It.IsAny<CancellationToken>()))
+                .Callback<RefreshAuthMessage, HubServiceEndpoint, CancellationToken>((message, _, _) => captured = message)
+                .ReturnsAsync(new RefreshConnectionAuthResult(AckStatus.Ok));
+
+            await manager.RefreshAuthAsync("conn-token-1", DateTimeOffset.UtcNow, null, default);
+
+            Assert.NotNull(captured);
+            Assert.Null(captured!.Claims);
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_NullOrEmptyConnectionToken_ThrowsArgumentException()
+        {
+            var manager = CreateManager();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => manager.GetConnectionClaimsAsync(null!, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+
+            exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => manager.GetConnectionClaimsAsync(string.Empty, default));
+            Assert.Equal("connectionToken", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task GetConnectionClaimsAsync_DelegatesTokenKeyedMessageToContainer_ReturnsResult()
+        {
+            var manager = CreateManager();
+            GetConnectionClaimsMessage captured = null;
+            var expected = new GetConnectionClaimsResult(AckStatus.Ok, new[] { new Claim("role", "user") });
+
+            _serviceConnectionManagerMock
+                .Setup(m => m.GetConnectionClaimsAsync(It.IsAny<GetConnectionClaimsMessage>(), It.IsAny<CancellationToken>()))
+                .Callback<GetConnectionClaimsMessage, CancellationToken>((message, _) => captured = message)
+                .ReturnsAsync(expected);
+
+            var result = await manager.GetConnectionClaimsAsync("conn-token-1", default);
+
+            Assert.NotNull(captured);
+            Assert.Equal("conn-token-1", captured!.ConnectionToken);
+            Assert.Equal(AckStatus.Ok, result.Status);
+            Assert.Equal("user", Assert.Single(result.Claims!).Value);
+        }
+
+        private WebSocketsHubLifetimeManager<TestHub> CreateManager() =>
+            new(
+                _serviceConnectionManagerMock.Object,
+                _protocolResolver,
+                _globalHubOptionsMock.Object,
+                _hubOptionsMock.Object,
+                _loggerFactoryMock.Object,
+                _serviceManagerOptionsMock.Object,
+                _clientInvocationManagerMock.Object,
+                _serverNameProviderMock.Object,
+                _hubName);
 
 #if NET7_0_OR_GREATER
         [Fact]


### PR DESCRIPTION
## Summary
Implements the Serverless-mode (Management SDK) side of #2281. See the issue for the full background, API design, and behavior/semantics.

## What this PR does

Lets a negotiation server (an Azure Function App or any Management SDK host) refresh an Azure SignalR client connection's auth expiration and application claims without reconnecting, mirroring Default mode. Unlike Default mode — which reuses the app's existing `HttpConnectionDispatcherOptions` and adds no public API — serverless has no app server, so this PR introduces **new public Management SDK API** (`ServiceHubContext.RefreshAuthAsync` +`ServiceHubContext.GetConnectionClaimsAsync`) that the host calls. The API is transport-agnostic: it behaves identically for `ServiceTransportType.Transient` (REST data plane) and `ServiceTransportType.Persistent` (service-protocol tunnel).

## Changes

The API is public and multi-targets `netstandard2.0` / `net8.0` (no net11 guard needed). The Persistent path reuses the service protocol messages `RefreshAuthMessage` (41) / `GetConnectionClaimsMessage` (42) already released in v1.33.1.

- **New public API** — `ServiceHubContext.RefreshAuthAsync(connectionToken, expireTime, claims?)` and `GetConnectionClaimsAsync(connectionToken)`, plus result types `RefreshAuthResult { AccessToken, TokenLifetimeSeconds }` and `ConnectionClaimsResult { Claims }`. Keyed by the connection token; `claims` null/empty ⇒ expiration-only refresh.
- **`IServiceHubLifetimeManager`** — adds `RefreshAuthAsync` / `GetConnectionClaimsAsync`.
- **Transient (`RestHubLifetimeManager`)** — calls the new REST data-plane endpoints: `POST /connections/:refreshAuth` (write) and `QUERY /connections/claims` (read); both return `{ claims }` on success. Adds `RestApiProvider.RefreshApiVersion` + `GetRefreshConnectionAuthEndpoint` / `GetConnectionClaimsEndpoint`, and a `RestClient` overload that threads an `HttpContent` body.
- **Persistent (`WebsocketsHubLifetimeManager`)** — sends the token-keyed `RefreshAuthMessage` / `GetConnectionClaimsMessage` over the existing service connection.
- **Token minting (`ServiceHubContextImpl`)** — mints the refreshed service access token locally from the runtime-returned post-refresh claims for the connection's owning endpoint; `TokenLifetimeSeconds = min(AccessTokenLifetime, expireTime − now)`.

## Tests

- `RestHubLifetimeManagerFacts` — REST `:refreshAuth` / `claims` URL, body, and status mapping; argument validation.
- `WebsocketsHubLifetimeManagerFacts` — Persistent delegates the message to the connection container; argument validation.
- `ServiceHubContextImplFacts` — minting happy path from mocked endpoint/provider; `ThrowOnNonSuccess` status mapping; `Ok` + null-claims and no-endpoint throw.